### PR TITLE
feat(skills): add /new-work skill for Jira candidate pre-fetch

### DIFF
--- a/.claude/skills/new-work/SKILL.md
+++ b/.claude/skills/new-work/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: new-work
+description: >
+  Fetch new Jira work candidates when no outstanding work needs attention.
+  Queries current sprint (and optionally backlog) for unassigned tickets
+  matching BOT_LABEL, ordered by priority, with full context and repo matching.
+when_to_use: >
+  Invoke after triage shows all tasks clean and no outstanding work. Triggers on:
+  "Priority 2", "new work", "find tickets", "no outstanding work", "all clean".
+  Do NOT use during triage or when active tasks need attention.
+user-invocable: true
+allowed-tools:
+  - "Bash(python3 .claude/skills/new-work/new_work.py *)"
+  - Read
+  - mcp__bot-memory__task_add
+  - mcp__bot-memory__task_check_capacity
+  - mcp__bot-memory__bot_status_update
+  - mcp__mcp-atlassian__jira_get_issue
+  - mcp__mcp-atlassian__jira_update_issue
+  - mcp__mcp-atlassian__jira_add_comment
+  - mcp__mcp-atlassian__jira_get_transitions
+  - mcp__mcp-atlassian__jira_transition_issue
+  - mcp__mcp-atlassian__jira_create_issue_link
+  - mcp__mcp-atlassian__jira_get_sprints_from_board
+  - mcp__mcp-atlassian__jira_add_issues_to_sprint
+---
+
+Run the new-work script to find candidate tickets:
+
+```bash
+python3 .claude/skills/new-work/new_work.py 2>&1
+```
+
+The output lists unassigned tickets from the current sprint (and backlog if enabled),
+ordered by priority, with full description/comments/links and repo: label matching.
+
+Pick the first candidate with matching `repos:` field. Follow CLAUDE.md Priority 2 rules
+for claiming, implementing, and opening PRs.

--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -33,6 +33,19 @@ def http_get(url, headers=None, timeout=10):
         return None
 
 
+def http_post(url, body, headers=None, timeout=10):
+    data = json.dumps(body).encode()
+    hdrs = dict(headers or {})
+    hdrs["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        print(f"ERR POST {url}: {e}", file=sys.stderr)
+        return None
+
+
 def jira_auth():
     if not JIRA_CREDS.exists():
         print(f"WARN: {JIRA_CREDS} not found", file=sys.stderr)
@@ -55,12 +68,13 @@ def jira_search(jql, limit=10):
     url, headers = jira_auth()
     if not url:
         return []
-    encoded = urllib.parse.urlencode({
+    fields = ["summary", "status", "labels", "assignee", "priority",
+              "description", "comment", "issuelinks", "issuetype"]
+    data = http_post(f"{url}/rest/api/2/search/jql", {
         "jql": jql,
         "maxResults": limit,
-        "fields": "summary,status,labels,assignee,priority,description,comment,issuelinks,issuetype",
-    })
-    data = http_get(f"{url}/rest/api/2/search?{encoded}", headers=headers, timeout=20)
+        "fields": fields,
+    }, headers=headers, timeout=20)
     if not data:
         print("ERR: Jira search returned no data", file=sys.stderr)
         return []

--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Fetch new Jira work candidates. Runs after triage when no outstanding work.
+
+Queries current sprint (and optionally backlog) for unassigned tickets
+matching BOT_LABEL, ordered by priority. Checks repo: labels against
+project-repos.json. Outputs full context for each candidate.
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+PROJECT_REPOS = Path(__file__).resolve().parent.parent.parent.parent / "project-repos.json"
+JIRA_CREDS = Path.home() / ".jira-credentials"
+BOT_LABEL = os.environ.get("BOT_LABEL", "")
+BOT_BOARD_ID = os.environ.get("BOT_BOARD_ID", "")
+BOT_BOARD_NAME = os.environ.get("BOT_BOARD_NAME", "")
+BOT_INCLUDE_BACKLOG = os.environ.get("BOT_INCLUDE_BACKLOG", "").lower() in ("1", "true", "yes")
+NOT_STARTED_STATUSES = ("New", "Backlog", "Refinement", "To Do")
+
+
+def http_get(url, headers=None, timeout=10):
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        print(f"ERR GET {url}: {e}", file=sys.stderr)
+        return None
+
+
+def jira_auth():
+    if not JIRA_CREDS.exists():
+        print(f"WARN: {JIRA_CREDS} not found", file=sys.stderr)
+        return None, None
+    try:
+        creds = json.loads(JIRA_CREDS.read_text())
+    except Exception as e:
+        print(f"ERR reading {JIRA_CREDS}: {e}", file=sys.stderr)
+        return None, None
+    url = creds.get("url", "").rstrip("/")
+    user, token = creds.get("username", ""), creds.get("token", "")
+    if not all([url, user, token]):
+        print("ERR: incomplete Jira credentials", file=sys.stderr)
+        return None, None
+    auth = base64.b64encode(f"{user}:{token}".encode()).decode()
+    return url, {"Authorization": f"Basic {auth}", "Accept": "application/json"}
+
+
+def jira_search(jql, limit=10):
+    url, headers = jira_auth()
+    if not url:
+        return []
+    encoded = urllib.parse.urlencode({
+        "jql": jql,
+        "maxResults": limit,
+        "fields": "summary,status,labels,assignee,priority,description,comment,issuelinks,issuetype",
+    })
+    data = http_get(f"{url}/rest/api/2/search?{encoded}", headers=headers, timeout=20)
+    if not data:
+        print("ERR: Jira search returned no data", file=sys.stderr)
+        return []
+    return data.get("issues", [])
+
+
+def resolve_board_id():
+    if BOT_BOARD_ID:
+        return BOT_BOARD_ID
+    if not BOT_BOARD_NAME:
+        print("WARN: neither BOT_BOARD_ID nor BOT_BOARD_NAME set, skipping sprint query", file=sys.stderr)
+        return None
+    url, headers = jira_auth()
+    if not url:
+        return None
+    encoded = urllib.parse.urlencode({"name": BOT_BOARD_NAME})
+    data = http_get(f"{url}/rest/agile/1.0/board?{encoded}", headers=headers, timeout=15)
+    boards = data.get("values", []) if data else []
+    if not boards:
+        print(f"ERR: no board found matching name '{BOT_BOARD_NAME}'", file=sys.stderr)
+        return None
+    board = boards[0]
+    print(f"Resolved board: {board.get('name', '?')} (id={board['id']})", file=sys.stderr)
+    return str(board["id"])
+
+
+def get_active_sprint():
+    board_id = resolve_board_id()
+    if not board_id:
+        return None
+    url, headers = jira_auth()
+    if not url:
+        return None
+    data = http_get(
+        f"{url}/rest/agile/1.0/board/{board_id}/sprint?state=active",
+        headers=headers, timeout=15)
+    sprints = data.get("values", []) if data else []
+    if sprints:
+        print(f"Active sprint: {sprints[0].get('name', '?')} (id={sprints[0]['id']})", file=sys.stderr)
+    return sprints[0] if sprints else None
+
+
+def get_known_repos():
+    try:
+        return set(json.loads(PROJECT_REPOS.read_text()).keys())
+    except Exception as e:
+        print(f"ERR reading {PROJECT_REPOS}: {e}", file=sys.stderr)
+        return set()
+
+
+def match_repo_labels(labels, known_repos):
+    repo_labels = [l.replace("repo:", "") for l in labels if l.startswith("repo:")]
+    if not repo_labels:
+        return []
+    matched = [r for r in repo_labels if r in known_repos]
+    return matched if len(matched) == len(repo_labels) else []
+
+
+def get_candidates():
+    if not BOT_LABEL:
+        print("ERR: BOT_LABEL not set", file=sys.stderr)
+        return []
+    known = get_known_repos()
+    status_list = ", ".join(f'"{s}"' for s in NOT_STARTED_STATUSES)
+    candidates = []
+
+    sprint = get_active_sprint()
+    if sprint:
+        jql = (
+            f"project = RHCLOUD AND labels = {BOT_LABEL} "
+            f"AND assignee is EMPTY AND status IN ({status_list}) "
+            f"AND sprint = {sprint['id']} "
+            f"ORDER BY priority DESC, created ASC"
+        )
+        candidates.extend(jira_search(jql, limit=10))
+
+    if len(candidates) < 10 and BOT_INCLUDE_BACKLOG:
+        existing_keys = {c["key"] for c in candidates}
+        jql = (
+            f"project = RHCLOUD AND labels = {BOT_LABEL} "
+            f"AND assignee is EMPTY AND status IN ({status_list}) "
+            f"AND sprint is EMPTY "
+            f"ORDER BY priority DESC, created ASC"
+        )
+        for c in jira_search(jql, limit=10):
+            if c["key"] not in existing_keys:
+                candidates.append(c)
+                if len(candidates) >= 10:
+                    break
+
+    results = []
+    for issue in candidates:
+        fields = issue.get("fields", {})
+        labels = fields.get("labels", [])
+        repos = match_repo_labels(labels, known)
+        comments = (fields.get("comment", {}).get("comments") or [])[-5:]
+
+        results.append({
+            "key": issue["key"],
+            "summary": fields.get("summary", ""),
+            "status": fields.get("status", {}).get("name", "?"),
+            "priority": fields.get("priority", {}).get("name", "?"),
+            "type": fields.get("issuetype", {}).get("name", "?"),
+            "labels": labels,
+            "repos": repos,
+            "description": fields.get("description") or "",
+            "comments": comments,
+            "links": fields.get("issuelinks", []),
+        })
+    return results
+
+
+def fmt_candidate(c):
+    lines = [f"{c['key']} [{c['status']}] priority={c['priority']} type={c['type']}"]
+    lines.append(f"  title: {c['summary']}")
+    if c["repos"]:
+        lines.append(f"  repos: {','.join(c['repos'])}")
+    else:
+        repo_labels = [l for l in c["labels"] if l.startswith("repo:")]
+        if repo_labels:
+            lines.append(f"  repo_labels: {','.join(repo_labels)} (NO MATCH in project-repos.json)")
+        else:
+            lines.append("  repos: (no repo: label)")
+    other_labels = [l for l in c["labels"] if not l.startswith("repo:") and l != BOT_LABEL]
+    if other_labels:
+        lines.append(f"  labels: {','.join(other_labels)}")
+    for lk in c["links"][:5]:
+        lt = lk.get("type", {}).get("name", "?")
+        linked = lk.get("inwardIssue") or lk.get("outwardIssue", {})
+        if linked:
+            lk_status = linked.get("fields", {}).get("status", {}).get("name", "?")
+            lines.append(f"  link: {lt} {linked.get('key','?')} [{lk_status}]")
+    if c["description"]:
+        lines.append("  description:")
+        for dl in c["description"].strip().split("\n"):
+            lines.append(f"    {dl}")
+    if c["comments"]:
+        lines.append(f"  comments ({len(c['comments'])}):")
+        for cm in c["comments"]:
+            author = cm.get("author", {}).get("displayName", "?")
+            t = cm.get("created", "")[:16]
+            body = cm.get("body", "")
+            lines.append(f"    [{t}] {author}:")
+            for bl in body.strip().split("\n"):
+                lines.append(f"      {bl}")
+    return "\n".join(lines)
+
+
+def main():
+    candidates = get_candidates()
+    if not candidates:
+        print("NO CANDIDATES FOUND")
+        return
+
+    print(f"NEW WORK CANDIDATES ({len(candidates)})")
+    print()
+    for c in candidates:
+        print(fmt_candidate(c))
+        print()
+
+    with_repos = [c for c in candidates if c["repos"]]
+    without_repos = [c for c in candidates if not c["repos"]]
+    print(f"-> {len(with_repos)} with matching repos, {len(without_repos)} without")
+    if with_repos:
+        print(f"-> Top pick: {with_repos[0]['key']} repos={','.join(with_repos[0]['repos'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,6 @@ GH_USERNAME=your-github-username
 GL_USER_NAME=your-gitlab-username
 GL_USER_EMAIL=your-gitlab-email
 GL_USERNAME=your-gitlab-username
+
+BOT_BOARD_NAME=Your-Jira-board-name
+BOT_INCLUDE_BACKLOG=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,14 +241,9 @@ Only if ALL tasks clean — no pending feedback, no interrupted work, no unfinis
 
 **Check capacity**: `task_check_capacity`. No capacity → only investigation tickets (`needs-investigation`). At limit for impl tickets.
 
-**Discover statuses first**: On first cycle (or periodically), `jira_get_transitions` on any RHCLOUD ticket → learn available statuses. Pick only "not started" statuses (e.g. New, Backlog, Refinement — NOT In Progress, Code Review, Done, etc.). Cache via `memory_store` tag `jira-statuses`. Refresh weekly.
+Invoke `/new-work` skill. It pre-fetches unassigned candidates from current sprint (+ backlog if `BOT_INCLUDE_BACKLOG=true`), ordered by priority, with full context (description, comments, links) and `repo:` label matching against `project-repos.json`.
 
-JQL (`limit=10`, paginate w/ `page_token`):
-```
-project = RHCLOUD AND labels = PRIMARY_LABEL AND assignee is EMPTY AND status IN (<not-started-statuses>) ORDER BY priority DESC, created ASC
-```
-
-Scan page for ticket w/ `repo:` label matching `project-repos.json`. Multiple `repo:` labels OK if all match. At capacity → only `needs-investigation`. No match → next page (`page_token`, NOT `start_at`). All pages exhausted → memory housekeeping → "NO_WORK_FOUND" → stop.
+Pick the first candidate with matching `repos:` field. At capacity → only `needs-investigation`. No match in output → memory housekeeping → "NO_WORK_FOUND" → stop.
 
 **`[FIRING]` / ALERT tickets ARE real work.** `ALERT{hash}` labels + `[FIRING]` prefixes = automated alerts for issues that need fixing (e.g. RDSEOL = RDS end-of-life upgrades). These are NOT monitoring noise to skip. Treat like any other ticket — check `repo:` label, match persona, implement. Priority often higher than regular tickets because they signal something broken or expiring.
 


### PR DESCRIPTION
## Summary

- Adds standalone `/new-work` skill that pre-fetches unassigned Jira ticket candidates when triage shows no outstanding work
- Queries current sprint first (via board name resolution), then backlog (opt-in via `BOT_INCLUDE_BACKLOG`), filtered by `BOT_LABEL`, ordered by priority DESC, limited to 10
- Includes full context per candidate: description, last 5 comments, issue links, and `repo:` label matching against `project-repos.json`
- Updates CLAUDE.md Priority 2 section to reference the skill instead of manual JQL instructions

## Env vars

| Var | Purpose |
|-----|---------|
| `BOT_LABEL` | Primary label filter (existing) |
| `BOT_BOARD_NAME` | Board name (e.g. "RHCLOUD") — resolved to ID via Jira Agile API |
| `BOT_BOARD_ID` | Direct board ID (fallback, optional) |
| `BOT_INCLUDE_BACKLOG` | `true` to also scan backlog tickets not in any sprint |

## Test plan

- [ ] Set `BOT_LABEL`, `BOT_BOARD_NAME` env vars
- [ ] Run `python3 .claude/skills/new-work/new_work.py 2>&1` — verify candidates listed
- [ ] Verify sprint-first ordering, backlog fill when enabled
- [ ] Verify `repo:` label matching against `project-repos.json`
- [ ] Verify stderr logging for auth/API errors

RHCLOUD-47260

🤖 Generated with [Claude Code](https://claude.com/claude-code)