### PR TITLE
feat(deploy): add openshift deploy template to dev bot

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1,0 +1,202 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: platform-frontend-ai-dev
+parameters:
+- name: NAMESPACE
+  value: ${NAMESPACE}
+- name: BOT_IMAGE
+  value: quay.io/redhatinsights/platform-frontend-ai-dev-bot
+- name: BOT_IMAGE_TAG
+  value: latest
+- name: MEMORY_SERVER_IMAGE
+  value: quay.io/redhatinsights/platform-frontend-ai-dev-memory-server
+- name: MEMORY_SERVER_IMAGE_TAG
+  value: latest
+- name: BOT_LABEL
+  value: hcc-ai-framework
+- name: BOT_REPLICAS
+  value: "1"
+objects:
+
+# ============================================================================
+# Prerequisites
+#
+# 1. RDS instance with the pgvector extension enabled
+# 2. Secret "devbot-secrets" with the following keys:
+#      SSH_PRIVATE_KEY_B64    — base64-encoded SSH private key
+#      GPG_PRIVATE_KEY_B64   — base64-encoded GPG private key
+#      GH_TOKEN              — GitHub personal access token
+#      GOOGLE_SA_KEY_B64     — base64-encoded Google service account key
+#
+# Networking (Routes, NetworkPolicies) is managed via app-interface.
+#
+# ============================================================================
+
+# --- Memory Server Deployment ---
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: devbot-memory-server
+    labels:
+      app.kubernetes.io/name: memory-server
+      app.kubernetes.io/part-of: devbot
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: memory-server
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: memory-server
+          app.kubernetes.io/part-of: devbot
+      spec:
+        containers:
+        - name: memory-server
+          image: ${MEMORY_SERVER_IMAGE}:${MEMORY_SERVER_IMAGE_TAG}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          env:
+          - name: PGSQL_HOSTNAME
+            valueFrom:
+              secretKeyRef:
+                name: platform-frontend-ai-dev-rds
+                key: db.host
+          - name: PGSQL_PORT
+            valueFrom:
+              secretKeyRef:
+                name: platform-frontend-ai-dev-rds
+                key: db.port
+          - name: PGSQL_USER
+            valueFrom:
+              secretKeyRef:
+                name: platform-frontend-ai-dev-rds
+                key: db.user
+          - name: PGSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: platform-frontend-ai-dev-rds
+                key: db.password
+          - name: PGSQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: platform-frontend-ai-dev-rds
+                key: db.name
+          - name: PGSQL_SSLMODE
+            value: require
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
+# --- Memory Server Service ---
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: devbot-memory-server
+    labels:
+      app.kubernetes.io/name: memory-server
+      app.kubernetes.io/part-of: devbot
+  spec:
+    type: ClusterIP
+    selector:
+      app.kubernetes.io/name: memory-server
+    ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+
+# --- Bot Deployment ---
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: devbot-bot
+    labels:
+      app.kubernetes.io/name: bot
+      app.kubernetes.io/part-of: devbot
+  spec:
+    replicas: ${{BOT_REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: bot
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: bot
+          app.kubernetes.io/part-of: devbot
+      spec:
+        containers:
+        - name: bot
+          image: ${BOT_IMAGE}:${BOT_IMAGE_TAG}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
+          env:
+          - name: BOT_LABEL
+            value: ${BOT_LABEL}
+          - name: BOT_MEMORY_URL
+            value: http://devbot-memory-server:8080/sse
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /home/botuser/sa-key.json
+          # Secrets
+          - name: SSH_PRIVATE_KEY_B64
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: SSH_PRIVATE_KEY_B64
+          - name: GPG_PRIVATE_KEY_B64
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: GPG_PRIVATE_KEY_B64
+          - name: GH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: GH_TOKEN
+          - name: GOOGLE_SA_KEY_B64
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: GOOGLE_SA_KEY_B64
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "4"
+              memory: 4Gi

--- a/memory-server/src/db.py
+++ b/memory-server/src/db.py
@@ -7,9 +7,25 @@ from pgvector.asyncpg import register_vector
 _pool: asyncpg.Pool | None = None
 
 
+def _build_database_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if url:
+        return url
+    host = os.environ.get("PGSQL_HOSTNAME", "localhost")
+    port = os.environ.get("PGSQL_PORT", "5432")
+    user = os.environ["PGSQL_USER"]
+    password = os.environ["PGSQL_PASSWORD"]
+    database = os.environ["PGSQL_DATABASE"]
+    sslmode = os.environ.get("PGSQL_SSLMODE")
+    base = f"postgresql://{user}:{password}@{host}:{port}/{database}"
+    if sslmode:
+        base += f"?sslmode={sslmode}"
+    return base
+
+
 async def init_pool() -> asyncpg.Pool:
     global _pool
-    url = os.environ.get("DATABASE_URL", "postgresql://bot:bot@localhost:5433/bot_memory")
+    url = _build_database_url()
 
     # First, run schema (creates the vector extension) using a direct connection
     conn = await asyncpg.connect(url)


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                                                          
  - Adds an OpenShift deployment template (deploy/template.yaml) for the Phase 3 onboarding, deploying the bot and memory-server
  - Uses RDS (with pgvector) instead of a self-managed postgres container — DB credentials are read from the platform-frontend-ai-dev-rds secret via secretKeyRef                                                                                                                         
  - Updates memory-server/src/db.py to support individual PGSQL_* env vars as an alternative to DATABASE_URL (docker-compose still works unchanged)                                                                                                                                       
  - Proxy is excluded — the target cluster has direct egress                                                                                                                                                                                                                              
  - Routes and NetworkPolicies are excluded — those will be managed via app-interface                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                          
  Components                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                          
  - devbot-bot — Main dev bot agent (CLI process, no exposed port)                                                                                                                                                                                                                        
  - devbot-memory-server (devbot-memory-server:8080) — MCP memory server + dashboard UI
                                                                                                                                                                                                                                                                                          
  Prerequisites
                                                                                                                                                                                                                                                                                          
  1. RDS instance with the pgvector extension pre-created (CREATE EXTENSION vector; must be run by a user with rds_superuser role during provisioning — the memory-server's startup schema uses IF NOT EXISTS so it's a no-op after that)                                                 
  2. devbot-secrets Secret pre-provisioned with: SSH_PRIVATE_KEY_B64, GPG_PRIVATE_KEY_B64, GH_TOKEN, GOOGLE_SA_KEY_B64
  3. platform-frontend-ai-dev-rds Secret with keys: db.host, db.port, db.user, db.password, db.name                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                          
  Follow-up work                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                          
  - Configure Routes and NetworkPolicies in app-interface                                                                                                                                                                                                                                 
  - Confirm CREATE EXTENSION vector is included in RDS provisioning via app-interface