### PR TITLE
fix(triage): surface review bodies and classify bot reviews as feedback

### DIFF
--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -297,6 +297,27 @@ def fmt_task(e):
     return "\n".join(lines)
 
 
+def _is_bot_author(author):
+    if not author or author == "?":
+        return False
+    a = author.lower()
+    return "[bot]" in a or a.endswith("-bot") or a in (
+        "github-actions", "dependabot", "renovate",
+    )
+
+
+def has_new_pr_feedback(e):
+    last_addr = e["task"].get("last_addressed", "")
+    for c in e["pr_comments"]:
+        author = c.get("a", "?")
+        if _is_bot_author(author):
+            continue
+        ct = c.get("t", "")[:16]
+        if not last_addr or ct > last_addr[:16]:
+            return True
+    return False
+
+
 def has_new_jira_feedback(e):
     last_addr = e["task"].get("last_addressed", "")
     for c in e["jira_comments"]:
@@ -346,6 +367,8 @@ def main():
             feedback.append(e)
         elif t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs"):
             interrupted.append(e)
+        elif has_new_pr_feedback(e):
+            feedback.append(e)
         elif has_new_jira_feedback(e):
             feedback.append(e)
         else:

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -177,8 +177,12 @@ def classify_gh(pr):
     if pr.get("reviewDecision") == "CHANGES_REQUESTED":
         issues.append("changes_requested")
     for r in (pr.get("reviews") or []):
-        if r.get("state") == "CHANGES_REQUESTED":
-            issues.append(f"review:{r.get('author', {}).get('login', '?')}")
+        rstate = r.get("state", "")
+        author = r.get("author", {}).get("login", "?")
+        if rstate == "CHANGES_REQUESTED":
+            issues.append(f"review:{author}")
+        elif rstate == "COMMENTED" and len((r.get("body") or "").strip()) > 20:
+            issues.append(f"review_comment:{author}")
     return state, issues
 
 
@@ -225,6 +229,14 @@ def enrich(task):
                 pr_results.append({"repo": pr_repo, "num": pr_num, "host": host, "state": state, "issues": issues, "data": data})
                 all_issues.extend(issues)
                 pr_comments.extend(gh_pr_comments(up, pr_num))
+                for rv in (data.get("reviews") or []):
+                    body = (rv.get("body") or "").strip()
+                    if body:
+                        pr_comments.append({
+                            "a": rv.get("author", {}).get("login", "?"),
+                            "t": rv.get("submittedAt", "")[:16],
+                            "b": f"[REVIEW {rv.get('state', '?')}] {body}",
+                        })
         elif host == "gitlab" and up:
             data = gl_mr(up, pr_num)
             if data:
@@ -330,7 +342,7 @@ def main():
             ci_fail.append(e)
         elif "conflict" in issues:
             conflict.append(e)
-        elif any(i in ("changes_requested", "unresolved_threads") or i.startswith("review:") for i in issues):
+        elif any(i in ("changes_requested", "unresolved_threads") or i.startswith("review:") or i.startswith("review_comment:") for i in issues):
             feedback.append(e)
         elif t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs"):
             interrupted.append(e)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ PR statuses are in the triage output. For each `pr_open`/`pr_changes` task:
 0. **Reload persona**: Read `personas/<name>/prompt.md` for repo tech stack (same logic as step 6). Has CI fix patterns + sequencing rules.
 1. `cd` repo dir. `git fetch origin`. Fork? Also `git fetch upstream`.
 2. Check `host` in `project-repos.json` → `gh` (GitHub) or `glab` (GitLab). **ALL `glab` commands MUST include `--hostname gitlab.cee.redhat.com`** — without it, glab defaults to `gitlab.com` which is blocked. Fork repos: `glab mr` needs `--repo <upstream-project-path>`.
-3. **Review reminder**: If no Slack notification sent yet for this task → ALWAYS send `slack_notify` `review_reminder` (first notification, regardless of PR age). After first notification, cooldown handles repeat reminders automatically every 48h. **Bot reviews don't count** — only human reviews matter. PR with only bot reviews = still needs human review → send reminder.
+3. **Review reminder**: If no Slack notification sent yet for this task → ALWAYS send `slack_notify` `review_reminder` (first notification, regardless of PR age). After first notification, cooldown handles repeat reminders automatically every 48h. **Bot reviews don't count for reminders** — only human reviews satisfy the "reviewed" condition. PR with only bot reviews = still needs human review → send reminder. **However, bot review feedback IS actionable** — address suggestions from coderabbitai, sourcery-ai, etc. as real code review feedback. Fix valid issues, dismiss false positives with a reply.
 
 4. Handle in order:
 


### PR DESCRIPTION
## Summary
- Review bodies from formal PR reviews (sourcery-ai, coderabbitai, etc.) were fetched by `gh_pr` but never displayed in triage output — only inline thread comments and issue-level comments were shown
- `COMMENTED` state reviews with actionable feedback were classified as CLEAN, causing the bot to skip valid code review suggestions entirely
- Clarifies in CLAUDE.md that "bot reviews don't count" applies only to Slack review reminders, not to addressing the feedback itself

## Changes
- **triage.py**: Inject review bodies into `pr_comments` with `[REVIEW STATE]` prefix so they appear in triage output
- **triage.py**: Flag `COMMENTED` reviews with >20 char bodies as `review_comment:{author}`, routing them to the FEEDBACK bucket
- **triage.py**: Update bucket classification to treat `review_comment:` as feedback alongside `review:` and `changes_requested`
- **CLAUDE.md**: Clarify that bot review feedback IS actionable — fix valid issues, dismiss false positives with a reply

## Test plan
- [ ] Run triage on a PR with only bot reviews (coderabbitai/sourcery-ai) — should appear in FEEDBACK bucket, not CLEAN
- [ ] Review bodies should be visible in triage output with `[REVIEW COMMENTED]` prefix
- [ ] PRs with no reviews should still classify as CLEAN
- [ ] `CHANGES_REQUESTED` reviews should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)