### PR TITLE
fix(docker): add tini init to reap zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,11 @@ RUN dnf install -y --nodocs libcap-devel \
 RUN dnf install -y --nodocs buildah fuse-overlayfs \
     && dnf clean all
 
+# tini — proper init process that reaps zombie children
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
+    && curl -fsSL -o /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-${ARCH}" \
+    && chmod +x /usr/local/bin/tini
+
 # grype (container image vulnerability scanner)
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
     && curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.87.0_linux_${ARCH}.tar.gz" \
@@ -176,4 +181,4 @@ RUN chown -R botuser:0 /home/botuser \
     && chmod -R g+rwX /home/botuser
 USER botuser
 
-ENTRYPOINT ["bash", "entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "bash", "entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Add `tini` as PID 1 init process to automatically reap zombie children
- Bot spawns hundreds of child processes (git, gh, npm) via Claude Code — without init, exited children become zombies until hitting the cgroup PID limit (500), blocking the bot entirely
- `tini` is a ~30KB static binary that handles zombie reaping and signal forwarding

## Context

Bot instance reported 303 zombie git processes consuming 493/500 PID capacity. Container restart was the only recovery path. With tini, zombies are reaped automatically.

## Test plan
- [ ] Container builds successfully
- [ ] Bot starts and runs cycles normally
- [ ] `ps aux` inside container shows no zombie (`Z`) processes after several cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)