### PR TITLE
fix(docker): increase bot shm_size to 512m for Chrome

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
         GOVERSIONS: "1.24.2 1.25.7"
     security_opt:
       - no-new-privileges
+    shm_size: 512m
     mem_limit: 8g
     cpus: 4
     pids_limit: 500


### PR DESCRIPTION
## Summary

- Fix Chrome `ERR_INSUFFICIENT_RESOURCES` crash during visual verification
- Docker defaults `/dev/shm` to 64MB — Chrome needs more for SPA rendering
- Standard fix: `shm_size: 512m` on the bot service

Fixes RHCLOUD-47710

## Test plan

- [ ] `docker compose up -d bot` — verify `/dev/shm` is 512MB: `docker compose exec bot df -h /dev/shm`
- [ ] Bot visual verification cycle completes without Chrome resource errors