### PR TITLE
fix(deploy): correct Jira URL to Atlassian Cloud

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -282,7 +282,7 @@ objects:
                 name: devbot-secrets
                 key: gcp-vertex-claude-sa
           - name: JIRA_URL
-            value: https://issues.redhat.com
+            value: https://redhat.atlassian.net
           - name: JIRA_USERNAME
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Summary

- Fix `JIRA_URL` from `https://issues.redhat.com` (Jira Server) to `https://redhat.atlassian.net` (Jira Cloud)
- Bot was getting 401 because mcp-atlassian was hitting the wrong Jira instance

## Test plan
- [x] Merge and redeploy
- [ ] Verify bot can query Jira (search, get_issue, get_user_profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)