### PR TITLE
feat(deploy): expose memory server HTTP via openshift route

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -160,6 +160,24 @@ objects:
       protocol: TCP
       name: http
 
+# --- Memory Server Route (dashboard + health) ---
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: devbot-memory-server
+    labels:
+      app.kubernetes.io/name: memory-server
+      app.kubernetes.io/part-of: devbot
+  spec:
+    to:
+      kind: Service
+      name: devbot-memory-server
+    port:
+      targetPort: http
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+
 # --- Proxy Deployment (Squid + Executor server — holds all CLI secrets) ---
 - apiVersion: apps/v1
   kind: Deployment


### PR DESCRIPTION
### Description            

Add OpenShift Route for the devbot memory-server to expose the dashboard and health endpoint behind VPN. Uses edge TLS termination with the cluster's wildcard certificate — no cert-manager/letsencrypt needed. HTTP requests redirect to HTTPS via `insecureEdgeTerminationPolicy: Redirect`.   
                                                                                                                                                                                                                                                                                          
https://redhat.atlassian.net/browse/RHCLOUD-47029

  ---

  ### Blast radius                                                                                                                                                                                                                                                                        
   
  - **devbot-memory-server**: Now exposed via Route with edge TLS — previously only reachable within the cluster. Dashboard/health endpoints accessible to VPN users over HTTPS.                                                                                                                                   
  - **devbot-proxy**: No change to exposure
  - **devbot-bot**: No changes.                                                                                                                                                                                                                                                           
  - No downstream repos or consumers affected.                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                          
  ---                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                          
  ### Rollback plan    

  `git revert` is sufficient. The Route can be deleted manually from the cluster if needed (`oc delete route devbot-memory-server`).                                               
   
  ---                                                                                                                                                                                                                                                                                     
                       
  ### Checklist
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)                                                                                                                                                                                                          
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not `latest`                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                          
  ### AI disclosure                                                                                                                                                                                                                                                                       
  Assisted by: Claude Code (Opus) 