### PR TITLE
fix(deploy): update deploy secret keys and change default bot label to something unused

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -18,7 +18,7 @@ parameters:
 - name: PROXY_IMAGE_TAG
   value: latest
 - name: BOT_LABEL
-  value: hcc-ai-framework
+  value: hcc-ai-bot
 - name: BOT_REPLICAS
   value: "1"
 objects:
@@ -266,25 +266,25 @@ objects:
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
-                key: SSH_PRIVATE_KEY_B64
+                key: gh-bot-private-key
                 optional: true
           - name: GPG_PRIVATE_KEY_B64
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
-                key: GPG_PRIVATE_KEY_B64
+                key: gh-bot-gpg-private
                 optional: true
           - name: GH_TOKEN
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
-                key: GH_TOKEN
+                key: gh-bot-cli-token
                 optional: true
           - name: GOOGLE_SA_KEY_B64
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
-                key: GOOGLE_SA_KEY_B64
+                key: gcp-vertex-claude-sa
                 optional: true
           resources:
             requests:


### PR DESCRIPTION
Summary   
                                                                                                                                                                                                                                                                                          
  - Changes default BOT_LABEL from hcc-ai-framework to hcc-ai-bot to use a dedicated Jira label for the deployed bot                                                                                                                                                                      
  - Updates devbot-secrets secretKeyRef keys to match the Vault secret field names (gh-bot-private-key, gh-bot-gpg-private, gh-bot-cli-token, gcp-vertex-claude-sa)
                                                                                                                                                                                                                                                                                          
  Files changed                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                          
  - deploy/template.yaml — BOT_LABEL default + secret key names