### PR TITLE
feat(skills): add /wrap-up skill for post-merge bookkeeping

### DIFF
--- a/.claude/skills/wrap-up/SKILL.md
+++ b/.claude/skills/wrap-up/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: wrap-up
+description: >
+  Post-merge bookkeeping for completed PRs. Archives task, transitions Jira to
+  "Release Pending", posts Jira comment, sends Slack notification, deletes bot
+  branches (remote + local). Handles already-deleted branches gracefully.
+when_to_use: >
+  Invoke when triage shows a PR in MERGED state. Triggers on: "merged",
+  "wrap up", "wrap-up", "archive", "release pending", "PR merged".
+  Replaces manual task_update + jira_transition + jira_comment + slack_notify
+  + branch deletion calls.
+user-invocable: true
+allowed-tools:
+  - "Bash(python3 .claude/skills/wrap-up/wrap_up.py *)"
+  - Read
+  - mcp__bot-memory__memory_store
+---
+
+Run the wrap-up script for a merged PR:
+
+```bash
+python3 .claude/skills/wrap-up/wrap_up.py <JIRA_KEY> 2>&1
+```
+
+Use `--dry-run` to preview without making changes:
+
+```bash
+python3 .claude/skills/wrap-up/wrap_up.py <JIRA_KEY> --dry-run 2>&1
+```
+
+The script handles:
+1. Jira transition → "Release Pending"
+2. Jira comment with PR links
+3. Task archival in memory server
+4. Slack notification (`release_pending`)
+5. Remote branch deletion (tolerates already-deleted branches)
+6. Local branch deletion (tolerates missing repos/branches)
+
+After the script completes, use `memory_store` to save any notable learnings
+from the implementation (category: `learning` or `codebase_pattern`).

--- a/.claude/skills/wrap-up/wrap_up.py
+++ b/.claude/skills/wrap-up/wrap_up.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Post-merge wrap-up: archive task, transition Jira, notify Slack, delete branches.
+
+Usage: python3 .claude/skills/wrap-up/wrap_up.py <JIRA_KEY> [--dry-run]
+"""
+
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+MEMORY_URL = os.environ.get("BOT_MEMORY_URL", "http://localhost:8080").rstrip("/mcp").rstrip("/")
+PROJECT_REPOS = Path(__file__).resolve().parent.parent.parent.parent / "project-repos.json"
+JIRA_CREDS = Path.home() / ".jira-credentials"
+REPOS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "repos"
+
+
+def http_request(url, method="GET", body=None, headers=None, timeout=15):
+    hdrs = dict(headers or {})
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        hdrs["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else ""
+        print(f"  ERR {method} {url}: {e.code} {body_text[:200]}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"  ERR {method} {url}: {e}", file=sys.stderr)
+        return None
+
+
+def jira_auth():
+    if not JIRA_CREDS.exists():
+        return None, None
+    try:
+        creds = json.loads(JIRA_CREDS.read_text())
+    except Exception:
+        return None, None
+    url = creds.get("url", "").rstrip("/")
+    user, token = creds.get("username", ""), creds.get("token", "")
+    if not all([url, user, token]):
+        return None, None
+    auth = base64.b64encode(f"{user}:{token}".encode()).decode()
+    return url, {"Authorization": f"Basic {auth}", "Accept": "application/json"}
+
+
+def get_task(jira_key):
+    data = http_request(f"{MEMORY_URL}/api/tasks?exclude_status=archived&limit=50")
+    if not data or "items" not in data:
+        return None
+    for t in data["items"]:
+        if t.get("jira_key") == jira_key:
+            return t
+    return None
+
+
+def parse_repo_path(url):
+    if not url:
+        return ""
+    parsed = urllib.parse.urlparse(url if "://" in url else f"https://{url}")
+    path = parsed.path.lstrip("/").replace(".git", "")
+    return path
+
+
+def get_upstream_info(repo_name):
+    try:
+        repos = json.loads(PROJECT_REPOS.read_text())
+        entry = repos.get(repo_name, {})
+        upstream = entry.get("upstream", "")
+        host = entry.get("host", "github")
+        parsed = urllib.parse.urlparse(upstream if "://" in upstream else f"https://{upstream}")
+        hostname = parsed.hostname or ""
+        if "gitlab" in hostname:
+            host = "gitlab"
+        return parse_repo_path(upstream), host
+    except Exception:
+        return "", "github"
+
+
+def jira_transition_release_pending(jira_key):
+    url, headers = jira_auth()
+    if not url:
+        return False, "no Jira credentials"
+    transitions = http_request(f"{url}/rest/api/2/issue/{jira_key}/transitions", headers=headers)
+    if not transitions:
+        return False, "failed to get transitions"
+    target = None
+    for t in transitions.get("transitions", []):
+        name = t.get("name", "").lower()
+        if "release pending" in name:
+            target = t
+            break
+    if not target:
+        avail = [t.get("name") for t in transitions.get("transitions", [])]
+        return False, f"'Release Pending' not available. Available: {avail}"
+    result = http_request(
+        f"{url}/rest/api/2/issue/{jira_key}/transitions",
+        method="POST",
+        body={"transition": {"id": target["id"]}},
+        headers=headers,
+    )
+    if result is None:
+        return False, "transition POST failed"
+    return True, target["name"]
+
+
+def jira_comment(jira_key, pr_info):
+    url, headers = jira_auth()
+    if not url:
+        return False
+    pr_lines = []
+    for p in pr_info:
+        repo = p.get("repo", "?")
+        num = p.get("number", "?")
+        pr_url = p.get("url", "")
+        host = p.get("host", "github")
+        if pr_url:
+            pr_lines.append(f"- [{repo}#{num}]({pr_url})")
+        else:
+            pr_lines.append(f"- {repo}#{num} ({host})")
+
+    body = (
+        f"### PR Merged — Release Pending\n\n"
+        f"{''.join(pr_lines) if pr_lines else '(no PR info)'}\n\n"
+        f"Changes will be deployed to stage with the next release."
+    )
+    result = http_request(
+        f"{url}/rest/api/2/issue/{jira_key}/comment",
+        method="POST",
+        body={"body": body},
+        headers=headers,
+    )
+    return result is not None
+
+
+def archive_task(jira_key, summary):
+    result = http_request(
+        f"{MEMORY_URL}/api/tasks/{jira_key}",
+        method="DELETE",
+    )
+    return result is not None
+
+
+def slack_notify(jira_key, pr_info):
+    pr_links = []
+    for p in pr_info:
+        pr_url = p.get("url", "")
+        repo = p.get("repo", "?")
+        num = p.get("number", "?")
+        if pr_url:
+            pr_links.append(f"<{pr_url}|{repo}#{num}>")
+        else:
+            pr_links.append(f"{repo}#{num}")
+    msg = f"{jira_key} merged → Release Pending. PR: {', '.join(pr_links) if pr_links else '(unknown)'}"
+    result = http_request(
+        f"{MEMORY_URL}/mcp",
+        method="POST",
+        body={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "slack_notify",
+                "arguments": {
+                    "jira_key": jira_key,
+                    "event_type": "release_pending",
+                    "message": msg,
+                },
+            },
+        },
+    )
+    if result and "result" in result:
+        return True, result["result"]
+    return False, str(result)
+
+
+def delete_remote_branch(repo_name, branch, host, upstream_path):
+    if not branch:
+        return True, "no branch to delete"
+    if host == "gitlab":
+        encoded_branch = urllib.parse.quote(branch, safe="")
+        encoded_project = urllib.parse.quote(upstream_path, safe="")
+        try:
+            r = subprocess.run(
+                ["glab", "api", f"projects/{encoded_project}/repository/branches/{encoded_branch}",
+                 "-X", "DELETE", "--hostname", "gitlab.cee.redhat.com"],
+                capture_output=True, text=True, timeout=15,
+            )
+            out = r.stderr.strip() or r.stdout.strip()
+            if r.returncode == 0:
+                return True, "deleted"
+            if "404" in out or "not found" in out.lower():
+                return True, "already gone (auto-deleted on merge)"
+            return False, out
+        except Exception as e:
+            return False, str(e)
+    else:
+        ref = f"heads/{branch}"
+        targets = [f"repos/{upstream_path}/git/refs/{ref}"]
+        fork_path = parse_repo_path(
+            json.loads(PROJECT_REPOS.read_text()).get(repo_name, {}).get("url", "")
+        )
+        if fork_path and fork_path != upstream_path:
+            targets.append(f"repos/{fork_path}/git/refs/{ref}")
+        results = []
+        for target in targets:
+            try:
+                r = subprocess.run(
+                    ["gh", "api", target, "-X", "DELETE"],
+                    capture_output=True, text=True, timeout=15,
+                )
+                out = r.stderr.strip() or r.stdout.strip()
+                if r.returncode == 0:
+                    results.append(f"{target.split('/')[1]}: deleted")
+                elif "Not Found" in out or "Reference does not exist" in out:
+                    results.append(f"{target.split('/')[1]}: already gone")
+                else:
+                    results.append(f"{target.split('/')[1]}: {out[:100]}")
+            except Exception as e:
+                results.append(f"{target.split('/')[1]}: {e}")
+        return True, "; ".join(results)
+
+
+def delete_local_branch(repo_name, branch):
+    repo_dir = REPOS_DIR / repo_name
+    if not repo_dir.exists():
+        return True, "repo dir not cloned locally"
+    try:
+        r = subprocess.run(
+            ["git", "branch", "-D", branch],
+            capture_output=True, text=True, timeout=10,
+            cwd=str(repo_dir),
+        )
+        out = r.stderr.strip() or r.stdout.strip()
+        if r.returncode == 0:
+            return True, "deleted"
+        if "not found" in out.lower() or "error: branch" in out.lower():
+            return True, "already gone"
+        return False, out
+    except Exception as e:
+        return False, str(e)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: wrap_up.py <JIRA_KEY> [--dry-run]")
+        sys.exit(1)
+
+    jira_key = sys.argv[1]
+    dry_run = "--dry-run" in sys.argv
+
+    if dry_run:
+        print(f"[DRY RUN] wrap-up for {jira_key}")
+
+    task = get_task(jira_key)
+    if not task:
+        print(f"ERR: task {jira_key} not found in memory server")
+        sys.exit(1)
+
+    repo = task.get("repo", "")
+    branch = task.get("branch", "")
+    meta = task.get("metadata") or {}
+    pr_info = meta.get("prs", [])
+
+    if not pr_info and task.get("pr_number"):
+        _, host = get_upstream_info(repo)
+        pr_info = [{"repo": repo, "number": task["pr_number"], "url": task.get("pr_url", ""), "host": host}]
+
+    print(f"WRAP-UP {jira_key}")
+    print(f"  repo: {repo}")
+    print(f"  branch: {branch}")
+    print(f"  PRs: {json.dumps(pr_info)}")
+    print()
+
+    # 1. Transition Jira to "Release Pending"
+    print("1. Jira transition → Release Pending")
+    if dry_run:
+        print("  [skip]")
+    else:
+        ok, detail = jira_transition_release_pending(jira_key)
+        print(f"  {'OK' if ok else 'FAIL'}: {detail}")
+
+    # 2. Post Jira comment
+    print("2. Jira comment")
+    if dry_run:
+        print("  [skip]")
+    else:
+        ok = jira_comment(jira_key, pr_info)
+        print(f"  {'OK' if ok else 'FAIL'}")
+
+    # 3. Archive task
+    print("3. Archive task")
+    if dry_run:
+        print("  [skip]")
+    else:
+        ok = archive_task(jira_key, task.get("summary", ""))
+        print(f"  {'OK' if ok else 'FAIL'}")
+
+    # 4. Slack notification
+    print("4. Slack notify (release_pending)")
+    if dry_run:
+        print("  [skip]")
+    else:
+        ok, detail = slack_notify(jira_key, pr_info)
+        print(f"  {'OK' if ok else 'FAIL'}: {detail}")
+
+    # 5. Delete remote branch
+    all_repos = set()
+    if repo:
+        all_repos.add(repo)
+    for r in meta.get("repos", []):
+        all_repos.add(r)
+
+    print("5. Delete remote branch(es)")
+    for r in all_repos:
+        upstream_path, host = get_upstream_info(r)
+        if not upstream_path:
+            print(f"  {r}: no upstream path, skip")
+            continue
+        if dry_run:
+            print(f"  {r} ({host}): {upstream_path}/refs/heads/{branch} [skip]")
+        else:
+            ok, detail = delete_remote_branch(r, branch, host, upstream_path)
+            print(f"  {r}: {'OK' if ok else 'FAIL'} {detail}")
+
+    # 6. Delete local branch
+    print("6. Delete local branch(es)")
+    for r in all_repos:
+        if dry_run:
+            print(f"  {r}: git branch -D {branch} [skip]")
+        else:
+            ok, detail = delete_local_branch(r, branch)
+            print(f"  {r}: {'OK' if ok else 'FAIL'} {detail}")
+
+    print()
+    print(f"DONE — {jira_key} wrapped up")
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,14 +213,9 @@ PR statuses are in the triage output. For each `pr_open`/`pr_changes` task:
 - Context/requirements → incorporate
 - `task_update` `last_addressed`
 
-**PR merged**:
-- `task_update` status `archived`, `summary` w/ outcome
-- `jira_transition_issue` → "Release Pending" (NOT "Done" — merge = stage only)
-- Jira comment noting merge + stage deploy
+**PR merged**: Invoke `/wrap-up` with the Jira key. The script handles: task archival, Jira transition → "Release Pending", Jira comment, Slack notification, remote + local branch deletion (tolerates already-deleted branches). After wrap-up completes:
 - **Update linked issues**: duplicates → comment fix merged. Related → link PR. Blocked → blocker resolved.
-- **Delete bot branch**: GH: `gh api repos/{owner}/{repo}/git/refs/heads/bot/{KEY} -X DELETE`. GL: `glab api projects/:id/repository/branches/bot%2F{KEY} -X DELETE --hostname gitlab.cee.redhat.com`. Local: `git branch -D bot/{KEY}`.
 - **Store learnings**: `memory_store` as `learning` + `codebase_pattern`. Set `repo` + `tags`.
-- `slack_notify` `release_pending`: "{KEY} merged → Release Pending. PR: {url}"
 
 **Unresolvable**: Jira comment explaining blocker. `task_update` `paused_reason`. `slack_notify` `needs_help`: "{KEY} blocked — {reason}". Task stays tracked.
 
@@ -229,7 +224,7 @@ Handle one PR issue → stop. Next cycle picks up next.
 ### Priority 1.5: Check Assigned Tickets
 
 Triage output covers task statuses, PR states, and Jira comments. Use it to identify:
-1. **Merged PRs?** If triage shows `state=MERGED` → transition "Release Pending", Jira comment, `task_update` archived, `memory_store`.
+1. **Merged PRs?** If triage shows `state=MERGED` → invoke `/wrap-up <KEY>`. Then `memory_store` learnings.
 2. **New Jira comments?** Visible in triage output. Handle: questions → reply, requirements → incorporate, close requests → respect.
 3. PR still open, no comments → skip (Priority 1 handles).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,8 +355,10 @@ Before starting work, `jira_get_issue` → check issue links:
     GH direct: `gh pr create --title "..." --body "..."`
     Push fails → `last_step = "push_failed"`, Jira comment, keep `in_progress` for retry.
 
-    GL fork: `glab mr create --repo <upstream-path> --hostname gitlab.cee.redhat.com --title "..." --description "..."`
-    GL direct: `glab mr create --hostname gitlab.cee.redhat.com --title "..." --description "..."`
+    GL fork: `glab mr create --repo <upstream-path> --hostname gitlab.cee.redhat.com --title "..." --description "$(cat <<'EOF' ... EOF)"`
+    GL direct: `glab mr create --hostname gitlab.cee.redhat.com --title "..." --description "$(cat <<'EOF' ... EOF)"`
+
+    **CRITICAL**: glab URL-encodes newlines if description is passed inline. ALWAYS use heredoc `$(cat <<'EOF' ... EOF)` for multiline descriptions. Same pattern as `gh pr create --body`.
 
     Title ≤50 chars. Body = ticket key + changes summary.
     Readonly repos: include config changes in Jira comment.


### PR DESCRIPTION
## Summary

Adds a `/wrap-up` skill that handles all post-merge bookkeeping in a single script call, replacing ~8 individual tool calls per merged PR cycle.

### What the script does
1. Gets task from memory server
2. Transitions Jira to "Release Pending"
3. Posts merge confirmation comment on Jira
4. Archives task in memory server
5. Sends Slack notification (`release_pending`)
6. Deletes remote bot branches (GH via `gh api`, GL via `glab api`)
7. Deletes local bot branches

### Edge cases handled
- Remote branch already auto-deleted on merge → logged as "already gone", no error
- Local branch not found → logged as "already gone", no error
- Repo not cloned locally → logged as "repo dir not cloned locally", no error
- Fork repos → tries both upstream and fork remote branch deletion

### CLAUDE.md updates
- "PR merged" section now says "Invoke `/wrap-up`" instead of listing 7 manual steps
- Priority 1.5 merged PR handling also references `/wrap-up`

### Usage
```bash
python3 .claude/skills/wrap-up/wrap_up.py RHCLOUD-12345 2>&1
python3 .claude/skills/wrap-up/wrap_up.py RHCLOUD-12345 --dry-run 2>&1
```

Closes RHCLOUD-47285

## Test plan
- [ ] `python3 .claude/skills/wrap-up/wrap_up.py TEST-123 --dry-run` exits cleanly (task not found = expected)
- [ ] With memory server running: create a test task, run wrap-up, verify all steps complete
- [ ] Verify branch deletion tolerates 404 (already-deleted branches)
- [ ] Verify skill appears in `/` autocomplete as `wrap-up`