### PR TITLE
fix(bot): between-cycle disk cleanup

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -5,7 +5,9 @@ import argparse
 import asyncio
 import logging
 import os
+import shutil
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -96,6 +98,56 @@ def setup_logging() -> None:
         datefmt=datefmt,
         handlers=handlers,
     )
+
+
+LOW_DISK_THRESHOLD_MB = 512
+
+
+def cleanup_between_cycles(script_dir: Path) -> None:
+    """Free disk space between cycles if below threshold."""
+    logger = logging.getLogger(__name__)
+
+    try:
+        usage = shutil.disk_usage(str(script_dir))
+        free_mb = usage.free // (1024 * 1024)
+    except OSError:
+        return
+
+    if free_mb >= LOW_DISK_THRESHOLD_MB:
+        logger.info("Disk OK: %dM free (threshold %dM)", free_mb, LOW_DISK_THRESHOLD_MB)
+        return
+
+    logger.warning("Low disk: %dM free (threshold %dM) — cleaning up", free_mb, LOW_DISK_THRESHOLD_MB)
+
+    for name, cmd in [
+        ("Go build cache", ["go", "clean", "-cache"]),
+        ("Go mod cache", ["go", "clean", "-modcache"]),
+        ("npm cache", ["npm", "cache", "clean", "--force"]),
+    ]:
+        try:
+            subprocess.run(cmd, capture_output=True, timeout=30)
+            logger.info("Cleaned %s", name)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    repos_dir = script_dir / "repos"
+    if repos_dir.exists():
+        for repo in repos_dir.iterdir():
+            if (repo / ".git").is_dir():
+                try:
+                    subprocess.run(
+                        ["git", "gc", "--auto", "--quiet"],
+                        cwd=str(repo), capture_output=True, timeout=60,
+                    )
+                except (subprocess.TimeoutExpired, FileNotFoundError):
+                    pass
+
+    try:
+        usage = shutil.disk_usage(str(script_dir))
+        free_mb = usage.free // (1024 * 1024)
+        logger.info("Cleanup done. Free space: %dM", free_mb)
+    except OSError:
+        pass
 
 
 def main() -> None:
@@ -195,6 +247,8 @@ def main() -> None:
             else:
                 no_work = False
                 logger.warning("Cycle produced no result")
+
+            cleanup_between_cycles(SCRIPT_DIR)
 
             if no_work:
                 logger.info(

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -371,6 +371,8 @@ objects:
             requests:
               cpu: "1"
               memory: 2Gi
+              ephemeral-storage: 4Gi
             limits:
               cpu: "4"
               memory: 4Gi
+              ephemeral-storage: 8Gi


### PR DESCRIPTION
## Summary

- Adds `cleanup_between_cycles()` to `bot/run.py` — runs after each cycle, only triggers when free disk drops below 512M
- Cleans Go build cache, Go mod cache, npm cache, and runs `git gc --auto` on cloned repos
- Adds `ephemeral-storage` resource requests (4Gi) and limits (8Gi) to bot pod in k8s template

Fixes: [RHCLOUD-47288](https://redhat.atlassian.net/browse/RHCLOUD-47288)

## Test plan

- [ ] Bot runs normally when disk is healthy (logs "Disk OK", skips cleanup)
- [ ] Cleanup triggers when free space drops below 512M
- [ ] `go clean`, `npm cache clean`, `git gc` commands tolerate missing binaries (FileNotFoundError caught)
- [ ] k8s template validates with ephemeral-storage fields

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

[RHCLOUD-47288]: https://redhat.atlassian.net/browse/RHCLOUD-47288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ