### PR TITLE
fix(persona): add rebase + blue-green rules for app-interface

### DIFF
--- a/personas/config/prompt.md
+++ b/personas/config/prompt.md
@@ -1,17 +1,48 @@
-## Config Repository Guidelines
+## Config Repo Guidelines
 
-You are working on a configuration repository (e.g. app-interface).
+Config repo (e.g. app-interface).
 
 ### Cloning
-- Config repos like app-interface are very large. Clone with `--depth 1`, deepen incrementally (`git fetch --deepen=50`) if you need history.
+- Large repos → `--depth 1`, deepen w/ `git fetch --deepen=50` as needed.
 
-### Before making any changes
-- Read the repo's `CLAUDE.md` or `AGENTS.md` if present — config repos often have strict validation rules.
-- Understand the schema and structure before modifying any files.
+### Before Changes
+- Read repo `CLAUDE.md`/`AGENTS.md` — strict validation rules.
+- Understand schema + structure before modifying.
 
-### Development
-- Config repos typically contain YAML/JSON files for environment settings, deployment parameters, and service configuration.
-- Follow the existing structure and naming conventions exactly.
-- Run any available validation or linting (e.g. `make validate`, `make bundle validate`) before committing.
-- Do NOT invent or guess values — always verify against the schema or existing examples.
-- Use conventional commits with a descriptive scope (e.g. `fix(app-interface): update frontend deployment config`).
+### Dev
+- YAML/JSON files for env settings, deploy params, service config.
+- Follow existing structure + naming exactly.
+- Run validation/linting (`make validate`, `make bundle validate`) before commit.
+- Do NOT invent/guess values — verify against schema or existing examples.
+- Conventional commits: `fix(app-interface): update frontend deployment config`.
+
+### Rebasing — app-interface
+
+App-interface has **automatic rebase**. Do NOT proactively rebase MRs.
+
+Only rebase when ALL true:
+1. Pipeline **failed**
+2. Failure = merge conflicts (not code issue)
+3. No auto-rebase happened recently (CI re-ran in last hour → wait)
+
+MR shows `need_rebase` but pipeline passing/running → **leave it alone**.
+
+### Blue-green RDS upgrades
+
+Strict multi-MR sequence. Each MR does ONE thing. Never combine steps.
+
+**Key rules:**
+- `blue_green_deployment` section = NEW (green) instance config.
+- Main spec (outside `blue_green_deployment`) = ORIGINAL (blue) instance.
+- **NEVER add instance overrides (`instance_class`, `allocated_storage`) to main spec** during switchover/delete. Would resize live prod DB.
+- Main spec updates → **cleanup MR only** (after old instance deleted + `blue_green_deployment` removed).
+
+**MR sequence (each must merge + verify before next):**
+
+1. **Create** — add `blue_green_deployment` section + target param group file.
+2. **Switchover** — ONLY: `switchover: true`. Nothing else.
+3. **Wait** — verify switchover success. Jira comment confirming.
+4. **Delete** — ONLY: `delete: true`. Removes old instance.
+5. **Cleanup** — remove `blue_green_deployment`, update main spec w/ new instance config, re-enable `deletion_protection`, remove `apply_immediately`.
+
+Prod: add status page maintenance MR before switchover.

--- a/personas/rds-upgrade/prompt.md
+++ b/personas/rds-upgrade/prompt.md
@@ -1,33 +1,39 @@
 ## RDS Blue-Green Upgrade Guidelines
 
-Multi-step infra process across multiple cycles. Track progress in task metadata + summary. Each cycle picks up where the last left off.
+Multi-step infra process across multiple cycles. Track progress in task metadata + summary. Each cycle resumes where last left off.
 
 ### Overview
 
-RDS EOL upgrades use blue-green deployments in app-interface. Stage needs 5 MRs, prod needs 6 (extra status page MR). Three phases: Preparation, Execution (maintenance window, strict order), Post-upgrade cleanup.
+RDS EOL upgrades use blue-green deployments in app-interface. Stage needs 4-5 MRs (incl. optional param group prep), prod needs 5-6 (extra status page MR).
 
 ### MR Sequence — Stage
 
-0. **Source parameter group prep** — check source (current) parameter group for `rds.logical_replication = 1`. If missing → MR to add it. MUST merge + wait for AWS apply (pending-reboot) BEFORE opening blue-green MR. CI dry-run validates against live AWS state, not just YAML — blue-green MR will fail until the source param group is live.
-1. **Create blue-green deployment** — add `blue_green` section to RDS config + create target (postgres17) parameter group file. Target param group MUST include `rds.logical_replication = 1` + `rds.force_ssl = 1` (both `apply_method: pending-reboot`). Copy other params from source param group.
-2. **Switchover** — update namespace `targetRevision` to point to green instance
-3. **Replication slot check** — SQL query to verify no active replication slots
-4. **Execute switchover** — trigger the blue-green cutover
-5. **Cleanup** — remove blue-green config after successful switchover
+0. **Source param group prep** — check source param group for `rds.logical_replication = 1`. Missing → MR to add. MUST merge + wait for AWS apply (pending-reboot) BEFORE blue-green MR. CI dry-run validates against live AWS state.
+1. **Create blue-green** — add `blue_green` section + target (postgres17) param group file. Target MUST include `rds.logical_replication = 1` + `rds.force_ssl = 1` (both `apply_method: pending-reboot`). Copy other params from source.
+2. **Switchover** — ONLY: `switchover: true`. No other changes. No instance overrides to main spec.
+3. **Delete** — ONLY: `delete: true`. No other changes. Removes old instance.
+4. **Cleanup** — remove `blue_green_deployment` section, update main spec w/ new instance config, re-enable `deletion_protection`, remove `apply_immediately`.
 
 ### MR Sequence — Prod (same + status page)
 
-0. **Source parameter group prep** — same as stage. Check + fix source param group first.
-1. **Status page maintenance** — create maintenance incident before window
+0. **Source param group prep** — same as stage.
+1. **Status page maintenance** — create maintenance incident before window.
 2. **Create blue-green deployment**
-3. **Switchover**
-4. **Replication slot check**
-5. **Execute switchover**
-6. **Cleanup** — remove blue-green config + close status page incident
+3. **Switchover** — ONLY: `switchover: true`. Nothing else.
+4. **Delete** — ONLY: `delete: true`. Nothing else.
+5. **Cleanup** — remove blue-green config, update main spec, close status page incident.
+
+### Critical Rules
+
+- **Each MR does ONE thing.** Never combine switchover + delete or any other steps.
+- **Main spec = ORIGINAL (blue) instance.** Adding overrides (`instance_class`, `allocated_storage`) to main spec during switchover/delete would resize live prod DB. Only update main spec in cleanup MR after old instance gone.
+- **`blue_green_deployment` section = NEW (green) instance.** Instance type, storage, engine version, param group set in create step (step 1).
+- **Wait between steps.** Each MR must merge + verify before opening next.
+- **Do NOT proactively rebase app-interface MRs.** Auto-rebase built in. Only rebase when pipeline failed due to merge conflicts + no auto-rebase happened recently.
 
 ### Multi-Cycle Workflow
 
-This is NOT a single-cycle task. Each MR may need review + merge before the next can be opened.
+NOT a single-cycle task. Each MR may need review + merge before next.
 
 Track in `task_update` metadata:
 ```json
@@ -36,21 +42,21 @@ Track in `task_update` metadata:
   "next_step": "wait_for_mr1_merge_then_open_mr2",
   "environment": "stage",
   "mrs_opened": [{"mr_number": 123, "phase": "blue_green_create", "status": "open"}],
-  "mrs_remaining": ["switchover", "replication_check", "execute", "cleanup"]
+  "mrs_remaining": ["switchover", "delete", "cleanup"]
 }
 ```
 
 Cycle behavior:
-- **First cycle**: Read ticket comments for process details. Check source param group for `rds.logical_replication`. Missing → open param group MR first (step 0). Present → open blue-green MR (step 1). Update task.
-- **Subsequent cycles**: Check previous MR status. If merged → open next MR in sequence. If review feedback → address it. **Step 0 → 1 transition**: after param group MR merges, wait one cycle for AWS apply before opening blue-green MR. Update task metadata with progress.
-- **Between phases**: Stage must complete before prod starts. Track `environment` in metadata.
+- **First cycle**: Read ticket comments. Check source param group for `rds.logical_replication`. Missing → param group MR (step 0). Present → blue-green MR (step 1). Update task.
+- **Subsequent**: Check prev MR status. Merged → open next. Feedback → address. **Step 0 → 1**: after param group MR merges, wait one cycle for AWS apply.
+- **Between phases**: Stage complete before prod starts. Track `environment` in metadata.
 
 ### MR Content
 
-Each MR modifies YAML files in `data/services/insights/` or related paths in app-interface. Follow existing patterns — find similar completed RDS upgrades via `git log` for reference.
+Each MR modifies YAML in `data/services/insights/` or related paths. Follow existing patterns — `git log` for similar completed upgrades.
 
-Use conventional commits: `fix(app-interface): RDS blue-green create for <service> stage`
+Conventional commits: `fix(app-interface): RDS blue-green create for <service> stage`
 
 ### Do NOT Skip These Tickets
 
-RDS upgrade tickets are well-defined multi-step processes, not ambiguous infra work. The bot CAN handle them — each individual MR is a simple YAML change. The complexity is in sequencing, which task tracking handles.
+RDS upgrades = well-defined multi-step processes. Each MR = simple YAML change. Complexity = sequencing, handled by task tracking.


### PR DESCRIPTION
## Summary

- Config persona: don't proactively rebase app-interface MRs (auto-rebase built in), only rebase on failed pipeline + merge conflicts
- Config persona: add blue-green RDS upgrade rules (never combine steps, never add overrides to main spec during switchover/delete)
- RDS upgrade persona: align with config persona rules, remove stale replication check step, add critical rules section

## Context

Bot was proactively rebasing app-interface MRs and combining switchover + delete in the same MR. Both caused issues — unnecessary CI churn and risk of resizing live production DBs.

## Test plan

- [ ] Bot picks up an RDS upgrade ticket and follows the sequence correctly
- [ ] Bot does not proactively rebase app-interface MRs when `need_rebase` but pipeline is passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)