### PR TITLE
feat: support podman as container runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: install run init dashboard costs costs-today costs-week seed-costs stop logs help memory-server memory-server-stop memory-dump memory-import memory-reset
 
 LABEL ?= hcc-ai-framework
+CONTAINER_RT ?= $(shell command -v docker 2>/dev/null && echo docker || echo podman)
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -48,30 +49,30 @@ seed-costs: ## Import costs.jsonl into the database
 	uv run python scripts/seed-costs.py data/costs.jsonl
 
 memory-server: ## Start memory server + postgres
-	docker compose -f memory-server/docker-compose.yml up --build
+	$(CONTAINER_RT) compose -f memory-server/docker-compose.yml up --build
 
 memory-server-stop: ## Stop memory server + postgres
-	docker compose -f memory-server/docker-compose.yml down
+	$(CONTAINER_RT) compose -f memory-server/docker-compose.yml down
 
 memory-dump: ## Dump memory DB to data/memory-dump.sql
-	@(docker compose exec -T postgres pg_dump -U bot --data-only --inserts --on-conflict-do-nothing bot_memory 2>/dev/null || \
-	  docker compose -f memory-server/docker-compose.yml exec -T postgres pg_dump -U bot --data-only --inserts --on-conflict-do-nothing bot_memory) > data/memory-dump.sql
+	@($(CONTAINER_RT) compose exec -T postgres pg_dump -U bot --data-only --inserts --on-conflict-do-nothing bot_memory 2>/dev/null || \
+	  $(CONTAINER_RT) compose -f memory-server/docker-compose.yml exec -T postgres pg_dump -U bot --data-only --inserts --on-conflict-do-nothing bot_memory) > data/memory-dump.sql
 	@echo "Dumped to data/memory-dump.sql"
 
 memory-import: ## Import data from data/memory-dump.sql (additive, skips duplicates)
-	@docker compose exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql 2>/dev/null || \
-	  docker compose -f memory-server/docker-compose.yml exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql
+	@$(CONTAINER_RT) compose exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql 2>/dev/null || \
+	  $(CONTAINER_RT) compose -f memory-server/docker-compose.yml exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql
 	@echo "Imported from data/memory-dump.sql"
 
 memory-reset: ## Wipe and reimport memory DB from data/memory-dump.sql
-	@(docker compose exec -T postgres psql -U bot -d bot_memory -c "DELETE FROM bot_status; DELETE FROM cycles; DELETE FROM memories; DELETE FROM tasks;" 2>/dev/null || \
-	  docker compose -f memory-server/docker-compose.yml exec -T postgres psql -U bot -d bot_memory -c "DELETE FROM bot_status; DELETE FROM cycles; DELETE FROM memories; DELETE FROM tasks;") && \
-	(docker compose exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql 2>/dev/null || \
-	  docker compose -f memory-server/docker-compose.yml exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql)
+	@($(CONTAINER_RT) compose exec -T postgres psql -U bot -d bot_memory -c "DELETE FROM bot_status; DELETE FROM cycles; DELETE FROM memories; DELETE FROM tasks;" 2>/dev/null || \
+	  $(CONTAINER_RT) compose -f memory-server/docker-compose.yml exec -T postgres psql -U bot -d bot_memory -c "DELETE FROM bot_status; DELETE FROM cycles; DELETE FROM memories; DELETE FROM tasks;") && \
+	($(CONTAINER_RT) compose exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql 2>/dev/null || \
+	  $(CONTAINER_RT) compose -f memory-server/docker-compose.yml exec -T postgres psql -U bot -d bot_memory < data/memory-dump.sql)
 	@echo "Reset and imported from data/memory-dump.sql"
 
 docker-up: ## Start full stack (postgres + memory server + bot)
-	docker compose up --build
+	$(CONTAINER_RT) compose up --build
 
 docker-down: ## Stop full stack
-	docker compose down
+	$(CONTAINER_RT) compose down

--- a/init.sh
+++ b/init.sh
@@ -9,6 +9,17 @@ log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] [init] $*"
 }
 
+# Detect container runtime: prefer docker, fall back to podman
+if command -v docker &>/dev/null; then
+  CONTAINER_RT="docker"
+elif command -v podman &>/dev/null; then
+  CONTAINER_RT="podman"
+else
+  log "ERROR: Neither docker nor podman found. Install one to continue."
+  exit 1
+fi
+log "Using container runtime: $CONTAINER_RT"
+
 log "Checking LSP dependencies..."
 
 # TypeScript LSP
@@ -42,7 +53,7 @@ fi
 # Start memory server
 log "Starting memory server..."
 cd "$SCRIPT_DIR/memory-server"
-docker compose up -d --build
+$CONTAINER_RT compose up -d --build
 log "Waiting for memory server health check..."
 for i in $(seq 1 30); do
   if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
@@ -50,7 +61,7 @@ for i in $(seq 1 30); do
     break
   fi
   if [ "$i" -eq 30 ]; then
-    log "WARNING: Memory server failed to start within 30s. Check docker compose logs."
+    log "WARNING: Memory server failed to start within 30s. Check $CONTAINER_RT compose logs."
   fi
   sleep 1
 done

--- a/memory-server/Makefile
+++ b/memory-server/Makefile
@@ -1,5 +1,7 @@
 .PHONY: install sync lock run dev up down logs clean seed
 
+CONTAINER_RT ?= $(shell command -v docker 2>/dev/null && echo docker || echo podman)
+
 install:
 	uv sync
 
@@ -17,19 +19,19 @@ dev: up
 
 # Docker
 up:
-	docker compose up -d postgres
+	$(CONTAINER_RT) compose up -d postgres
 	@echo "Waiting for postgres..."
-	@until docker compose exec postgres pg_isready -U bot -d bot_memory > /dev/null 2>&1; do sleep 1; done
+	@until $(CONTAINER_RT) compose exec postgres pg_isready -U bot -d bot_memory > /dev/null 2>&1; do sleep 1; done
 	@echo "Postgres ready"
 
 down:
-	docker compose down
+	$(CONTAINER_RT) compose down
 
 logs:
-	docker compose logs -f
+	$(CONTAINER_RT) compose logs -f
 
 clean:
-	docker compose down -v
+	$(CONTAINER_RT) compose down -v
 
 # Seed from open-prs.json
 seed:
@@ -37,7 +39,7 @@ seed:
 
 # Full stack in Docker
 up-all:
-	docker compose up -d --build
+	$(CONTAINER_RT) compose up -d --build
 
 down-all:
-	docker compose down
+	$(CONTAINER_RT) compose down


### PR DESCRIPTION
## Summary
- Auto-detect `docker` or `podman` at runtime via a `CONTAINER_RT` variable
- Both `Makefile` and `memory-server/Makefile` use `$(shell command -v docker ...)` with podman fallback
- `init.sh` detects the available container runtime and uses it for all compose commands
- Users can override explicitly: `CONTAINER_RT=podman make memory-server`

## Changed files
- `Makefile` — added `CONTAINER_RT` variable, replaced all `docker compose` calls
- `memory-server/Makefile` — same pattern
- `init.sh` — added runtime detection block, replaced `docker` references

## Test plan
- [ ] Run `make memory-server` on a system with docker installed — should use docker
- [ ] Run `make memory-server` on a system with only podman — should use podman
- [ ] Run `CONTAINER_RT=podman make memory-server` to verify manual override
- [ ] Run `./init.sh` and verify container runtime detection log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)