### PR TITLE
fix(bot): Bot startup dependency checks and cycle run time limit

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -13,6 +13,7 @@ class Config:
     max_turns: int
     interval: int
     idle_interval: int
+    cycle_timeout: int
     board_key: str
 
 
@@ -25,6 +26,7 @@ def load_config(script_dir: Path) -> Config:
         max_turns=raw["claude"]["maxTurns"],
         interval=raw["polling"]["intervalSeconds"],
         idle_interval=raw["polling"].get("idleIntervalSeconds", 3600),
+        cycle_timeout=raw["claude"].get("cycleTimeoutSeconds", 1800),
         board_key=raw["jira"]["boardKey"],
     )
 

--- a/bot/run.py
+++ b/bot/run.py
@@ -199,16 +199,26 @@ def main() -> None:
         while True:
             logger.info("Running agent cycle...")
 
-            result, ctx = asyncio.run(
-                run_cycle(
-                    label=args.label,
-                    config=config,
-                    mcp_servers=mcp_servers,
-                    allowed_tools=ALLOWED_TOOLS,
-                    cwd=str(SCRIPT_DIR),
-                    instance_id=instance_id,
+            try:
+                result, ctx = asyncio.run(
+                    asyncio.wait_for(
+                        run_cycle(
+                            label=args.label,
+                            config=config,
+                            mcp_servers=mcp_servers,
+                            allowed_tools=ALLOWED_TOOLS,
+                            cwd=str(SCRIPT_DIR),
+                            instance_id=instance_id,
+                        ),
+                        timeout=config.cycle_timeout,
+                    )
                 )
-            )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Cycle timed out after %ds — skipping to next cycle",
+                    config.cycle_timeout,
+                )
+                result, ctx = None, None
 
             if result is not None:
                 no_work = record_cost(

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -247,6 +247,14 @@ objects:
             value: ${BOT_LABEL}
           - name: BOT_MEMORY_URL
             value: http://devbot-memory-server:8080/sse
+          - name: BOT_MEMORY_HEALTH_URL
+            value: http://devbot-memory-server:8080/health
+          - name: BOT_MEMORY_HEALTH_TIMEOUT
+            value: "120"
+          - name: BOT_PROXY_HEALTH_URL
+            value: http://devbot-proxy:3128
+          - name: BOT_PROXY_HEALTH_TIMEOUT
+            value: "60"
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /home/botuser/sa-key.json
           # Proxy — PROXY_HOST for SSH config, HTTP(S)_PROXY for HTTP clients

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,14 +138,13 @@ wait_for() {
 }
 
 # Proxy must be up before Chromium (which routes through it)
-if [ "${PROXY_HOST:-proxy}" != "proxy" ]; then
-    wait_for "proxy" "http://${PROXY_HOST}:3128" 60
+if [ -n "${BOT_PROXY_HEALTH_URL:-}" ]; then
+    wait_for "proxy" "$BOT_PROXY_HEALTH_URL" "${BOT_PROXY_HEALTH_TIMEOUT:-60}"
 fi
 
 # Memory server must be up before the bot connects via MCP
-if [ -n "${BOT_MEMORY_URL:-}" ] && [ "${BOT_MEMORY_URL}" != "http://localhost:8080/sse" ]; then
-    MEMORY_HEALTH_URL="${BOT_MEMORY_URL%/sse}/health"
-    wait_for "memory-server" "$MEMORY_HEALTH_URL" 120
+if [ -n "${BOT_MEMORY_HEALTH_URL:-}" ]; then
+    wait_for "memory-server" "$BOT_MEMORY_HEALTH_URL" "${BOT_MEMORY_HEALTH_TIMEOUT:-120}"
 fi
 
 # Start headless Chromium in background (Playwright-installed binary)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,6 +121,33 @@ gh auth status 2>&1 | head -3 || { echo "WARNING: gh auth failed"; }
 echo "Verifying GitLab auth..."
 glab auth status --hostname gitlab.cee.redhat.com 2>&1 | head -3 || { echo "WARNING: glab auth failed"; }
 
+# --- Wait for dependent services (OpenShift deploys all pods concurrently) ---
+wait_for() {
+    local name="$1" url="$2" timeout="${3:-120}"
+    echo "Waiting for ${name} at ${url} (timeout=${timeout}s)..."
+    local elapsed=0
+    until curl -sf "$url" > /dev/null 2>&1; do
+        elapsed=$((elapsed + 2))
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "FATAL: ${name} not ready after ${timeout}s" >&2
+            exit 1
+        fi
+        sleep 2
+    done
+    echo "${name} is ready."
+}
+
+# Proxy must be up before Chromium (which routes through it)
+if [ "${PROXY_HOST:-proxy}" != "proxy" ]; then
+    wait_for "proxy" "http://${PROXY_HOST}:3128" 60
+fi
+
+# Memory server must be up before the bot connects via MCP
+if [ -n "${BOT_MEMORY_URL:-}" ] && [ "${BOT_MEMORY_URL}" != "http://localhost:8080/sse" ]; then
+    MEMORY_HEALTH_URL="${BOT_MEMORY_URL%/sse}/health"
+    wait_for "memory-server" "$MEMORY_HEALTH_URL" 120
+fi
+
 # Start headless Chromium in background (Playwright-installed binary)
 CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f | head -1)
 "$CHROME_BIN" \


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                                                          
  - Add dependency wait checks in entrypoint.sh so the bot waits for the proxy and memory server to be healthy before starting. OpenShift deploys all pods concurrently, and the bot may be connecting to services before they were ready (or connecting to old pods mid-rollout). The waits
  only activate in OpenShift — local docker-compose is unaffected.                                                                                                                                                                                                                        
  - Add a 30-minute cycle timeout (asyncio.wait_for) around each run_cycle call. If a cycle hangs (e.g., Vertex AI streaming response stalls), it times out and moves to the next cycle instead of blocking forever. Configurable via config.json → claude.cycleTimeoutSeconds (default:
  1800).                                                                                                                                                                                                                                                                                  
                  
  Test plan                                                                                                                                                                                                                                                                               
                  
  - Verify local docker-compose up still works (wait checks should be skipped)                                                                                                                                                                                                            
  - Deploy to OpenShift and confirm bot logs show "Waiting for proxy/memory-server..." and "is ready." before starting
  - Confirm bot completes a normal cycle under 30 minutes without being killed by the timeout