### PR TITLE
feat(persona): add Playwright e2e test instructions

### DIFF
--- a/personas/frontend/prompt.md
+++ b/personas/frontend/prompt.md
@@ -35,11 +35,19 @@ Chrome navigates `https://stage.foo.redhat.com:1337/` → resolves 127.0.0.1 via
 
 1. **Build**: `npm run build`
 
-2. **Static file server** — serve build output:
+2. **Static file server** — serve build output (check `webpack.config` or `vite.config` for output dir — usually `dist/` or `build/`):
 
-   insights-chrome (shell): `npx http-server ./build -p 9912 -c-1 -a :: --cors=\* &`
+   insights-chrome (shell): `nohup npx http-server ./dist -p 9912 -c-1 -a :: --cors=\* > /tmp/http-server.log 2>&1 &`
 
-   Regular apps (federated modules): `npx http-server ./build -p 8003 -c-1 -a :: --cors=\* &`
+   Regular apps (federated modules): `nohup npx http-server ./dist -p 8003 -c-1 -a :: --cors=\* > /tmp/http-server.log 2>&1 &`
+
+   **MUST use `nohup`** — without it, http-server dies when the shell session ends.
+
+   **insights-chrome only**: Create symlinks so `/apps/chrome/*` paths resolve:
+   ```bash
+   mkdir -p dist/apps/chrome
+   for f in dist/*; do [ "$(basename "$f")" = "apps" ] && continue; ln -sf "../../$(basename "$f")" "dist/apps/chrome/$(basename "$f")"; done
+   ```
 
 3. **Routes config** — write `/tmp/dev-proxy-routes.json`:
 
@@ -55,7 +63,7 @@ Chrome navigates `https://stage.foo.redhat.com:1337/` → resolves 127.0.0.1 via
 
    Optional local API: add `"/api/<app-name>/*": {"url": "http://127.0.0.1:8000", "rh-identity-headers": true}`
 
-4. **Start proxy**: `ROUTES_JSON_PATH=/tmp/dev-proxy-routes.json start-dev-proxy.sh &`
+4. **Start proxy**: `nohup bash -c 'ROUTES_JSON_PATH=/tmp/dev-proxy-routes.json start-dev-proxy.sh' > /tmp/caddy.log 2>&1 &`
 
    Wait few seconds for Caddy. App at `https://stage.foo.redhat.com:1337/`.
 
@@ -87,3 +95,60 @@ Chrome navigates `https://stage.foo.redhat.com:1337/` → resolves 127.0.0.1 via
 - Kill stale: `lsof -ti :1337,:8003,:9912 | xargs kill 2>/dev/null || true`
 - If ticket has repro steps → build + proxy (steps 1-4), verify no visual regressions via chrome-devtools MCP.
 - **Always stop all servers**: `lsof -ti :1337,:8003,:9912 | xargs kill`
+
+### Playwright e2e tests
+
+Run Playwright tests if the repo has them (`playwright.config.ts` exists). Do this **after** visual verification, with dev proxy already running.
+
+#### Prerequisites
+
+Dev proxy + http-server must be running (steps 0-4 above). If not already started, start them first.
+
+#### Patch playwright.config.ts
+
+Playwright launches its own Chromium — it needs proxy + host resolver args to work in the container. Patch `playwright.config.ts` before running:
+
+Add `launchOptions` to the `use` block:
+```typescript
+use: {
+  // ... existing config ...
+  launchOptions: {
+    args: [
+      '--proxy-server=http://proxy:3128',
+      '--proxy-bypass-list=*.foo.redhat.com;localhost;127.0.0.1',
+      '--host-resolver-rules=MAP stage.foo.redhat.com 127.0.0.1,MAP consent.trustarc.com 127.0.0.1',
+      '--ignore-certificate-errors',
+      '--no-sandbox',
+      '--disable-gpu',
+    ],
+  },
+}
+```
+
+Do NOT commit this patch — it's container-specific. `git checkout -- playwright.config.ts` after tests.
+
+#### Run tests
+
+```bash
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+export E2E_USER=$(python3.12 -c "import json; c=json.load(open('/home/botuser/app/.credentials')); print(c['sso']['username'])")
+export E2E_PASSWORD=$(python3.12 -c "import json; c=json.load(open('/home/botuser/app/.credentials')); print(c['sso']['password'])")
+
+npx playwright test --workers=1 --max-failures=1 --reporter=list
+```
+
+**`--workers=1` mandatory** — container can't spawn multiple Chrome instances.
+
+#### Failures
+
+- All pass → proceed to PR
+- Test failure → check `test-results/` for screenshots + videos. Fix code, re-run.
+- `EAGAIN` / `pthread_create` errors → resource limits, already mitigated by `--workers=1`
+- `Xvfb` errors → only affects Cypress, not Playwright. Ignore Cypress e2e, run Playwright only.
+
+#### Cleanup
+
+Revert playwright.config.ts patch: `git checkout -- playwright.config.ts`
+
+Stop servers (step 10 above).

--- a/proxy/squid.conf
+++ b/proxy/squid.conf
@@ -22,10 +22,6 @@ acl allowed_domains dstdomain .nodejs.org
 acl allowed_domains dstdomain pypi.org
 acl allowed_domains dstdomain files.pythonhosted.org
 
-# Cypress binary downloads (e2e test runner)
-acl allowed_domains dstdomain download.cypress.io
-acl allowed_domains dstdomain cdn.cypress.io
-
 # Go toolchain and modules
 acl allowed_domains dstdomain go.dev
 acl allowed_domains dstdomain dl.google.com


### PR DESCRIPTION
## Summary

- Add Playwright e2e test instructions to the frontend persona so the bot can run e2e tests locally after UI changes
- Fix `nohup` requirement for http-server and Caddy (they die when shell session ends)
- Fix build output dir (`dist/` not `build/`) and add symlink setup for insights-chrome
- Document `playwright.config.ts` runtime patching for container proxy/DNS resolution

## Context

Validated all 8 Playwright release-gate tests passing in the bot container with `--workers=1`. Cypress e2e tests are blocked (require Xvfb, unavailable on UBI9) — separate ticket [RHCLOUD-47095](https://redhat.atlassian.net/browse/RHCLOUD-47095) tracks migration.

## Depends on

- PR #46 (dev proxy in bot container)

RHCLOUD-47096

## Test plan

- [ ] Bot picks up a frontend ticket with UI changes
- [ ] Bot runs Playwright e2e tests after visual verification
- [ ] All tests pass with `--workers=1`
- [ ] `playwright.config.ts` patch is reverted before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-47095]: https://redhat.atlassian.net/browse/RHCLOUD-47095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ