### PR TITLE
fix(deploy): update deploy template to use a single image tag

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -7,15 +7,11 @@ parameters:
   value: ${NAMESPACE}
 - name: BOT_IMAGE
   value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev
-- name: BOT_IMAGE_TAG
-  required: true
 - name: MEMORY_SERVER_IMAGE
   value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev-memory-server
-- name: MEMORY_SERVER_IMAGE_TAG
-  required: true
 - name: PROXY_IMAGE
   value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev-proxy
-- name: PROXY_IMAGE_TAG
+- name: IMAGE_TAG
   required: true
 - name: BOT_LABEL
   value: hcc-ai-bot
@@ -58,7 +54,7 @@ objects:
       spec:
         containers:
         - name: memory-server
-          image: ${MEMORY_SERVER_IMAGE}:${MEMORY_SERVER_IMAGE_TAG}
+          image: ${MEMORY_SERVER_IMAGE}:${IMAGE_TAG}
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
@@ -161,7 +157,7 @@ objects:
       spec:
         containers:
         - name: proxy
-          image: ${PROXY_IMAGE}:${PROXY_IMAGE_TAG}
+          image: ${PROXY_IMAGE}:${IMAGE_TAG}
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
@@ -230,7 +226,7 @@ objects:
       spec:
         containers:
         - name: bot
-          image: ${BOT_IMAGE}:${BOT_IMAGE_TAG}
+          image: ${BOT_IMAGE}:${IMAGE_TAG}
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                          
  - **The app-interface SaaS pipeline expects a single IMAGE_TAG param to inject digests — the per-image _TAG params were not being populated, causing pods to stay on stale images after new builds**    
  - Consolidate BOT_IMAGE_TAG, MEMORY_SERVER_IMAGE_TAG, and PROXY_IMAGE_TAG into a single IMAGE_TAG parameter
  - All three images are built from the same repo/commit, so they _should_ always share the same tag                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                          
  Test plan                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                          
  - Verify SaaS dry-run passes with the single IMAGE_TAG param                                                                                                                                                                                                                            
  - Confirm pods pick up the new image after merge + deploy