### PR TITLE
feat(mcp): migrate from SSE to MCP protocol

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,8 +5,8 @@
       "args": ["--browserUrl", "http://127.0.0.1:9222", "--acceptInsecureCerts"]
     },
     "bot-memory": {
-      "type": "sse",
-      "url": "http://localhost:8080/sse"
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
     }
   }
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -246,7 +246,7 @@ objects:
           - name: BOT_LABEL
             value: ${BOT_LABEL}
           - name: BOT_MEMORY_URL
-            value: http://devbot-memory-server:8080/sse
+            value: http://devbot-memory-server:8080/mcp
           - name: BOT_MEMORY_HEALTH_URL
             value: http://devbot-memory-server:8080/health
           - name: BOT_MEMORY_HEALTH_TIMEOUT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - SSO_PASSWORD
       - BOT_LABEL=${BOT_LABEL:-hcc-ai-framework}
       - BOT_INSTANCE_ID=${BOT_INSTANCE_ID:-}
-      - BOT_MEMORY_URL=http://memory-server:8080/sse
+      - BOT_MEMORY_URL=http://memory-server:8080/mcp
       - COSTS_API_URL=http://memory-server:8080/api/costs
       - BOT_DASHBOARD_URL=http://memory-server:8080/api/bot-status
       - GOOGLE_APPLICATION_CREDENTIALS=/home/botuser/sa-key.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,7 @@ if [ -n "${GOOGLE_SA_KEY_B64:-}" ]; then
 fi
 
 # Point MCP config to the memory server
-sed -i "s|http://localhost:8080/sse|${BOT_MEMORY_URL}|" .mcp.json
+sed -i "s|http://localhost:8080/mcp|${BOT_MEMORY_URL}|" .mcp.json
 
 # Configure gh CLI auth
 mkdir -p ~/.config/gh

--- a/memory-server/src/server.py
+++ b/memory-server/src/server.py
@@ -107,8 +107,8 @@ async def ws_events(websocket: WebSocket):
 
 
 if __name__ == "__main__":
-    # Build the MCP SSE app (handles /sse and /messages/ endpoints + custom routes)
-    mcp_app = mcp.http_app(transport="sse")
+    # Build the MCP app (handles /mcp endpoint + custom routes)
+    mcp_app = mcp.http_app(transport="streamable-http")
 
     # Wrap in an outer Starlette app so we can add WebSocket + lifespan
     app = Starlette(

--- a/memory-server/src/server.py
+++ b/memory-server/src/server.py
@@ -110,9 +110,15 @@ if __name__ == "__main__":
     # Build the MCP app (handles /mcp endpoint + custom routes)
     mcp_app = mcp.http_app(transport="streamable-http")
 
+    @asynccontextmanager
+    async def combined_lifespan(app):
+        async with lifespan(app):
+            async with mcp_app.lifespan(app):
+                yield
+
     # Wrap in an outer Starlette app so we can add WebSocket + lifespan
     app = Starlette(
-        lifespan=lifespan,
+        lifespan=combined_lifespan,
         routes=[
             WebSocketRoute("/ws", ws_events),
             Mount("/", app=mcp_app),


### PR DESCRIPTION
Summary

  - Add dependency health checks in entrypoint.sh so the bot waits for the proxy and memory server to be healthy before starting. OpenShift deploys all pods concurrently, so without this the bot can connect to services that aren't ready yet. Health check URLs and timeouts are configured via explicit env vars in the deploy template (BOT_PROXY_HEALTH_URL, BOT_MEMORY_HEALTH_URL, etc.) — no hardcoded values or URL parsing. Checks are skipped locally since the env vars aren't set.
  - Add a 30-minute cycle timeout around each run_cycle call. If a cycle hangs (e.g., Vertex AI streaming response stalls), it logs an error and moves to the next cycle instead of blocking forever. Configurable via config.json → claude.cycleTimeoutSeconds (default: 1800).
  - Migrate MCP transport from SSE to streamable HTTP. The memory server, .mcp.json, deploy template, docker-compose, and entrypoint all switch from /sse to /mcp endpoint.

  Test plan

  - Verify local docker-compose up still works (health check waits should be skipped, MCP connects on /mcp)
  - Deploy to OpenShift and confirm bot logs show "Waiting for proxy..." / "Waiting for memory-server..." and "is ready." before Chromium/bot startup
  - Confirm bot completes a normal cycle without hitting the 30-minute timeout
  - Verify memory server dashboard is still accessible and tools work over streamable HTTP