### PR TITLE
feat(deploy): wire Jira and SSO secrets from Vault

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -23,11 +23,15 @@ objects:
 # Prerequisites
 #
 # 1. RDS instance with the pgvector extension enabled
-# 2. Secret "devbot-secrets" with the following keys:
-#      SSH_PRIVATE_KEY_B64    — base64-encoded SSH private key
-#      GPG_PRIVATE_KEY_B64   — base64-encoded GPG private key
-#      GH_TOKEN              — GitHub personal access token
-#      GOOGLE_SA_KEY_B64     — base64-encoded Google service account key
+# 2. Secret "devbot-secrets" (Vault) with the following keys:
+#      gh-bot-private-key    — SSH private key (base64)
+#      gh-bot-gpg-private    — GPG private key (base64)
+#      gh-bot-cli-token      — GitHub personal access token
+#      gcp-vertex-claude-sa  — Google service account key (base64)
+#      jira-email            — Jira username/email
+#      jira-token            — Jira API token
+#      e2e-username          — SSO username for UI verification
+#      e2e-password          — SSO password for UI verification
 #
 # Networking (Routes, NetworkPolicies) is managed via app-interface.
 #
@@ -256,32 +260,49 @@ objects:
             value: devbot-memory-server,localhost,127.0.0.1
           - name: no_proxy
             value: devbot-memory-server,localhost,127.0.0.1
-          # Secrets — optional: true until devbot-secrets is provisioned via
-          # Vault in a follow-up PR (chicken-and-egg with SaaS dry-run)
+          # Secrets from Vault (devbot-secrets)
           - name: SSH_PRIVATE_KEY_B64
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
                 key: gh-bot-private-key
-                optional: true
           - name: GPG_PRIVATE_KEY_B64
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
                 key: gh-bot-gpg-private
-                optional: true
           - name: GH_TOKEN
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
                 key: gh-bot-cli-token
-                optional: true
           - name: GOOGLE_SA_KEY_B64
             valueFrom:
               secretKeyRef:
                 name: devbot-secrets
                 key: gcp-vertex-claude-sa
-                optional: true
+          - name: JIRA_URL
+            value: https://issues.redhat.com
+          - name: JIRA_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: jira-email
+          - name: JIRA_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: jira-token
+          - name: SSO_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: e2e-username
+          - name: SSO_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: e2e-password
           resources:
             requests:
               cpu: "1"


### PR DESCRIPTION
## Summary

- Add `JIRA_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN` env vars for mcp-atlassian Jira integration
- Add `SSO_USERNAME`, `SSO_PASSWORD` env vars for UI verification via chrome-devtools
- Remove `optional: true` from existing secrets (Vault now provisioned)
- Update Prerequisites comment to reflect actual Vault key names

Companion app-interface MR (bumps Vault version to 10): https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/184932

RHCLOUD-46889

## Test plan
- [x] Merge app-interface MR first (Vault version 10 with new keys)
- [ ] Verify bot pod starts with all secrets mounted
- [ ] Confirm mcp-atlassian can query Jira
- [ ] Confirm chrome-devtools SSO login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)