### PR TITLE
fix(infra): fix glab CLI install, auth, and GitLab MR status checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ Triage buckets (first match wins):
 2. **Interrupted work** — `in_progress` w/ `last_step` set, no PR yet. Reload persona → resume.
 3. **Investigations without report** — `in_progress` + `needs-investigation`, no analysis posted yet.
 4. **CVE investigations missing grype scan** — `last_step = "investigation_posted"`, no grype scan done. Build Dockerfile + scan per CVE persona.
-5. **Failed retryable tasks** — `last_step` = `clone_failed`/`push_failed`/`ci_failed`. Retry once. Same error → `paused_reason`, move on.
+5. **Failed retryable tasks** — `last_step` = `clone_failed`/`push_failed`/`ci_failed`. **Start fresh**: close existing PR (if any), delete remote branch, delete local branch, re-create from default branch. Same error twice → `paused_reason`, move on.
 
 None apply → Priority 1.
 
@@ -183,16 +183,30 @@ For each `pr_open`/`pr_changes` task (check `metadata.prs` for multi-repo, else 
 
 0. **Reload persona**: Read `personas/<name>/prompt.md` for repo tech stack (same logic as step 6). Has CI fix patterns + sequencing rules.
 1. `cd` repo dir. `git fetch origin`. Fork? Also `git fetch upstream`.
-2. Check `host` in `project-repos.json` → `gh` (GitHub) or `glab` (GitLab). Fork repos: `glab mr` needs `--repo <upstream-project-path>`.
+2. Check `host` in `project-repos.json` → `gh` (GitHub) or `glab` (GitLab). **ALL `glab` commands MUST include `--hostname gitlab.cee.redhat.com`** — without it, glab defaults to `gitlab.com` which is blocked. Fork repos: `glab mr` needs `--repo <upstream-project-path>`.
 3. PR status:
    - GH: `gh pr view <n> --json state,mergeable,statusCheckRollup,reviewDecision,reviews,url`
-   - GL: `glab mr view <n> --repo <upstream-project-path>`. For CI status: `glab api "projects/<url-encoded-project>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`.
+   - GL: Use the API for full status (glab mr view lacks structured data):
+     ```
+     glab api "projects/<url-encoded-path>/merge_requests/<n>" --hostname gitlab.cee.redhat.com
+     ```
+     URL-encode the project path: `service/app-interface` → `service%2Fapp-interface`.
+     Key fields in the response:
+     - `state`: "opened", "merged", "closed"
+     - `merge_status` / `detailed_merge_status`: "can_be_merged", "cannot_be_merged", "unchecked"
+     - `has_conflicts`: true/false — if true, needs rebase
+     - `head_pipeline.status`: "success", "failed", "running", "pending"
+     - `blocking_discussions_resolved`: false = unresolved threads block merge
+     - `draft`: true = WIP, not ready for merge
+     
+     For CI details: `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`
+     For approvals: `glab api "projects/<path>/merge_requests/<n>/approvals" --hostname gitlab.cee.redhat.com`
 
 4. **Review reminder**: If no Slack notification sent yet for this task → ALWAYS send `slack_notify` `review_reminder` (first notification, regardless of PR age). After first notification, cooldown handles repeat reminders automatically every 48h. **Bot reviews don't count** — only human reviews matter. PR with only bot reviews = still needs human review → send reminder.
 
 5. Handle in order:
 
-**Failing CI**: `gh pr checks <n>` / `glab ci view`. Checkout branch → fix → commit → push. Comment on Jira. `task_update` `last_addressed`.
+**Failing CI**: `gh pr checks <n>` / `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`. Checkout branch → fix → commit → push. Comment on Jira. `task_update` `last_addressed`.
 
 **Merge conflicts**: Rebase on default branch → resolve → force push. Jira comment. `task_update` `last_addressed`.
 
@@ -220,7 +234,7 @@ For each `pr_open`/`pr_changes` task (check `metadata.prs` for multi-repo, else 
 - `jira_transition_issue` → "Release Pending" (NOT "Done" — merge = stage only)
 - Jira comment noting merge + stage deploy
 - **Update linked issues**: duplicates → comment fix merged. Related → link PR. Blocked → blocker resolved.
-- **Delete bot branch**: GH: `gh api repos/{owner}/{repo}/git/refs/heads/bot/{KEY} -X DELETE`. GL: `glab api projects/:id/repository/branches/bot%2F{KEY} -X DELETE`. Local: `git branch -D bot/{KEY}`.
+- **Delete bot branch**: GH: `gh api repos/{owner}/{repo}/git/refs/heads/bot/{KEY} -X DELETE`. GL: `glab api projects/:id/repository/branches/bot%2F{KEY} -X DELETE --hostname gitlab.cee.redhat.com`. Local: `git branch -D bot/{KEY}`.
 - **Store learnings**: `memory_store` as `learning` + `codebase_pattern`. Set `repo` + `tags`.
 - `slack_notify` `release_pending`: "{KEY} merged → Release Pending. PR: {url}"
 
@@ -236,7 +250,7 @@ project = RHCLOUD AND labels = PRIMARY_LABEL AND assignee = currentUser() AND st
 ```
 
 For each:
-1. **Merged PRs?** `gh pr list --head bot/<KEY> --state merged` / `glab mr list --source-branch bot/<KEY> --merged`. If merged → transition "Release Pending", Jira comment, `task_update` archived, `memory_store`.
+1. **Merged PRs?** `gh pr list --head bot/<KEY> --state merged` / `glab mr list --source-branch bot/<KEY> --merged --hostname gitlab.cee.redhat.com`. If merged → transition "Release Pending", Jira comment, `task_update` archived, `memory_store`.
 2. **New Jira comments?** `jira_get_issue` → check for unaddressed comments since `last_addressed`. Handle: questions → reply, requirements → incorporate, close requests → respect.
 3. PR still open, no comments → skip (Priority 1 handles).
 
@@ -315,7 +329,7 @@ Before starting work, `jira_get_issue` → check issue links:
 
    Dir = `./repos/<repo-name>/` (from upstream URL basename, no `.git`).
 
-   **Clone on demand**: Not exists → `git clone --depth 1 <url> ./repos/<name>/`. Has upstream → `git remote add upstream <upstream-url>`. Clone fails → Jira comment, stop. Start shallow (`--depth 1`), deepen incrementally if needed (`git fetch --deepen=50`). Never clone full history upfront.
+   **Clone on demand**: Not exists → `git clone --depth 1 --single-branch <url> ./repos/<name>/`. Has upstream → `git remote add upstream <upstream-url>`. If more history needed → `git fetch --deepen=50` or `git fetch --unshallow`. Clone fails → Jira comment, stop.
 
    **Verify remotes**: Exists → `git remote -v`. Origin must match `url`. Upstream remote must match `upstream` field. Fix w/ `set-url`/`add` as needed.
 
@@ -323,6 +337,12 @@ Before starting work, `jira_get_issue` → check issue links:
    - Fork: `git fetch upstream` → `git checkout master && git reset --hard upstream/master`. If push fails, sync fork first: `gh repo sync <fork> --source <upstream> --force`
    - Direct: `git fetch origin` → checkout default branch → pull
    - Branch: `bot/<TICKET-KEY>`
+
+   **Fresh start (retry/redo)**: When retrying failed work, always start clean:
+   1. Close existing PR if open: GH `gh pr close <n> --repo <upstream>` / GL `glab mr close <n> --hostname gitlab.cee.redhat.com`
+   2. Delete remote branch: GH `gh api repos/{owner}/{repo}/git/refs/heads/bot/{KEY} -X DELETE` / GL `glab api projects/:id/repository/branches/bot%2F{KEY} -X DELETE --hostname gitlab.cee.redhat.com`
+   3. Delete local branch: `git branch -D bot/<KEY>`
+   4. Re-create branch from updated default branch and re-implement
 
    **Git identity**: Global config is set by `run.py` at startup (name, email, GPG signing). Do NOT run `git config --local` for identity/signing — it's already handled globally. Do NOT check `GPG_SIGNING_KEY` env var (it's sanitized at startup).
 
@@ -366,8 +386,8 @@ Before starting work, `jira_get_issue` → check issue links:
     GH direct: `gh pr create --title "..." --body "..."`
     Push fails → `last_step = "push_failed"`, Jira comment, keep `in_progress` for retry.
 
-    GL fork: `glab mr create --repo <upstream-path> --title "..." --description "..."`
-    GL direct: `glab mr create --title "..." --description "..."`
+    GL fork: `glab mr create --repo <upstream-path> --hostname gitlab.cee.redhat.com --title "..." --description "..."`
+    GL direct: `glab mr create --hostname gitlab.cee.redhat.com --title "..." --description "..."`
 
     Title ≤50 chars. Body = ticket key + changes summary.
     Readonly repos: include config changes in Jira comment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,10 +76,12 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
     && curl -fsSL "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_linux_${ARCH}.tar.gz" \
     | tar -xz -C /usr/local --strip-components=1
 
-# glab CLI
+# glab CLI — download then extract (no pipe, so curl failures are caught)
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://gitlab.com/gitlab-org/cli/-/releases/v1.51.0/downloads/glab_1.51.0_linux_${ARCH}.tar.gz" \
-    | tar -xz -C /usr/local/bin --strip-components=2 bin/glab
+    && curl -fSL -o /tmp/glab.tar.gz "https://gitlab.com/gitlab-org/cli/-/releases/v1.51.0/downloads/glab_1.51.0_linux_${ARCH}.tar.gz" \
+    && tar -xzf /tmp/glab.tar.gz -C /usr/local/bin --strip-components=1 bin/glab \
+    && rm /tmp/glab.tar.gz \
+    && glab version
 
 # bubblewrap (sandbox runtime for Claude Code)
 RUN dnf install -y --nodocs libcap-devel \
@@ -151,6 +153,7 @@ RUN ssh-keyscan -t ed25519,rsa,ecdsa github.com >> /home/botuser/.ssh/known_host
 # Git config
 RUN git config --global user.name "platex-rehor-bot" \
     && git config --global user.email "platform-experience-services@redhat.com" \
+    && git config --global http.https://gitlab.cee.redhat.com.sslVerify false \
     && git config --global gpg.format openpgp \
     && git config --global commit.gpgsign true
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,19 @@
 # Bot container entrypoint — decode secrets, start Chromium, launch bot.
 set -e
 
+# --- Verify required CLI tools ---
+MISSING=""
+for tool in gh glab git gpg; do
+    if ! command -v "$tool" &>/dev/null; then
+        MISSING="$MISSING $tool"
+    fi
+done
+if [ -n "$MISSING" ]; then
+    echo "FATAL: Missing required tools:$MISSING" >&2
+    echo "Rebuild with: docker compose build --no-cache bot" >&2
+    exit 1
+fi
+
 # Kubernetes secretKeyRef auto-decodes base64, so secrets arrive as raw values
 # in OpenShift. Local docker-compose still passes them base64-encoded via .env.
 # This helper handles both: values starting with "-----" or "{" are not valid
@@ -87,14 +100,26 @@ if [ -n "${GITLAB_TOKEN:-}" ]; then
     mkdir -p ~/.config/glab-cli
     cat > ~/.config/glab-cli/config.yml <<EOF
 git_protocol: ssh
+check_update: false
+no_prompt: true
+host: gitlab.cee.redhat.com
 hosts:
     gitlab.cee.redhat.com:
         token: ${GITLAB_TOKEN}
+        api_protocol: https
         api_host: gitlab.cee.redhat.com
         git_protocol: ssh
+        skip_tls_verify: true
 EOF
+    chmod 600 ~/.config/glab-cli/config.yml
     unset GITLAB_TOKEN
 fi
+
+# --- Verify auth ---
+echo "Verifying GitHub auth..."
+gh auth status 2>&1 | head -3 || { echo "WARNING: gh auth failed"; }
+echo "Verifying GitLab auth..."
+glab auth status --hostname gitlab.cee.redhat.com 2>&1 | head -3 || { echo "WARNING: glab auth failed"; }
 
 # Start headless Chromium in background (Playwright-installed binary)
 CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f | head -1)


### PR DESCRIPTION
## Summary

- Fix glab CLI binary install — was silently failing due to piped download hiding errors and wrong `--strip-components`
- Add startup tool verification — container exits with clear error if gh/glab/git/gpg missing
- Fix glab config for `gitlab.cee.redhat.com` — default host, TLS skip, chmod 600, no_prompt
- Add auth verification on startup — gh and glab status logged in boot output
- Update CLAUDE.md: `--hostname` on all glab commands, GitLab API for MR status, `--single-branch` clones, fresh-start retry

## Test plan

- [ ] `docker compose build --no-cache bot` succeeds with `glab version` output visible
- [ ] Bot startup logs show `Logged in to gitlab.cee.redhat.com`
- [ ] Bot uses `glab api projects/...` for MR status instead of `glab mr view`
- [ ] No `DENIED CONNECT gitlab.com:443` in proxy logs

RHCLOUD-47130
