### PR TITLE
fix(deploy): fix pods failing to start in openshift context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,9 +130,11 @@ COPY config.json project-repos.json CLAUDE.md .mcp.json entrypoint.sh ./
 COPY .claude/ .claude/
 COPY personas/ personas/
 
-# Fix ownership
-RUN chown -R botuser:botuser /home/botuser/app
+# Fix ownership — botuser:0 + group-writable so OpenShift arbitrary UIDs (always GID 0) can write
+RUN chown -R botuser:0 /home/botuser \
+    && chmod -R g+rwX /home/botuser
 
+ENV HOME=/home/botuser
 USER botuser
 
 # Buildah rootless config — vfs driver (no kernel module needed, works everywhere)

--- a/memory-server/Dockerfile
+++ b/memory-server/Dockerfile
@@ -13,6 +13,8 @@ USER 0
 
 RUN pip3 install uv
 
+ENV UV_CACHE_DIR=/tmp/uv-cache
+
 WORKDIR /app
 
 COPY memory-server/pyproject.toml memory-server/uv.lock* ./

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,7 +7,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
 COPY squid.conf /etc/squid/squid.conf
 
 RUN mkdir -p /var/log/squid /var/spool/squid /var/run/squid \
-    && chown -R squid:squid /var/log/squid /var/spool/squid /var/run/squid
+    && chown -R squid:0 /var/log/squid /var/spool/squid /var/run/squid \
+    && chmod -R g+rwX /var/log/squid /var/spool/squid /var/run/squid
 
 EXPOSE 3128
 USER squid


### PR DESCRIPTION
## Summary      
                                                                                                                                                                                                                                                                                          
  All three containers failed to start due to permission issues under non-root/arbitrary UIDs:                                                                                                                                                                                            
   
  - **Bot**: `entrypoint.sh` errored with `/.ssh/id_gh: No such file or directory` — Docker's `USER` directive doesn't set `HOME`, so `~` expanded to `/` instead of `/home/botuser`. Added `ENV HOME=/home/botuser`.                                                                     
  - **Memory server**: UV cache init failed with `Permission denied` at `/opt/app-root/src/.cache/uv` (UBI base image default HOME, unwritable at runtime). Set `ENV UV_CACHE_DIR=/tmp/uv-cache`.
  - **Proxy**: Squid couldn't open `/var/run/squid/squid.pid` — dirs were `squid:squid` but OpenShift runs with a random UID (always GID 0). Changed to `chown squid:0` + `chmod g+rwX` so both local (`USER squid`) and OpenShift (arbitrary UID, GID 0) work.