### PR TITLE
feat(triage): pre-triage skill to reduce LLM tool calls

### DIFF
--- a/.claude/hooks/block-secrets-read.sh
+++ b/.claude/hooks/block-secrets-read.sh
@@ -47,6 +47,16 @@ if echo "$FILE_PATH" | grep -qE '(^|/)\.env(\.|$)'; then
   deny "BLOCKED: Reading .env files is not allowed."
 fi
 
+# Block reading Jira credentials file
+if echo "$FILE_PATH" | grep -qE '(^|/)\.jira-credentials$'; then
+  deny "BLOCKED: Reading Jira credentials file is not allowed."
+fi
+
+# Block reading glab CLI config (contains token)
+if echo "$FILE_PATH" | grep -qE '\.config/glab-cli/'; then
+  deny "BLOCKED: Reading GitLab CLI config is not allowed (contains auth token)."
+fi
+
 # Block reading AWS credentials
 if echo "$FILE_PATH" | grep -qE '\.aws/(credentials|config)'; then
   deny "BLOCKED: Reading AWS credential files is not allowed."

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: triage
+description: >
+  Pre-triage data gathering for bot cycle. Fetches active tasks, PR/MR statuses,
+  PR comments, Jira comments, capacity from memory server + gh/glab CLIs + Jira API.
+  Groups by action bucket: MERGED, CI_FAIL, CONFLICTS, FEEDBACK, INTERRUPTED, CLEAN.
+when_to_use: >
+  Invoke at START of every bot cycle. Triggers on: "starting cycle", "triage",
+  "task_list", "check tasks", "workflow loop", "priority 0", "resume work".
+  Replaces manual task_list + jira_get_issue + gh pr view calls.
+user-invocable: true
+allowed-tools:
+  - "Bash(python3 .claude/skills/triage/triage.py *)"
+  - Read
+  - mcp__bot-memory__task_update
+  - mcp__bot-memory__bot_status_update
+  - mcp__mcp-atlassian__jira_get_issue
+  - mcp__mcp-atlassian__jira_add_comment
+  - mcp__mcp-atlassian__jira_search
+---
+
+Run the triage script to gather task/PR/Jira data:
+
+```bash
+python3 .claude/skills/triage/triage.py 2>&1
+```
+
+The output is authoritative — do NOT re-fetch data already shown.
+If `[jira unavailable]` for any ticket → use `jira_get_issue` MCP for those only.
+
+Act on top bucket first. ONE item/cycle per CLAUDE.md rules.
+Call `bot_status_update` w/ jira_key+repo before starting work.

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -133,7 +133,7 @@ def upstream_repo(repo_name):
         host = parsed.hostname or ""
         if host == "github.com":
             return _parse_repo_path(up), "github"
-        if host.endswith("gitlab.com") or host.endswith("gitlab.cee.redhat.com"):
+        if host in ("gitlab.com", "gitlab.cee.redhat.com"):
             return _parse_repo_path(up), "gitlab"
     except Exception:
         pass

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Pre-triage data gatherer. Output = caveman-compressed markdown.
+
+Runs as !`command` in SKILL.md. Gathers tasks, PR statuses, Jira comments,
+PR comments, capacity. Groups by action bucket.
+"""
+
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+MEMORY_URL = os.environ.get("BOT_MEMORY_URL", "http://localhost:8080").rstrip("/mcp").rstrip("/")
+PROJECT_REPOS = Path(__file__).resolve().parent.parent.parent.parent / "project-repos.json"
+JIRA_CREDS = Path.home() / ".jira-credentials"
+
+
+def http_get(url, headers=None, timeout=10):
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        print(f"ERR GET {url}: {e}", file=sys.stderr)
+        return None
+
+
+def get_tasks():
+    data = http_get(f"{MEMORY_URL}/api/tasks?exclude_status=archived&limit=50")
+    return data.get("items", []) if data else []
+
+
+def get_capacity():
+    data = http_get(f"{MEMORY_URL}/api/tasks?exclude_status=archived&exclude_status=done&exclude_status=paused&limit=50")
+    if data and "items" in data:
+        n = len([t for t in data["items"] if t.get("status") in ("in_progress", "pr_open", "pr_changes")])
+        return n, 10
+    return 0, 10
+
+
+def gh_pr(owner_repo, num):
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "view", str(num), "--repo", owner_repo,
+             "--json", "state,mergeable,statusCheckRollup,reviewDecision,reviews,url,title,isDraft"],
+            capture_output=True, text=True, timeout=15)
+        return json.loads(r.stdout) if r.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def gl_mr(project_path, num):
+    encoded = project_path.replace("/", "%2F")
+    try:
+        r = subprocess.run(
+            ["glab", "api", f"projects/{encoded}/merge_requests/{num}",
+             "--hostname", "gitlab.cee.redhat.com"],
+            capture_output=True, text=True, timeout=15)
+        return json.loads(r.stdout) if r.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def gh_pr_comments(owner_repo, num):
+    comments = []
+    for ep in [f"repos/{owner_repo}/pulls/{num}/comments",
+               f"repos/{owner_repo}/issues/{num}/comments"]:
+        try:
+            r = subprocess.run(
+                ["gh", "api", ep, "--jq",
+                 '.[] | {a: .user.login, t: .created_at, b: .body}'],
+                capture_output=True, text=True, timeout=15)
+            if r.returncode == 0 and r.stdout.strip():
+                for line in r.stdout.strip().split("\n"):
+                    try:
+                        comments.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+        except Exception:
+            pass
+    return comments
+
+
+def gl_mr_notes(project_path, num):
+    encoded = project_path.replace("/", "%2F")
+    try:
+        r = subprocess.run(
+            ["glab", "api", f"projects/{encoded}/merge_requests/{num}/notes?per_page=50&sort=asc",
+             "--hostname", "gitlab.cee.redhat.com"],
+            capture_output=True, text=True, timeout=15)
+        if r.returncode == 0:
+            return [{"a": n.get("author", {}).get("username", "?"),
+                      "t": n.get("created_at", "")[:16],
+                      "b": n.get("body", "")}
+                     for n in json.loads(r.stdout) if not n.get("system")]
+    except Exception:
+        pass
+    return []
+
+
+def jira_issue(key):
+    if not JIRA_CREDS.exists():
+        return None
+    try:
+        creds = json.loads(JIRA_CREDS.read_text())
+    except Exception:
+        return None
+    url, user, token = creds.get("url", "").rstrip("/"), creds.get("username", ""), creds.get("token", "")
+    if not all([url, user, token]):
+        return None
+    auth = base64.b64encode(f"{user}:{token}".encode()).decode()
+    return http_get(
+        f"{url}/rest/api/2/issue/{key}?fields=summary,status,comment,assignee,labels,issuelinks",
+        headers={"Authorization": f"Basic {auth}", "Accept": "application/json"}, timeout=15)
+
+
+def upstream_repo(repo_name):
+    try:
+        repos = json.loads(PROJECT_REPOS.read_text())
+        entry = repos.get(repo_name, {})
+        up = entry.get("upstream", "")
+        if "github.com" in up:
+            path = up.split(":")[-1].replace(".git", "") if (":" in up and "@" in up) else "/".join(up.split("/")[-2:]).replace(".git", "")
+            return path, "github"
+        if "gitlab" in up:
+            path = up.split(":")[-1].replace(".git", "") if (":" in up and "@" in up) else "/".join(up.split("/")[-2:]).replace(".git", "")
+            return path, "gitlab"
+    except Exception:
+        pass
+    return "", entry.get("host", "github") if 'entry' in dir() else "github"
+
+
+def fmt_comments(comments, label, since=None):
+    if not comments:
+        return f"  {label}: (none)"
+    if since:
+        since_prefix = since[:16]
+        comments = [c for c in comments
+                    if (c.get("t", c.get("created", ""))[:16]) > since_prefix]
+    if not comments:
+        return f"  {label}: (none since last_addressed)"
+    comments = list(reversed(comments))
+    lines = [f"  {label} ({len(comments)}, newest first):"]
+    for c in comments:
+        author = c.get("a", c.get("author", {}).get("displayName", "?") if isinstance(c.get("author"), dict) else c.get("author", "?"))
+        t = c.get("t", c.get("created", ""))[:16]
+        body = c.get("b", c.get("body", ""))
+        lines.append(f"    [{t}] {author}:")
+        for bl in body.strip().split("\n"):
+            lines.append(f"      {bl}")
+    return "\n".join(lines)
+
+
+def classify_gh(pr):
+    state = pr.get("state", "UNKNOWN")
+    if state == "MERGED":
+        return "MERGED", ["merged"]
+    if state == "CLOSED":
+        return "CLOSED", ["closed"]
+    issues = []
+    if pr.get("mergeable") == "CONFLICTING":
+        issues.append("conflict")
+    checks = pr.get("statusCheckRollup") or []
+    failed = [c.get("name", "?") for c in checks if c.get("conclusion") == "FAILURE"]
+    if failed:
+        issues.append(f"ci_fail:{','.join(failed)}")
+    if pr.get("reviewDecision") == "CHANGES_REQUESTED":
+        issues.append("changes_requested")
+    for r in (pr.get("reviews") or []):
+        if r.get("state") == "CHANGES_REQUESTED":
+            issues.append(f"review:{r.get('author', {}).get('login', '?')}")
+    return state, issues
+
+
+def classify_gl(mr):
+    state = mr.get("state", "unknown")
+    if state == "merged":
+        return "MERGED", ["merged"]
+    if state == "closed":
+        return "CLOSED", ["closed"]
+    issues = []
+    if mr.get("has_conflicts"):
+        issues.append("conflict")
+    pipe = (mr.get("head_pipeline") or {}).get("status", "")
+    if pipe == "failed":
+        issues.append("ci_fail")
+    if not mr.get("blocking_discussions_resolved", True):
+        issues.append("unresolved_threads")
+    return state.upper(), issues
+
+
+def enrich(task):
+    repo = task.get("repo", "")
+    meta = task.get("metadata") or {}
+    prs_info = meta.get("prs", [])
+    if not prs_info and task.get("pr_number"):
+        _, host = upstream_repo(repo)
+        prs_info = [{"repo": repo, "number": task["pr_number"], "host": host}]
+
+    pr_results = []
+    pr_comments = []
+    all_issues = []
+
+    for p in prs_info:
+        pr_repo, pr_num, pr_host = p.get("repo", repo), p.get("number"), p.get("host", "github")
+        if not pr_num:
+            continue
+        up, dh = upstream_repo(pr_repo)
+        host = pr_host or dh
+
+        if host == "github" and up:
+            data = gh_pr(up, pr_num)
+            if data:
+                state, issues = classify_gh(data)
+                pr_results.append({"repo": pr_repo, "num": pr_num, "host": host, "state": state, "issues": issues, "data": data})
+                all_issues.extend(issues)
+                pr_comments.extend(gh_pr_comments(up, pr_num))
+        elif host == "gitlab" and up:
+            data = gl_mr(up, pr_num)
+            if data:
+                state, issues = classify_gl(data)
+                pr_results.append({"repo": pr_repo, "num": pr_num, "host": host, "state": state, "issues": issues, "data": data})
+                all_issues.extend(issues)
+                pr_comments.extend(gl_mr_notes(up, pr_num))
+
+    jira = jira_issue(task.get("jira_key", ""))
+    jira_comments = []
+    if jira:
+        jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
+
+    return {"task": task, "prs": pr_results, "pr_comments": pr_comments,
+            "jira": jira, "jira_comments": jira_comments, "issues": all_issues}
+
+
+def fmt_task(e):
+    t = e["task"]
+    key, status, repo = t.get("jira_key", "?"), t.get("status", "?"), t.get("repo", "?")
+    meta = t.get("metadata") or {}
+    lines = [f"{key} [{status}] {repo}"]
+    if t.get("title"):
+        lines.append(f"  title: {t['title']}")
+    if t.get("summary"):
+        lines.append(f"  summary: {t['summary'][:150]}")
+    if meta.get("last_step"):
+        lines.append(f"  last_step: {meta['last_step']}")
+    if t.get("last_addressed"):
+        lines.append(f"  last_addressed: {t['last_addressed']}")
+
+    for p in e["prs"]:
+        issue_str = ",".join(p["issues"]) if p["issues"] else "clean"
+        lines.append(f"  PR {p['repo']}#{p['num']} ({p['host']}) state={p['state']} [{issue_str}]")
+
+    last_addr = t.get("last_addressed")
+    if e["pr_comments"]:
+        lines.append(fmt_comments(e["pr_comments"], "pr_comments", since=last_addr))
+    if e["jira"]:
+        fields = e["jira"].get("fields", {})
+        lines.append(f"  jira_status: {fields.get('status', {}).get('name', '?')}")
+        labels = fields.get("labels", [])
+        if labels:
+            lines.append(f"  labels: {','.join(labels)}")
+        links = fields.get("issuelinks", [])
+        for lk in links[:5]:
+            lt = lk.get("type", {}).get("name", "?")
+            linked = lk.get("inwardIssue") or lk.get("outwardIssue", {})
+            if linked:
+                lines.append(f"  link: {lt} {linked.get('key','?')} [{linked.get('fields',{}).get('status',{}).get('name','?')}]")
+        jc = [{"author": c.get("author", {}).get("displayName", "?"),
+               "t": c.get("created", "")[:16],
+               "b": c.get("body", "")} for c in e["jira_comments"]]
+        lines.append(fmt_comments(jc, "jira_comments", since=last_addr))
+    else:
+        lines.append("  [jira unavailable — use jira_get_issue]")
+
+    return "\n".join(lines)
+
+
+def has_new_jira_feedback(e):
+    last_addr = e["task"].get("last_addressed", "")
+    for c in e["jira_comments"]:
+        ct = c.get("created", "")[:16]
+        if last_addr and ct > last_addr[:16]:
+            body = c.get("body", "")
+            if not ("### " in body or "| " in body or "PR:" in body):
+                return True
+    return False
+
+
+def main():
+    tasks = get_tasks()
+    active_n, max_n = get_capacity()
+
+    active = [t for t in tasks if t.get("status") in ("in_progress", "pr_open", "pr_changes")]
+    paused = [t for t in tasks if t.get("status") == "paused"]
+    done = [t for t in tasks if t.get("status") == "done"]
+
+    print(f"TRIAGE | capacity: {active_n}/{max_n} | active: {len(active)} | paused: {len(paused)} | done: {len(done)}")
+    print()
+
+    if not active:
+        print("NO ACTIVE TASKS -> Priority 2 (new Jira work)")
+        if done:
+            print(f"done pending archival: {','.join(t.get('jira_key','?') for t in done)}")
+        if paused:
+            print(f"paused: {','.join(t.get('jira_key','?') for t in paused)}")
+        return
+
+    enriched = [enrich(t) for t in active]
+
+    merged, ci_fail, conflict, feedback, interrupted, clean = [], [], [], [], [], []
+
+    for e in enriched:
+        issues = e["issues"]
+        t = e["task"]
+        meta = t.get("metadata") or {}
+
+        if "merged" in issues:
+            merged.append(e)
+        elif any(i.startswith("ci_fail") for i in issues):
+            ci_fail.append(e)
+        elif "conflict" in issues:
+            conflict.append(e)
+        elif any(i in ("changes_requested", "unresolved_threads") or i.startswith("review:") for i in issues):
+            feedback.append(e)
+        elif t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs"):
+            interrupted.append(e)
+        elif has_new_jira_feedback(e):
+            feedback.append(e)
+        else:
+            clean.append(e)
+
+    if merged:
+        print(f"== MERGED ({len(merged)}) — archive + transition ==")
+        for e in merged:
+            print(fmt_task(e))
+            print()
+
+    if ci_fail:
+        print(f"== CI FAILING ({len(ci_fail)}) — fix + push ==")
+        for e in ci_fail:
+            print(fmt_task(e))
+            print()
+
+    if conflict:
+        print(f"== CONFLICTS ({len(conflict)}) — rebase ==")
+        for e in conflict:
+            print(fmt_task(e))
+            print()
+
+    if feedback:
+        print(f"== FEEDBACK ({len(feedback)}) — respond/impl ==")
+        for e in feedback:
+            print(fmt_task(e))
+            print()
+
+    if interrupted:
+        print(f"== INTERRUPTED ({len(interrupted)}) — resume ==")
+        for e in interrupted:
+            print(fmt_task(e))
+            print()
+
+    if clean:
+        print(f"== CLEAN ({len(clean)}) — no action ==")
+        for e in clean:
+            t = e["task"]
+            print(f"  {t.get('jira_key','?')} [{t.get('status','?')}] {t.get('repo','?')}")
+        print()
+
+    if paused:
+        print(f"PAUSED: {' | '.join(t.get('jira_key','?')+':'+str(t.get('paused_reason','')) for t in paused)}")
+    if done:
+        print(f"DONE (archive?): {','.join(t.get('jira_key','?') for t in done)}")
+
+    total = len(merged) + len(ci_fail) + len(conflict) + len(feedback) + len(interrupted)
+    if total == 0:
+        print("-> all clean -> Priority 2")
+    else:
+        print(f"-> {total} task(s) need work. Top bucket first. ONE/cycle.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -10,6 +10,7 @@ import json
 import os
 import subprocess
 import sys
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -117,17 +118,23 @@ def jira_issue(key):
         headers={"Authorization": f"Basic {auth}", "Accept": "application/json"}, timeout=15)
 
 
+def _parse_repo_path(url):
+    if ":" in url and "@" in url:
+        return url.split(":")[-1].replace(".git", "")
+    return "/".join(url.split("/")[-2:]).replace(".git", "")
+
+
 def upstream_repo(repo_name):
     try:
         repos = json.loads(PROJECT_REPOS.read_text())
         entry = repos.get(repo_name, {})
         up = entry.get("upstream", "")
-        if "github.com" in up:
-            path = up.split(":")[-1].replace(".git", "") if (":" in up and "@" in up) else "/".join(up.split("/")[-2:]).replace(".git", "")
-            return path, "github"
-        if "gitlab" in up:
-            path = up.split(":")[-1].replace(".git", "") if (":" in up and "@" in up) else "/".join(up.split("/")[-2:]).replace(".git", "")
-            return path, "gitlab"
+        parsed = urllib.parse.urlparse(up if "://" in up else f"ssh://{up}")
+        host = parsed.hostname or ""
+        if host == "github.com":
+            return _parse_repo_path(up), "github"
+        if host.endswith("gitlab.com") or host.endswith("gitlab.cee.redhat.com"):
+            return _parse_repo_path(up), "gitlab"
     except Exception:
         pass
     return "", entry.get("host", "github") if 'entry' in dir() else "github"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,17 +155,19 @@ ONE item per cycle. Priority order:
 - Cycle end: `idle`, "Cycle complete. Sleeping..." or "No work found. Sleeping..."
 - Error: `error`, "<what went wrong>"
 
+### Triage (start of every cycle)
+
+Invoke `/triage` skill first. It runs a script that pre-gathers all active tasks, PR/MR statuses (state, CI, reviews, merge conflicts), Jira comments, PR comments, and capacity — grouped by action bucket (MERGED, CI_FAIL, CONFLICTS, FEEDBACK, INTERRUPTED, CLEAN).
+
+Do NOT re-fetch this data. Do NOT call `task_list`, `jira_get_issue`, or `gh pr view` for tasks already in the triage output. If any ticket shows `[jira unavailable]`, use `jira_get_issue` MCP tool for those only.
+
 ### Priority 0: Resume + Respond to Feedback
 
-`task_list` → get all active tasks. **MUST check ALL for feedback before triaging:**
-
-- EVERY `in_progress`/`pr_open`/`pr_changes` task: call `jira_get_issue` → read ALL comments → determine unaddressed
-- Open PRs: also check PR/MR comments via `gh api`/`glab mr view`
-- Build list of tasks w/ unaddressed feedback BEFORE deciding what to work on
+Use triage output to identify tasks with unaddressed feedback. Do NOT re-fetch data already in triage output.
 
 **CRITICAL — Shared Jira identity**: Bot shares Jira creds with human operator → same author. CANNOT filter by author. Identify bot comments by **content patterns**: structured reports (### headers), grype scan tables, PR links, status updates, duplicate notices. Short conversational comments ("Hello bot, can you verify...", "Can you check...") = human. **When in doubt → treat as human feedback.**
 
-**Do NOT skip.** Do NOT short-circuit via metadata. Must fetch Jira comments. Investigation tasks (`last_step = "investigation_posted"`) especially important — humans reply days later.
+Investigation tasks (`last_step = "investigation_posted"`) especially important — humans reply days later.
 
 Triage buckets (first match wins):
 
@@ -179,32 +181,14 @@ None apply → Priority 1.
 
 ### Priority 1: Maintain Existing PRs
 
-For each `pr_open`/`pr_changes` task (check `metadata.prs` for multi-repo, else `repo`/`pr_number`/`pr_url`):
+PR statuses are in the triage output. For each `pr_open`/`pr_changes` task:
 
 0. **Reload persona**: Read `personas/<name>/prompt.md` for repo tech stack (same logic as step 6). Has CI fix patterns + sequencing rules.
 1. `cd` repo dir. `git fetch origin`. Fork? Also `git fetch upstream`.
 2. Check `host` in `project-repos.json` → `gh` (GitHub) or `glab` (GitLab). **ALL `glab` commands MUST include `--hostname gitlab.cee.redhat.com`** — without it, glab defaults to `gitlab.com` which is blocked. Fork repos: `glab mr` needs `--repo <upstream-project-path>`.
-3. PR status:
-   - GH: `gh pr view <n> --json state,mergeable,statusCheckRollup,reviewDecision,reviews,url`
-   - GL: Use the API for full status (glab mr view lacks structured data):
-     ```
-     glab api "projects/<url-encoded-path>/merge_requests/<n>" --hostname gitlab.cee.redhat.com
-     ```
-     URL-encode the project path: `service/app-interface` → `service%2Fapp-interface`.
-     Key fields in the response:
-     - `state`: "opened", "merged", "closed"
-     - `merge_status` / `detailed_merge_status`: "can_be_merged", "cannot_be_merged", "unchecked"
-     - `has_conflicts`: true/false — if true, needs rebase
-     - `head_pipeline.status`: "success", "failed", "running", "pending"
-     - `blocking_discussions_resolved`: false = unresolved threads block merge
-     - `draft`: true = WIP, not ready for merge
-     
-     For CI details: `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`
-     For approvals: `glab api "projects/<path>/merge_requests/<n>/approvals" --hostname gitlab.cee.redhat.com`
+3. **Review reminder**: If no Slack notification sent yet for this task → ALWAYS send `slack_notify` `review_reminder` (first notification, regardless of PR age). After first notification, cooldown handles repeat reminders automatically every 48h. **Bot reviews don't count** — only human reviews matter. PR with only bot reviews = still needs human review → send reminder.
 
-4. **Review reminder**: If no Slack notification sent yet for this task → ALWAYS send `slack_notify` `review_reminder` (first notification, regardless of PR age). After first notification, cooldown handles repeat reminders automatically every 48h. **Bot reviews don't count** — only human reviews matter. PR with only bot reviews = still needs human review → send reminder.
-
-5. Handle in order:
+4. Handle in order:
 
 **Failing CI**: `gh pr checks <n>` / `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`. Checkout branch → fix → commit → push. Comment on Jira. `task_update` `last_addressed`.
 
@@ -244,14 +228,9 @@ Handle one PR issue → stop. Next cycle picks up next.
 
 ### Priority 1.5: Check Assigned Tickets
 
-JQL:
-```
-project = RHCLOUD AND labels = PRIMARY_LABEL AND assignee = currentUser() AND status NOT IN (Done, "Release Pending") ORDER BY updated DESC
-```
-
-For each:
-1. **Merged PRs?** `gh pr list --head bot/<KEY> --state merged` / `glab mr list --source-branch bot/<KEY> --merged --hostname gitlab.cee.redhat.com`. If merged → transition "Release Pending", Jira comment, `task_update` archived, `memory_store`.
-2. **New Jira comments?** `jira_get_issue` → check for unaddressed comments since `last_addressed`. Handle: questions → reply, requirements → incorporate, close requests → respect.
+Triage output covers task statuses, PR states, and Jira comments. Use it to identify:
+1. **Merged PRs?** If triage shows `state=MERGED` → transition "Release Pending", Jira comment, `task_update` archived, `memory_store`.
+2. **New Jira comments?** Visible in triage output. Handle: questions → reply, requirements → incorporate, close requests → respect.
 3. PR still open, no comments → skip (Priority 1 handles).
 
 One ticket/cycle → stop.
@@ -409,7 +388,7 @@ Keep task record updated throughout (not just end). `task_update` w/ `summary` +
 - `last_step`: `branch_created`/`implemented`/`tests_passing`/`push_failed`/`pr_opened`/`review_addressed`/`investigation_posted`/`archived`
 - `files_changed`, `commits`, `next_step`, `notes`, `repos`, `prs`
 
-**On startup — interrupted work**: `task_list` → any `in_progress` w/ `last_step`? → `memory_search` repo + problem → resume from `next_step`. Task metadata = specific work state. RAG memory = cross-ticket learnings.
+**On startup — interrupted work**: Triage output shows all `in_progress` tasks w/ `last_step`. Any w/ `last_step` set? → `memory_search` repo + problem → resume from `next_step`. Task metadata = specific work state. RAG memory = cross-ticket learnings.
 
 ## Rules
 

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -158,6 +158,7 @@ async def run_cycle(
     prompt = (
         f"Your primary label is: {label}.{instance_line} "
         "Follow the instructions in CLAUDE.md. "
+        "Start by invoking the /triage skill to pre-gather task and PR data. "
         "IMPORTANT: Use ULTRA caveman output for all internal text — "
         "drop articles, filler, hedging, conjunctions. Abbreviate: DB/auth/config/req/res/fn/impl/env/dep/pkg. "
         "Arrows for causality (X → Y). One word when one word enough. "

--- a/bot/config.py
+++ b/bot/config.py
@@ -108,7 +108,7 @@ def sanitize_env() -> None:
 
 ALLOWED_TOOLS = [
     # Built-in tools
-    "Edit", "Write", "Read", "Glob", "Grep", "Bash", "LSP",
+    "Edit", "Write", "Read", "Glob", "Grep", "Bash", "LSP", "Skill",
     # Jira MCP tools
     "mcp__mcp-atlassian__jira_search",
     "mcp__mcp-atlassian__jira_get_issue",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,6 +80,14 @@ if [ -n "${GOOGLE_SA_KEY_B64:-}" ]; then
     decode_or_raw "$GOOGLE_SA_KEY_B64" > /home/botuser/sa-key.json
 fi
 
+# Write Jira credentials file for triage skill (same pattern as gh/glab config files)
+if [ -n "${JIRA_URL:-}" ] && [ -n "${JIRA_USERNAME:-}" ] && [ -n "${JIRA_API_TOKEN:-}" ]; then
+    cat > ~/.jira-credentials <<EOF
+{"url": "${JIRA_URL}", "username": "${JIRA_USERNAME}", "token": "${JIRA_API_TOKEN}"}
+EOF
+    chmod 600 ~/.jira-credentials
+fi
+
 # Point MCP config to the memory server
 sed -i "s|http://localhost:8080/mcp|${BOT_MEMORY_URL}|" .mcp.json
 


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill (`.claude/skills/triage/`) that pre-gathers all triage data via a Python script before the LLM starts reasoning
- Replaces 15-25 manual tool calls per cycle (task_list, jira_get_issue, gh pr view, etc.) with a single `python3 triage.py` invocation
- Comments are filtered by `last_addressed` timestamp and ordered newest-first to eliminate re-fetching
- Jira credentials are written to `~/.jira-credentials` by entrypoint.sh (same pattern as gh/glab config files)
- Security hooks updated to block reading `.jira-credentials` and `glab-cli` config

RHCLOUD-47252

## Test plan

- [x] Deployed to bot container and verified triage skill runs successfully
- [x] Bot treats skill output as authoritative — no re-fetching of PR/Jira data
- [x] Skill Bash permission scoped to `python3 .claude/skills/triage/triage.py *` only
- [ ] Verify comment filtering by `last_addressed` works with real task data
- [ ] Full cycle test: triage → pick work → implement → PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)