### PR TITLE
fix(deploy): split IMAGE_TAG into per-component tags

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -11,7 +11,11 @@ parameters:
   value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev-memory-server
 - name: PROXY_IMAGE
   value: quay.io/redhat-services-prod/hcc-platex-services/platform-frontend-ai-dev-proxy
-- name: IMAGE_TAG
+- name: BOT_IMAGE_TAG
+  required: true
+- name: MEMORY_SERVER_IMAGE_TAG
+  required: true
+- name: PROXY_IMAGE_TAG
   required: true
 - name: BOT_LABEL
   value: hcc-ai-bot
@@ -58,7 +62,7 @@ objects:
       spec:
         containers:
         - name: memory-server
-          image: ${MEMORY_SERVER_IMAGE}:${IMAGE_TAG}
+          image: ${MEMORY_SERVER_IMAGE}:${MEMORY_SERVER_IMAGE_TAG}
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
@@ -161,7 +165,7 @@ objects:
       spec:
         containers:
         - name: proxy
-          image: ${PROXY_IMAGE}:${IMAGE_TAG}
+          image: ${PROXY_IMAGE}:${PROXY_IMAGE_TAG}
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
@@ -230,7 +234,7 @@ objects:
       spec:
         containers:
         - name: bot
-          image: ${BOT_IMAGE}:${IMAGE_TAG}
+          image: ${BOT_IMAGE}:${BOT_IMAGE_TAG}
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Split single `IMAGE_TAG` into `BOT_IMAGE_TAG`, `MEMORY_SERVER_IMAGE_TAG`, `PROXY_IMAGE_TAG`
- Each Konflux component releases independently with different commit SHAs
- Single tag breaks when e.g. proxy releases at a different commit than bot/memory-server

## Test plan
- [ ] Merge this first, then update app-interface saas file with per-component tags
- [ ] Verify all three deployments pull correct images

🤖 Generated with [Claude Code](https://claude.com/claude-code)