### PR TITLE
feat(deploy-template): add back proxy to deploy template and move ssh config gen to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,10 +130,8 @@ RUN chown -R botuser:botuser /home/botuser/app
 
 USER botuser
 
-# SSH config — tunnel through Squid proxy for network isolation
+# SSH directory — config is generated at runtime by entrypoint.sh
 RUN mkdir -p /home/botuser/.ssh && chmod 700 /home/botuser/.ssh
-RUN echo -e "Host github.com github.com-bot\n  HostName github.com\n  User git\n  IdentityFile /home/botuser/.ssh/id_ed25519\n  IdentitiesOnly yes\n  StrictHostKeyChecking accept-new\n  ProxyCommand socat - PROXY:proxy:%h:%p,proxyport=3128\n\nHost gitlab.cee.redhat.com\n  IdentityFile /home/botuser/.ssh/id_ed25519\n  StrictHostKeyChecking accept-new\n  ProxyCommand socat - PROXY:proxy:%h:%p,proxyport=3128" \
-    > /home/botuser/.ssh/config && chmod 600 /home/botuser/.ssh/config
 ENV GIT_SSH_COMMAND="ssh -F /home/botuser/.ssh/config"
 
 # Pre-add known host keys so first connection doesn't warn

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -6,12 +6,16 @@ parameters:
 - name: NAMESPACE
   value: ${NAMESPACE}
 - name: BOT_IMAGE
-  value: quay.io/redhatinsights/platform-frontend-ai-dev-bot
+  value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev-bot
 - name: BOT_IMAGE_TAG
   value: latest
 - name: MEMORY_SERVER_IMAGE
-  value: quay.io/redhatinsights/platform-frontend-ai-dev-memory-server
+  value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev-memory-server
 - name: MEMORY_SERVER_IMAGE_TAG
+  value: latest
+- name: PROXY_IMAGE
+  value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev-proxy
+- name: PROXY_IMAGE_TAG
   value: latest
 - name: BOT_LABEL
   value: hcc-ai-framework
@@ -136,6 +140,75 @@ objects:
       protocol: TCP
       name: http
 
+# --- Proxy Deployment ---
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: devbot-proxy
+    labels:
+      app.kubernetes.io/name: proxy
+      app.kubernetes.io/part-of: devbot
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: proxy
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: proxy
+          app.kubernetes.io/part-of: devbot
+      spec:
+        containers:
+        - name: proxy
+          image: ${PROXY_IMAGE}:${PROXY_IMAGE_TAG}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
+          ports:
+          - containerPort: 3128
+            name: squid
+            protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 3128
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: 3128
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+# --- Proxy Service ---
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: devbot-proxy
+    labels:
+      app.kubernetes.io/name: proxy
+      app.kubernetes.io/part-of: devbot
+  spec:
+    type: ClusterIP
+    selector:
+      app.kubernetes.io/name: proxy
+    ports:
+    - port: 3128
+      targetPort: squid
+      protocol: TCP
+      name: squid
+
 # --- Bot Deployment ---
 - apiVersion: apps/v1
   kind: Deployment
@@ -172,6 +245,21 @@ objects:
             value: http://devbot-memory-server:8080/sse
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /home/botuser/sa-key.json
+          # Proxy — PROXY_HOST for SSH config, HTTP(S)_PROXY for HTTP clients
+          - name: PROXY_HOST
+            value: devbot-proxy
+          - name: HTTP_PROXY
+            value: http://devbot-proxy:3128
+          - name: HTTPS_PROXY
+            value: http://devbot-proxy:3128
+          - name: http_proxy
+            value: http://devbot-proxy:3128
+          - name: https_proxy
+            value: http://devbot-proxy:3128
+          - name: NO_PROXY
+            value: devbot-memory-server,localhost,127.0.0.1
+          - name: no_proxy
+            value: devbot-memory-server,localhost,127.0.0.1
           # Secrets
           - name: SSH_PRIVATE_KEY_B64
             valueFrom:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,24 @@ set -e
 echo "$SSH_PRIVATE_KEY_B64" | base64 -d > ~/.ssh/id_ed25519
 chmod 600 ~/.ssh/id_ed25519
 
+# Generate SSH config — PROXY_HOST defaults to "proxy" (matches docker-compose service name)
+PROXY_HOST="${PROXY_HOST:-proxy}"
+cat > ~/.ssh/config <<SSHEOF
+Host github.com github.com-bot
+  HostName github.com
+  User git
+  IdentityFile /home/botuser/.ssh/id_ed25519
+  IdentitiesOnly yes
+  StrictHostKeyChecking accept-new
+  ProxyCommand socat - PROXY:${PROXY_HOST}:%h:%p,proxyport=3128
+
+Host gitlab.cee.redhat.com
+  IdentityFile /home/botuser/.ssh/id_ed25519
+  StrictHostKeyChecking accept-new
+  ProxyCommand socat - PROXY:${PROXY_HOST}:%h:%p,proxyport=3128
+SSHEOF
+chmod 600 ~/.ssh/config
+
 # Import GPG key for commit signing
 gpg --batch --import <(echo "$GPG_PRIVATE_KEY_B64" | base64 -d) 2>/dev/null
 export GPG_SIGNING_KEY="$(gpg --list-secret-keys --keyid-format long 2>/dev/null | grep ed25519 | head -1 | awk '{print $2}' | cut -d/ -f2)"


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                                                          
  - Adds proxy Deployment + Service to the deploy template and adds proxy env vars (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, PROXY_HOST) to the bot deployment
  - Updates default image paths from quay.io/redhatinsights/ to quay.io/redhat-services-prod/hcc-platex-services/ to match Konflux imagePatterns                                                                                                                                          
  - Moves SSH config generation from Dockerfile (build-time) to entrypoint.sh (runtime) so the proxy hostname is configurable via PROXY_HOST env var. Previously the proxy hostname proxy was baked into the image, which doesn't resolve in OpenShift where the service is named         
  devbot-proxy. Defaults to proxy so docker-compose works unchanged.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                          
  Files changed                                                                                                                                                                                                                                                                           
                  
  - deploy/template.yaml — proxy Deployment/Service, proxy env vars on bot, Konflux image paths                                                                                                                                                                                           
  - Dockerfile — removed baked-in SSH config, kept mkdir/chmod for .ssh dir
  - entrypoint.sh — generates SSH config at startup using PROXY_HOST                                                                                                                                                                             
                                                                                                                                                                                                                                                                                          
  Follow-up work                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                          
  - Configure Routes and NetworkPolicies in app-interface 
  - Run pgvector enablement on RDS db