### PR TITLE
fix(deploy): fix broken startup probe

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -169,7 +169,7 @@ wait_for() {
     local name="$1" url="$2" timeout="${3:-120}"
     echo "Waiting for ${name} at ${url} (timeout=${timeout}s)..."
     local elapsed=0
-    until curl -sf "$url" > /dev/null 2>&1; do
+    until curl -sf --noproxy '*' "$url" > /dev/null 2>&1; do
         elapsed=$((elapsed + 2))
         if [ "$elapsed" -ge "$timeout" ]; then
             echo "FATAL: ${name} not ready after ${timeout}s" >&2


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                          
  - Fix proxy health check deadlock during bot startup. The wait_for function uses curl to check if services are ready, but the bot pod has HTTP_PROXY/HTTPS_PROXY env vars set. This caused curl to try routing the proxy health check through the proxy itself — which can't work because the proxy isn't up yet. The fix adds --noproxy '*' to the curl call so all startup health checks connect directly to the target service.                                                                                                                                        
                                                                                                                                                                                                                                                                                          
  Test plan       

  - Deploy to OpenShift and confirm bot logs show "Waiting for proxy..." → "proxy is ready." → "Waiting for memory-server..." → "memory-server is ready." before Chromium startup                                                                                                         
  - Verify bot completes a full cycle after startup