### PR TITLE
refactor(post-pr): replace API tokens with CLI tools and MCP

### DIFF
--- a/.claude/skills/post-pr/README.md
+++ b/.claude/skills/post-pr/README.md
@@ -80,7 +80,6 @@ result = execute_post_pr_workflow(
     ticket_id="RHCLOUD-456",
     summary="Add vector search caching",
     github_token=None,  # Falls back to GITHUB_TOKEN env var
-    jira_token=None,    # Falls back to POST_PR_JIRA_TOKEN env var
     slack_channel="#hcc-ai-assistant",
     reviewers=["user1", "user2"],
     skip_operations=[],
@@ -103,13 +102,12 @@ else:
 Set these environment variables for API integrations:
 
 ```bash
-# GitHub (required)
-export GITHUB_TOKEN=ghp_your_token_here  # Or GH_TOKEN
+# GitHub — uses `gh` CLI (already authenticated in container, no token needed)
+# GitLab — uses `glab` CLI (already authenticated in container, no token needed)
 
-# JIRA Cloud (required for JIRA operations)
-export POST_PR_JIRA_TOKEN=your_api_token_here
-export POST_PR_JIRA_EMAIL=your.email@redhat.com
-export POST_PR_JIRA_URL=https://redhat.atlassian.net  # Optional, this is the default
+# JIRA (via MCP — requires JIRA_MCP_URL to be set)
+export JIRA_MCP_URL=http://localhost:9090/mcp  # mcp-atlassian server URL
+export POST_PR_JIRA_URL=https://redhat.atlassian.net  # Optional, used for browse links only
 
 # Slack (required for Slack notifications)
 export POST_PR_SLACK_WEBHOOK=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
@@ -118,7 +116,7 @@ export POST_PR_SLACK_WEBHOOK=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 export POST_PR_MEMORY_STORE=/path/to/memory.json  # Default: /tmp/memory.json
 ```
 
-**Note:** Uses JIRA Cloud API v3 with Basic authentication (email + API token).
+**Note:** No API tokens needed. GitHub/GitLab operations use their respective CLIs (`gh`/`glab`), JIRA uses MCP via `jira_call`.
 
 ## Testing
 
@@ -188,20 +186,23 @@ Managed with **uv** for fast, reliable dependency resolution.
 
 ## API Integrations
 
-### GitHub REST API
-- **Authentication**: Bearer token (GITHUB_TOKEN or GH_TOKEN)
+### GitHub (via `gh` CLI)
+- **Authentication**: Handled by `gh` CLI (pre-authenticated)
 - **Operations**: Add labels, update PR description, request reviewers
-- **Endpoint**: `https://api.github.com`
+- **Commands**: `gh api repos/{owner}/{repo}/...`
 
-### JIRA Cloud API v3
-- **Authentication**: Basic (email:token)
-- **Transitions**: `GET/POST /rest/api/3/issue/{key}/transitions`
-- **Comments**: Atlassian Document Format (ADF)
-- **Endpoint**: `https://redhat.atlassian.net` (default)
-- **Note**: Requires API v3 (v2 returns empty transitions array)
+### GitLab (via `glab` CLI)
+- **Authentication**: Handled by `glab` CLI (pre-authenticated)
+- **Operations**: Add labels, update MR description, request reviewers
+- **Commands**: `glab api projects/{path}/merge_requests/{n}/... --hostname <host>`
+
+### JIRA (via MCP)
+- **Authentication**: Handled by mcp-atlassian server
+- **Operations**: Get transitions, transition issue, add comment
+- **Client**: `jira_call()` from shared `jira_mcp.py`
 
 ### Slack Webhooks
-- **Format**: Incoming webhook with attachment format
+- **Format**: Incoming webhook with attachment format (httpx)
 - **Fields**: PR number, link, summary
 - **Color coding**: "good" (green) for PR created events
 
@@ -209,23 +210,17 @@ Managed with **uv** for fast, reliable dependency resolution.
 
 ### Common Issues
 
-**Error: "GitHub token not configured"**
-- Set `GITHUB_TOKEN` or `GH_TOKEN` environment variable
-- Or pass `--github-token` parameter
+**Error: "Failed to add labels" / gh CLI errors**
+- Ensure `gh` CLI is installed and authenticated (`gh auth status`)
+- For GitLab, ensure `glab` is installed and authenticated
 
-**Error: "JIRA token not configured"**
-- Set `POST_PR_JIRA_TOKEN` and `POST_PR_JIRA_EMAIL` environment variables
+**Error: "Failed to get transitions from Jira MCP"**
+- Ensure `JIRA_MCP_URL` is set and the mcp-atlassian server is running
 - Or run with `--skip=jira` to skip JIRA operations
-- **Note**: Requires JIRA Cloud API v3 (redhat.atlassian.net)
 
 **Error: "Slack webhook not configured"**
 - Set `POST_PR_SLACK_WEBHOOK` environment variable
 - Or run with `--skip=slack` to skip Slack notifications
-
-**JIRA transitions return empty array**
-- Ensure using JIRA Cloud API v3 (not v2)
-- Check `POST_PR_JIRA_URL` is set to `https://redhat.atlassian.net`
-- Verify email and token are correct for Basic auth
 
 **Workflow stops partway through**
 - This is expected behavior (fail-fast)

--- a/.claude/skills/post-pr/README.md
+++ b/.claude/skills/post-pr/README.md
@@ -79,7 +79,6 @@ result = execute_post_pr_workflow(
     pr_number=123,
     ticket_id="RHCLOUD-456",
     summary="Add vector search caching",
-    github_token=None,  # Falls back to GITHUB_TOKEN env var
     slack_channel="#hcc-ai-assistant",
     reviewers=["user1", "user2"],
     skip_operations=[],

--- a/.claude/skills/post-pr/scripts/post_pr_operations.py
+++ b/.claude/skills/post-pr/scripts/post_pr_operations.py
@@ -119,13 +119,13 @@ class PostPROperations:
         parsed = urllib.parse.urlparse(pr_url)
         hostname = parsed.hostname or ""
 
-        if "github.com" in hostname:
+        if hostname == "github.com":
             parts = pr_url.rstrip("/").split("/")
             if len(parts) < 5:
                 raise ValueError(f"Invalid GitHub PR URL: {pr_url}")
             return {"host": "github", "owner": parts[-4], "repo": parts[-3]}
 
-        if "gitlab" in hostname:
+        if hostname == "gitlab.com" or hostname == "gitlab.cee.redhat.com":
             path_parts = parsed.path.split("/-/merge_requests/")
             if len(path_parts) != 2:
                 raise ValueError(f"Invalid GitLab MR URL: {pr_url}")

--- a/.claude/skills/post-pr/scripts/post_pr_operations.py
+++ b/.claude/skills/post-pr/scripts/post_pr_operations.py
@@ -14,11 +14,12 @@ Fully integrated with GitHub REST API, JIRA Cloud API v3, and Slack webhooks.
 """
 
 import argparse
-import base64
 import json
 import logging
 import os
+import subprocess
 import sys
+import urllib.parse
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
@@ -26,6 +27,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+from jira_mcp import jira_call
 
 logging.basicConfig(level=logging.INFO, format="[post-pr] %(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -87,167 +91,264 @@ class PostPROperations:
 
     def __init__(
         self,
-        github_token: str,
-        jira_url: str,
-        jira_token: str,
-        jira_email: str,
         slack_webhook: str,
         memory_store_path: str,
+        jira_url: str = "https://redhat.atlassian.net",
         dry_run: bool = False,
     ):
-        """Initialize with configuration.
-
-        Args:
-            github_token: GitHub API token
-            jira_url: JIRA instance URL (e.g., https://redhat.atlassian.net)
-            jira_token: JIRA API token
-            jira_email: Email for JIRA Basic auth
-            slack_webhook: Slack webhook URL
-            memory_store_path: Path to memory storage file
-            dry_run: If True, log actions without executing
-        """
-        self.github_token = github_token
         self.jira_url = jira_url
-        self.jira_token = jira_token
-        self.jira_email = jira_email
         self.slack_webhook = slack_webhook
         self.memory_store_path = Path(memory_store_path)
         self.dry_run = dry_run
-
-        # Ensure directories exist
         self.memory_store_path.parent.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _run_cli(args: List[str], input_data: Optional[str] = None) -> tuple:
+        """Run a CLI command and return (success, output)."""
+        try:
+            r = subprocess.run(args, input=input_data, capture_output=True, text=True, timeout=30)
+            output = r.stdout.strip() or r.stderr.strip()
+            if r.returncode != 0:
+                return False, output
+            return True, output
+        except Exception as e:
+            return False, str(e)
+
+    def _parse_pr_url(self, pr_url: str) -> Dict[str, str]:
+        """Parse a PR/MR URL into components."""
+        parsed = urllib.parse.urlparse(pr_url)
+        hostname = parsed.hostname or ""
+
+        if "github.com" in hostname:
+            parts = pr_url.rstrip("/").split("/")
+            if len(parts) < 5:
+                raise ValueError(f"Invalid GitHub PR URL: {pr_url}")
+            return {"host": "github", "owner": parts[-4], "repo": parts[-3]}
+
+        if "gitlab" in hostname:
+            path_parts = parsed.path.split("/-/merge_requests/")
+            if len(path_parts) != 2:
+                raise ValueError(f"Invalid GitLab MR URL: {pr_url}")
+            project_path = path_parts[0].strip("/")
+            segments = project_path.rsplit("/", 1)
+            owner = segments[0] if len(segments) > 1 else ""
+            repo = segments[-1]
+            return {
+                "host": "gitlab",
+                "hostname": hostname,
+                "owner": owner,
+                "repo": repo,
+                "project_path": project_path,
+            }
+
+        raise ValueError(f"Unsupported PR URL (not GitHub or GitLab): {pr_url}")
 
     def task_update(
         self, pr_url: str, pr_number: int, ticket_id: str, reviewers: Optional[List[str]] = None
     ) -> OperationResult:
-        """Update GitHub PR with labels, JIRA link in description, and request reviewers.
+        """Update PR/MR with labels, JIRA link in description, and request reviewers.
 
-        Args:
-            pr_url: GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
-            pr_number: PR number
-            ticket_id: JIRA ticket ID to link in PR description
-            reviewers: List of GitHub usernames to request as reviewers
-
-        Returns:
-            OperationResult with success/failure status
+        Supports both GitHub (via gh CLI) and GitLab (via glab CLI).
         """
         try:
-            if not self.github_token:
-                raise ValueError(
-                    "GitHub token not configured (set GITHUB_TOKEN env var or pass github_token parameter)"
-                )
-
-            # Parse owner and repo from PR URL
-            # Example: https://github.com/RedHatInsights/hcc-ai-assistant/pull/123
-            parts = pr_url.rstrip("/").split("/")
-            if len(parts) < 5 or "github.com" not in pr_url:
-                raise ValueError(f"Invalid GitHub PR URL: {pr_url}")
-
-            owner = parts[-4]
-            repo = parts[-3]
-
-            # Default reviewers if none provided
+            info = self._parse_pr_url(pr_url)
             if reviewers is None:
                 reviewers = []
 
-            updates = []
-            headers = {
-                "Authorization": f"token {self.github_token}",
-                "Accept": "application/vnd.github.v3+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-            }
-
-            # 1. Add labels
-            labels_to_add = ["code-review", "awaiting-review"]
-            if self.dry_run:
-                logger.info(f"[DRY RUN] Would add labels to PR #{pr_number}: {labels_to_add}")
+            if info["host"] == "github":
+                return self._update_github_pr(info, pr_url, pr_number, ticket_id, reviewers)
             else:
-                with httpx.Client() as client:
-                    response = client.post(
-                        f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/labels",
-                        headers=headers,
-                        json={"labels": labels_to_add},
-                        timeout=30.0,
-                    )
-                    response.raise_for_status()
-                    logger.info(f"Added labels to PR #{pr_number}: {labels_to_add}")
-            updates.append(f"Added labels: {', '.join(labels_to_add)}")
-
-            # 2. Update PR description with JIRA link
-            jira_link = f"{self.jira_url}/browse/{ticket_id}"
-            jira_section = f"\n\n---\n**JIRA Ticket**: [{ticket_id}]({jira_link})"
-
-            if self.dry_run:
-                logger.info(f"[DRY RUN] Would update PR description with JIRA link: {jira_link}")
-            else:
-                with httpx.Client() as client:
-                    # First, get current PR description
-                    get_response = client.get(
-                        f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}",
-                        headers=headers,
-                        timeout=30.0,
-                    )
-                    get_response.raise_for_status()
-                    pr_data = get_response.json()
-                    current_body = pr_data.get("body") or ""
-
-                    # Check if JIRA link already exists
-                    if ticket_id not in current_body:
-                        updated_body = current_body + jira_section
-
-                        # Update PR description
-                        patch_response = client.patch(
-                            f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}",
-                            headers=headers,
-                            json={"body": updated_body},
-                            timeout=30.0,
-                        )
-                        patch_response.raise_for_status()
-                        logger.info(f"Updated PR description with JIRA link: {jira_link}")
-                    else:
-                        logger.info("JIRA link already exists in PR description")
-            updates.append("Added JIRA link to description")
-
-            # 3. Request reviewers
-            if reviewers:
-                if self.dry_run:
-                    logger.info(f"[DRY RUN] Would request reviewers for PR #{pr_number}: {reviewers}")
-                else:
-                    with httpx.Client() as client:
-                        response = client.post(
-                            f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
-                            headers=headers,
-                            json={"reviewers": reviewers},
-                            timeout=30.0,
-                        )
-                        response.raise_for_status()
-                        logger.info(f"Requested reviewers for PR #{pr_number}: {reviewers}")
-                updates.append(f"Requested reviewers: {', '.join(reviewers)}")
-
-            return OperationResult(
-                operation="task_update",
-                status=OperationStatus.SUCCESS,
-                message=f"Updated PR #{pr_number}: {'; '.join(updates)}",
-                details={
-                    "pr_url": pr_url,
-                    "pr_number": pr_number,
-                    "owner": owner,
-                    "repo": repo,
-                    "labels_added": labels_to_add,
-                    "jira_ticket": ticket_id,
-                    "jira_link": jira_link,
-                    "reviewers_requested": reviewers,
-                },
-            )
+                return self._update_gitlab_mr(info, pr_url, pr_number, ticket_id, reviewers)
 
         except Exception as e:
-            logger.error(f"Failed to update GitHub PR: {e}")
+            logger.error(f"Failed to update PR/MR: {e}")
             return OperationResult(
-                operation="task_update", status=OperationStatus.FAILED, message=f"GitHub PR update failed: {e}"
+                operation="task_update", status=OperationStatus.FAILED, message=f"PR/MR update failed: {e}"
             )
 
+    def _update_github_pr(
+        self, info: Dict[str, str], pr_url: str, pr_number: int, ticket_id: str, reviewers: List[str]
+    ) -> OperationResult:
+        """Update GitHub PR via gh CLI."""
+        owner = info["owner"]
+        repo = info["repo"]
+        updates = []
+        labels_to_add = ["code-review", "awaiting-review"]
+
+        if self.dry_run:
+            logger.info(f"[DRY RUN] Would update GitHub PR #{pr_number} on {owner}/{repo}")
+        else:
+            ok, out = self._run_cli(
+                ["gh", "api", f"repos/{owner}/{repo}/issues/{pr_number}/labels", "-X", "POST", "--input", "-"],
+                input_data=json.dumps({"labels": labels_to_add}),
+            )
+            if not ok:
+                raise ValueError(f"Failed to add labels: {out}")
+            logger.info(f"Added labels to PR #{pr_number}: {labels_to_add}")
+        updates.append(f"Added labels: {', '.join(labels_to_add)}")
+
+        jira_link = f"{self.jira_url}/browse/{ticket_id}"
+        jira_section = f"\n\n---\n**JIRA Ticket**: [{ticket_id}]({jira_link})"
+
+        if self.dry_run:
+            logger.info(f"[DRY RUN] Would update PR description with JIRA link: {jira_link}")
+        else:
+            ok, out = self._run_cli(["gh", "api", f"repos/{owner}/{repo}/pulls/{pr_number}"])
+            if not ok:
+                raise ValueError(f"Failed to get PR: {out}")
+            pr_data = json.loads(out)
+            current_body = pr_data.get("body") or ""
+
+            if ticket_id not in current_body:
+                updated_body = current_body + jira_section
+                ok, out = self._run_cli(
+                    ["gh", "api", f"repos/{owner}/{repo}/pulls/{pr_number}", "-X", "PATCH", "--input", "-"],
+                    input_data=json.dumps({"body": updated_body}),
+                )
+                if not ok:
+                    raise ValueError(f"Failed to update PR description: {out}")
+                logger.info(f"Updated PR description with JIRA link: {jira_link}")
+            else:
+                logger.info("JIRA link already exists in PR description")
+        updates.append("Added JIRA link to description")
+
+        if reviewers:
+            if self.dry_run:
+                logger.info(f"[DRY RUN] Would request reviewers for PR #{pr_number}: {reviewers}")
+            else:
+                ok, out = self._run_cli(
+                    [
+                        "gh", "api",
+                        f"repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
+                        "-X", "POST", "--input", "-",
+                    ],
+                    input_data=json.dumps({"reviewers": reviewers}),
+                )
+                if not ok:
+                    raise ValueError(f"Failed to request reviewers: {out}")
+                logger.info(f"Requested reviewers for PR #{pr_number}: {reviewers}")
+            updates.append(f"Requested reviewers: {', '.join(reviewers)}")
+
+        return OperationResult(
+            operation="task_update",
+            status=OperationStatus.SUCCESS,
+            message=f"Updated PR #{pr_number}: {'; '.join(updates)}",
+            details={
+                "pr_url": pr_url,
+                "pr_number": pr_number,
+                "owner": owner,
+                "repo": repo,
+                "labels_added": labels_to_add,
+                "jira_ticket": ticket_id,
+                "jira_link": jira_link,
+                "reviewers_requested": reviewers,
+            },
+        )
+
+    def _update_gitlab_mr(
+        self, info: Dict[str, str], pr_url: str, pr_number: int, ticket_id: str, reviewers: List[str]
+    ) -> OperationResult:
+        """Update GitLab MR via glab CLI."""
+        hostname = info["hostname"]
+        project_path = info["project_path"]
+        encoded_project = urllib.parse.quote(project_path, safe="")
+        owner = info["owner"]
+        repo = info["repo"]
+        updates = []
+        labels_to_add = ["code-review", "awaiting-review"]
+
+        if self.dry_run:
+            logger.info(f"[DRY RUN] Would update GitLab MR !{pr_number} on {project_path}")
+        else:
+            ok, out = self._run_cli([
+                "glab", "api", f"projects/{encoded_project}/merge_requests/{pr_number}",
+                "-X", "PUT", "-f", f"add_labels={','.join(labels_to_add)}",
+                "--hostname", hostname,
+            ])
+            if not ok:
+                raise ValueError(f"Failed to add labels: {out}")
+            logger.info(f"Added labels to MR !{pr_number}: {labels_to_add}")
+        updates.append(f"Added labels: {', '.join(labels_to_add)}")
+
+        jira_link = f"{self.jira_url}/browse/{ticket_id}"
+        jira_section = f"\n\n---\n**JIRA Ticket**: [{ticket_id}]({jira_link})"
+
+        if self.dry_run:
+            logger.info(f"[DRY RUN] Would update MR description with JIRA link: {jira_link}")
+        else:
+            ok, out = self._run_cli([
+                "glab", "api", f"projects/{encoded_project}/merge_requests/{pr_number}",
+                "--hostname", hostname,
+            ])
+            if not ok:
+                raise ValueError(f"Failed to get MR: {out}")
+            mr_data = json.loads(out)
+            current_body = mr_data.get("description") or ""
+
+            if ticket_id not in current_body:
+                updated_body = current_body + jira_section
+                ok, out = self._run_cli(
+                    [
+                        "glab", "api", f"projects/{encoded_project}/merge_requests/{pr_number}",
+                        "-X", "PUT", "--input", "-",
+                        "--hostname", hostname,
+                    ],
+                    input_data=json.dumps({"description": updated_body}),
+                )
+                if not ok:
+                    raise ValueError(f"Failed to update MR description: {out}")
+                logger.info(f"Updated MR description with JIRA link: {jira_link}")
+            else:
+                logger.info("JIRA link already exists in MR description")
+        updates.append("Added JIRA link to description")
+
+        if reviewers:
+            if self.dry_run:
+                logger.info(f"[DRY RUN] Would request reviewers for MR !{pr_number}: {reviewers}")
+            else:
+                reviewer_ids = []
+                for reviewer in reviewers:
+                    ok, out = self._run_cli([
+                        "glab", "api", f"users?username={reviewer}",
+                        "--hostname", hostname,
+                    ])
+                    if ok:
+                        users = json.loads(out)
+                        if users:
+                            reviewer_ids.append(users[0]["id"])
+
+                if reviewer_ids:
+                    ok, out = self._run_cli(
+                        [
+                            "glab", "api", f"projects/{encoded_project}/merge_requests/{pr_number}",
+                            "-X", "PUT", "--input", "-",
+                            "--hostname", hostname,
+                        ],
+                        input_data=json.dumps({"reviewer_ids": reviewer_ids}),
+                    )
+                    if not ok:
+                        raise ValueError(f"Failed to request reviewers: {out}")
+                    logger.info(f"Requested reviewers for MR !{pr_number}: {reviewers}")
+            updates.append(f"Requested reviewers: {', '.join(reviewers)}")
+
+        return OperationResult(
+            operation="task_update",
+            status=OperationStatus.SUCCESS,
+            message=f"Updated MR !{pr_number}: {'; '.join(updates)}",
+            details={
+                "pr_url": pr_url,
+                "pr_number": pr_number,
+                "owner": owner,
+                "repo": repo,
+                "labels_added": labels_to_add,
+                "jira_ticket": ticket_id,
+                "jira_link": jira_link,
+                "reviewers_requested": reviewers,
+            },
+        )
+
     def jira_transition_issue(self, ticket_id: str, target_status: str = "Code Review") -> OperationResult:
-        """Transition JIRA issue to target status.
+        """Transition JIRA issue to target status via MCP.
 
         Args:
             ticket_id: JIRA ticket ID (e.g., TICKET-456)
@@ -257,61 +358,42 @@ class PostPROperations:
             OperationResult with success/failure status
         """
         try:
-            if not self.jira_token:
-                raise ValueError("JIRA token not configured (set POST_PR_JIRA_TOKEN)")
-
-            # Use Basic auth for JIRA Cloud (email:token)
-            auth_string = f"{self.jira_email}:{self.jira_token}"
-            basic_auth = base64.b64encode(auth_string.encode()).decode()
-            headers = {
-                "Authorization": f"Basic {basic_auth}",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            }
-
             if self.dry_run:
                 logger.info(f"[DRY RUN] Would transition {ticket_id} to {target_status}")
             else:
-                with httpx.Client(follow_redirects=True) as client:
-                    # Get available transitions using API v3 (required for JIRA Cloud)
-                    get_response = client.get(
-                        f"{self.jira_url}/rest/api/3/issue/{ticket_id}/transitions",
-                        headers=headers,
-                        timeout=30.0,
-                    )
-                    get_response.raise_for_status()
-                    response_data = get_response.json()
-                    transitions = response_data.get("transitions", [])
+                data = jira_call("jira_get_transitions", {"issue_key": ticket_id})
+                if not data:
+                    raise ValueError("Failed to get transitions from Jira MCP")
 
-                    # Find the transition ID for the target status
-                    transition_id = None
+                transitions = data if isinstance(data, list) else data.get("transitions", [])
+
+                transition_id = None
+                for transition in transitions:
+                    name = transition.get("to", transition).get("name", "")
+                    if name == target_status:
+                        transition_id = transition.get("id")
+                        break
+
+                if not transition_id:
                     for transition in transitions:
-                        if transition.get("to", {}).get("name") == target_status:
+                        name = transition.get("to", transition).get("name", "")
+                        if name.lower() == target_status.lower():
                             transition_id = transition.get("id")
                             break
 
-                    if not transition_id:
-                        # If exact match not found, try case-insensitive match
-                        for transition in transitions:
-                            if transition.get("to", {}).get("name", "").lower() == target_status.lower():
-                                transition_id = transition.get("id")
-                                break
-
-                    if not transition_id:
-                        available = [t.get("to", {}).get("name") for t in transitions]
-                        raise ValueError(
-                            f"Cannot transition to '{target_status}'. Available transitions: {', '.join(available)}"
-                        )
-
-                    # Execute the transition using API v3
-                    post_response = client.post(
-                        f"{self.jira_url}/rest/api/3/issue/{ticket_id}/transitions",
-                        headers=headers,
-                        json={"transition": {"id": transition_id}},
-                        timeout=30.0,
+                if not transition_id:
+                    available = [t.get("to", t).get("name", "") for t in transitions]
+                    raise ValueError(
+                        f"Cannot transition to '{target_status}'. Available transitions: {', '.join(available)}"
                     )
-                    post_response.raise_for_status()
-                    logger.info(f"Transitioned {ticket_id} to {target_status}")
+
+                result = jira_call("jira_transition_issue", {
+                    "issue_key": ticket_id,
+                    "transition_id": str(transition_id),
+                })
+                if result is None:
+                    raise ValueError("Transition call returned None")
+                logger.info(f"Transitioned {ticket_id} to {target_status}")
 
             return OperationResult(
                 operation="jira_transition_issue",
@@ -331,7 +413,7 @@ class PostPROperations:
             )
 
     def jira_add_comment(self, ticket_id: str, pr_url: str, summary: str) -> OperationResult:
-        """Add comment to JIRA issue with PR link and summary.
+        """Add comment to JIRA issue with PR link and summary via MCP.
 
         Args:
             ticket_id: JIRA ticket ID
@@ -342,43 +424,18 @@ class PostPROperations:
             OperationResult with success/failure status
         """
         try:
-            if not self.jira_token:
-                raise ValueError("JIRA token not configured (set POST_PR_JIRA_TOKEN)")
-
-            # API v3 uses Atlassian Document Format (ADF) for comments
             comment_text = f"Pull Request created: {pr_url}\n\nSummary: {summary}"
-            comment_adf = {
-                "body": {
-                    "type": "doc",
-                    "version": 1,
-                    "content": [
-                        {"type": "paragraph", "content": [{"type": "text", "text": f"Pull Request created: {pr_url}"}]},
-                        {"type": "paragraph", "content": [{"type": "text", "text": f"Summary: {summary}"}]},
-                    ],
-                }
-            }
-
-            # Use Basic auth for JIRA Cloud (email:token)
-            auth_string = f"{self.jira_email}:{self.jira_token}"
-            basic_auth = base64.b64encode(auth_string.encode()).decode()
-            headers = {
-                "Authorization": f"Basic {basic_auth}",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            }
 
             if self.dry_run:
                 logger.info(f"[DRY RUN] Would add comment to {ticket_id}: {comment_text}")
             else:
-                with httpx.Client(follow_redirects=True) as client:
-                    response = client.post(
-                        f"{self.jira_url}/rest/api/3/issue/{ticket_id}/comment",
-                        headers=headers,
-                        json=comment_adf,
-                        timeout=30.0,
-                    )
-                    response.raise_for_status()
-                    logger.info(f"Added comment to {ticket_id}")
+                result = jira_call("jira_add_comment", {
+                    "issue_key": ticket_id,
+                    "body": comment_text,
+                })
+                if result is None:
+                    raise ValueError("Failed to add comment via Jira MCP")
+                logger.info(f"Added comment to {ticket_id}")
 
             return OperationResult(
                 operation="jira_add_comment",
@@ -535,10 +592,7 @@ def execute_post_pr_workflow(
     pr_number: int,
     ticket_id: str,
     summary: str,
-    github_token: Optional[str] = None,
     jira_url: Optional[str] = None,
-    jira_token: Optional[str] = None,
-    jira_email: Optional[str] = None,
     slack_webhook: Optional[str] = None,
     slack_channel: str = "#hcc-ai-assistant",
     memory_store_path: Optional[str] = None,
@@ -548,41 +602,18 @@ def execute_post_pr_workflow(
 ) -> WorkflowResult:
     """Execute the complete post-PR workflow.
 
-    Args:
-        pr_url: GitHub PR URL
-        pr_number: PR number
-        ticket_id: JIRA ticket ID
-        summary: PR summary
-        github_token: GitHub API token (optional, defaults to env var)
-        jira_url: JIRA instance URL (optional, defaults to env var)
-        jira_token: JIRA API token (optional, defaults to env var)
-        jira_email: JIRA user email (optional, defaults to env var)
-        slack_webhook: Slack webhook URL (optional, defaults to env var)
-        slack_channel: Slack channel for notifications
-        memory_store_path: Path to memory storage file (optional, defaults to env var)
-        reviewers: List of GitHub usernames to request as reviewers
-        skip_operations: List of operations to skip
-        dry_run: Show what would be done without executing
-
-    Returns:
-        WorkflowResult with status and operation results
+    GitHub/GitLab operations use gh/glab CLI (no tokens needed).
+    JIRA operations use MCP via jira_call.
     """
-    # Resolve configuration from environment variables
-    github_token = github_token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
     jira_url = jira_url or os.getenv("POST_PR_JIRA_URL", "https://redhat.atlassian.net")
-    jira_token = jira_token or os.getenv("POST_PR_JIRA_TOKEN")
-    jira_email = jira_email or os.getenv("POST_PR_JIRA_EMAIL", "")
     slack_webhook = slack_webhook or os.getenv("POST_PR_SLACK_WEBHOOK")
     memory_store_path = memory_store_path or os.getenv("POST_PR_MEMORY_STORE", "/tmp/memory.json")
 
     skip_operations = skip_operations or []
     operations = PostPROperations(
-        github_token=github_token,
-        jira_url=jira_url,
-        jira_token=jira_token,
-        jira_email=jira_email,
         slack_webhook=slack_webhook,
         memory_store_path=memory_store_path,
+        jira_url=jira_url,
         dry_run=dry_run,
     )
 
@@ -683,8 +714,6 @@ def main():
     parser.add_argument("pr_number", type=int, help="PR number")
     parser.add_argument("ticket_id", help="JIRA ticket ID")
     parser.add_argument("summary", help="PR summary")
-    parser.add_argument("--github-token", help="GitHub API token (falls back to GITHUB_TOKEN env var)")
-    parser.add_argument("--jira-token", help="JIRA API token (falls back to POST_PR_JIRA_TOKEN env var)")
     parser.add_argument("--slack-channel", default="#hcc-ai-assistant", help="Slack channel for notifications")
     parser.add_argument("--reviewers", help="Comma-separated list of GitHub usernames to request as reviewers")
     parser.add_argument(
@@ -703,8 +732,6 @@ def main():
         pr_number=args.pr_number,
         ticket_id=args.ticket_id,
         summary=args.summary,
-        github_token=args.github_token,
-        jira_token=args.jira_token,
         slack_channel=args.slack_channel,
         reviewers=reviewers,
         skip_operations=skip_operations,

--- a/.claude/skills/post-pr/scripts/post_pr_operations.py
+++ b/.claude/skills/post-pr/scripts/post_pr_operations.py
@@ -87,7 +87,9 @@ class WorkflowResult:
 
 
 class PostPROperations:
-    """Post-PR workflow operations (stub implementations)."""
+    """Post-PR workflow operations."""
+
+    CLI_TIMEOUT = 30
 
     def __init__(
         self,
@@ -103,14 +105,13 @@ class PostPROperations:
         self.memory_store_path.parent.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
-    def _run_cli(args: List[str], input_data: Optional[str] = None) -> tuple:
+    def _run_cli(args: List[str], input_data: Optional[str] = None, timeout: int = CLI_TIMEOUT) -> tuple:
         """Run a CLI command and return (success, output)."""
         try:
-            r = subprocess.run(args, input=input_data, capture_output=True, text=True, timeout=30)
-            output = r.stdout.strip() or r.stderr.strip()
+            r = subprocess.run(args, input=input_data, capture_output=True, text=True, timeout=timeout)
             if r.returncode != 0:
-                return False, output
-            return True, output
+                return False, r.stderr.strip() or r.stdout.strip()
+            return True, r.stdout.strip()
         except Exception as e:
             return False, str(e)
 
@@ -118,15 +119,10 @@ class PostPROperations:
         """Parse a PR/MR URL into components."""
         parsed = urllib.parse.urlparse(pr_url)
         hostname = parsed.hostname or ""
+        path = parsed.path or ""
 
-        if hostname == "github.com":
-            parts = pr_url.rstrip("/").split("/")
-            if len(parts) < 5:
-                raise ValueError(f"Invalid GitHub PR URL: {pr_url}")
-            return {"host": "github", "owner": parts[-4], "repo": parts[-3]}
-
-        if hostname == "gitlab.com" or hostname == "gitlab.cee.redhat.com":
-            path_parts = parsed.path.split("/-/merge_requests/")
+        if "/-/merge_requests/" in path:
+            path_parts = path.split("/-/merge_requests/")
             if len(path_parts) != 2:
                 raise ValueError(f"Invalid GitLab MR URL: {pr_url}")
             project_path = path_parts[0].strip("/")
@@ -140,6 +136,12 @@ class PostPROperations:
                 "repo": repo,
                 "project_path": project_path,
             }
+
+        if hostname == "github.com":
+            parts = path.strip("/").split("/")
+            if len(parts) < 4 or parts[-2] != "pull":
+                raise ValueError(f"Invalid GitHub PR URL: {pr_url}")
+            return {"host": "github", "owner": parts[0], "repo": parts[1]}
 
         raise ValueError(f"Unsupported PR URL (not GitHub or GitLab): {pr_url}")
 

--- a/.claude/skills/post-pr/tests/test_integration.py
+++ b/.claude/skills/post-pr/tests/test_integration.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -23,62 +24,74 @@ def env_vars(temp_dir):
     """Set up environment variables for testing."""
     original_env = os.environ.copy()
 
-    os.environ["GITHUB_TOKEN"] = "test-github-token"
     os.environ["POST_PR_JIRA_URL"] = "https://test-jira.example.com"
-    os.environ["POST_PR_JIRA_TOKEN"] = "test-jira-token"
     os.environ["POST_PR_SLACK_WEBHOOK"] = "https://hooks.slack.com/test"
     os.environ["POST_PR_MEMORY_STORE"] = str(temp_dir / "memory.json")
 
     yield
 
-    # Restore original environment
     os.environ.clear()
     os.environ.update(original_env)
 
 
+def _make_gh_side_effect():
+    """Create a subprocess.run side_effect for gh CLI calls."""
+    def side_effect(args, **kwargs):
+        result = Mock(spec=subprocess.CompletedProcess)
+        result.returncode = 0
+        result.stderr = ""
+        args_str = " ".join(args) if isinstance(args, list) else args
+
+        if "labels" in args_str and "POST" in args_str:
+            result.stdout = json.dumps([{"name": "code-review"}, {"name": "awaiting-review"}])
+        elif "pulls/" in args_str and "PATCH" not in args_str and "requested_reviewers" not in args_str:
+            result.stdout = json.dumps({"body": "Existing PR description"})
+        elif "PATCH" in args_str:
+            result.stdout = json.dumps({"body": "Updated"})
+        elif "requested_reviewers" in args_str:
+            result.stdout = json.dumps({"requested_reviewers": [{"login": "user1"}]})
+        else:
+            result.stdout = "{}"
+        return result
+    return side_effect
+
+
 @pytest.fixture
-def mock_github_api():
-    """Mock GitHub and JIRA API responses."""
-    with patch("scripts.post_pr_operations.httpx.Client") as mock_client_class:
+def mock_apis():
+    """Mock gh CLI (subprocess) and Jira MCP calls."""
+    with patch("scripts.post_pr_operations.subprocess.run") as mock_run, \
+         patch("scripts.post_pr_operations.jira_call") as mock_jira_call, \
+         patch("scripts.post_pr_operations.httpx.Client") as mock_client_class:
+        mock_run.side_effect = _make_gh_side_effect()
+
+        mock_jira_call.side_effect = [
+            {"transitions": [{"id": "21", "to": {"name": "Code Review"}}]},
+            {"success": True},
+            {"id": "12345"},
+        ]
+
         mock_client = Mock()
         mock_client_class.return_value.__enter__.return_value = mock_client
-
-        # Mock GitHub responses
         mock_post_response = Mock()
         mock_post_response.raise_for_status = Mock()
-
-        mock_get_response = Mock()
-        mock_get_response.raise_for_status = Mock()
-
-        # Will be called for both GitHub PR GET and JIRA transitions GET
-        def get_side_effect(url, **kwargs):
-            response = Mock()
-            response.raise_for_status = Mock()
-            if "github.com" in url:
-                response.json.return_value = {"body": "Existing PR description"}
-            elif "transitions" in url:
-                # JIRA transitions response
-                response.json.return_value = {
-                    "transitions": [
-                        {"id": "21", "to": {"name": "Code Review"}},
-                    ]
-                }
-            return response
-
-        mock_patch_response = Mock()
-        mock_patch_response.raise_for_status = Mock()
-
         mock_client.post.return_value = mock_post_response
-        mock_client.get.side_effect = get_side_effect
-        mock_client.patch.return_value = mock_patch_response
 
-        yield mock_client
+        yield mock_run, mock_jira_call
+
+
+def _reset_jira_mock(mock_jira_call):
+    """Reset jira_call mock with fresh side_effect for a new workflow run."""
+    mock_jira_call.side_effect = [
+        {"transitions": [{"id": "21", "to": {"name": "Code Review"}}]},
+        {"success": True},
+        {"id": "12345"},
+    ]
 
 
 class TestFullWorkflow:
     """Test complete post-PR workflow."""
 
-    def test_successful_workflow(self, env_vars, temp_dir, mock_github_api):
+    def test_successful_workflow(self, env_vars, temp_dir, mock_apis):
         """Test successful execution of all operations."""
         result = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/123",
@@ -95,11 +108,9 @@ class TestFullWorkflow:
         assert result.ticket_id == "TICKET-456"
         assert len(result.operations) == 6
 
-        # Verify all operations succeeded
         for op in result.operations:
             assert op.status == OperationStatus.SUCCESS
 
-        # Verify operation order
         expected_operations = [
             "task_update",
             "jira_transition_issue",
@@ -111,7 +122,7 @@ class TestFullWorkflow:
         actual_operations = [op.operation for op in result.operations]
         assert actual_operations == expected_operations
 
-    def test_workflow_with_skip_operations(self, env_vars, mock_github_api):
+    def test_workflow_with_skip_operations(self, env_vars, mock_apis):
         """Test workflow with some operations skipped."""
         result = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/124",
@@ -123,19 +134,17 @@ class TestFullWorkflow:
 
         assert result.success is True
 
-        # Verify skipped operations
         slack_op = next(op for op in result.operations if op.operation == "slack_notify")
         assert slack_op.status == OperationStatus.SKIPPED
 
         memory_op = next(op for op in result.operations if op.operation == "memory_store")
         assert memory_op.status == OperationStatus.SKIPPED
 
-        # Verify non-skipped operations succeeded
         for op in result.operations:
             if op.operation not in ["slack_notify", "memory_store"]:
                 assert op.status == OperationStatus.SUCCESS
 
-    def test_workflow_dry_run(self, env_vars, temp_dir, mock_github_api):
+    def test_workflow_dry_run(self, env_vars, temp_dir, mock_apis):
         """Test workflow in dry-run mode."""
         result = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/125",
@@ -147,43 +156,38 @@ class TestFullWorkflow:
 
         assert result.success is True
 
-        # Verify all operations succeeded (dry-run should not fail)
         for op in result.operations:
             assert op.status == OperationStatus.SUCCESS
 
-        # Verify no files were created (memory store shouldn't exist in dry-run)
         memory_store = Path(os.environ["POST_PR_MEMORY_STORE"])
         assert not memory_store.exists()
 
     def test_workflow_fails_fast_on_error(self, temp_dir, monkeypatch):
         """Test that workflow stops on first error (fail-fast)."""
-        # Clear all token environment variables
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        monkeypatch.delenv("GH_TOKEN", raising=False)
-        monkeypatch.delenv("POST_PR_JIRA_TOKEN", raising=False)
         monkeypatch.delenv("POST_PR_SLACK_WEBHOOK", raising=False)
-
-        # Set up minimal environment
         monkeypatch.setenv("POST_PR_MEMORY_STORE", str(temp_dir / "memory.json"))
 
-        result = execute_post_pr_workflow(
-            pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/126",
-            pr_number=126,
-            ticket_id="TICKET-459",
-            summary="Test failure",
-        )
+        with patch("scripts.post_pr_operations.subprocess.run") as mock_run:
+            mock_run.side_effect = lambda args, **kwargs: Mock(
+                returncode=1, stdout="", stderr="gh: command not found"
+            )
+
+            result = execute_post_pr_workflow(
+                pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/126",
+                pr_number=126,
+                ticket_id="TICKET-459",
+                summary="Test failure",
+            )
 
         assert result.success is False
 
-        # Find the failed operation (should be first one - task_update)
         failed_ops = [op for op in result.operations if op.status == OperationStatus.FAILED]
         assert len(failed_ops) > 0
         assert failed_ops[0].operation == "task_update"
 
-        # Verify workflow stopped after failure (only 1 operation ran)
         assert len(result.operations) == 1
 
-    def test_workflow_result_serialization(self, env_vars, mock_github_api):
+    def test_workflow_result_serialization(self, env_vars, mock_apis):
         """Test that workflow result can be serialized to JSON."""
         result = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/127",
@@ -192,11 +196,9 @@ class TestFullWorkflow:
             summary="Test serialization",
         )
 
-        # Convert to dict and serialize
         result_dict = result.to_dict()
         json_str = json.dumps(result_dict, indent=2)
 
-        # Verify JSON is valid and can be parsed
         parsed = json.loads(json_str)
         assert parsed["success"] is True
         assert parsed["pr_number"] == 127
@@ -207,7 +209,7 @@ class TestFullWorkflow:
 class TestWorkflowEdgeCases:
     """Test edge cases and error scenarios."""
 
-    def test_workflow_with_minimal_inputs(self, env_vars, mock_github_api):
+    def test_workflow_with_minimal_inputs(self, env_vars, mock_apis):
         """Test workflow with only required inputs."""
         result = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/128",
@@ -217,13 +219,15 @@ class TestWorkflowEdgeCases:
         )
 
         assert result.success is True
-        # Should use default Slack channel
         slack_op = next(op for op in result.operations if op.operation == "slack_notify")
         assert slack_op.details["channel"] == "#hcc-ai-assistant"
 
-    def test_workflow_with_long_summary(self, env_vars, mock_github_api):
+    def test_workflow_with_long_summary(self, env_vars, mock_apis):
         """Test workflow with very long PR summary."""
-        long_summary = "A" * 1000  # 1000 character summary
+        _, mock_jira_call = mock_apis
+        _reset_jira_mock(mock_jira_call)
+
+        long_summary = "A" * 1000
 
         result = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/129",
@@ -234,12 +238,14 @@ class TestWorkflowEdgeCases:
 
         assert result.success is True
 
-        # Verify summary is preserved in operations
         jira_comment_op = next(op for op in result.operations if op.operation == "jira_add_comment")
         assert long_summary in jira_comment_op.details["comment"]
 
-    def test_workflow_with_special_characters(self, env_vars, mock_github_api):
+    def test_workflow_with_special_characters(self, env_vars, mock_apis):
         """Test workflow with special characters in summary."""
+        _, mock_jira_call = mock_apis
+        _reset_jira_mock(mock_jira_call)
+
         special_summary = 'Test "quotes" & <tags> and \\backslashes\\'
 
         result = execute_post_pr_workflow(
@@ -251,13 +257,15 @@ class TestWorkflowEdgeCases:
 
         assert result.success is True
 
-        # Verify PR was updated successfully
         task_op = next(op for op in result.operations if op.operation == "task_update")
         assert task_op.status == OperationStatus.SUCCESS
         assert task_op.details["jira_ticket"] == "TICKET-463"
 
-    def test_workflow_with_reviewers(self, env_vars, mock_github_api):
+    def test_workflow_with_reviewers(self, env_vars, mock_apis):
         """Test workflow with reviewers specified."""
+        _, mock_jira_call = mock_apis
+        _reset_jira_mock(mock_jira_call)
+
         result = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/131",
             pr_number=131,
@@ -275,8 +283,10 @@ class TestWorkflowEdgeCases:
 class TestWorkflowPersistence:
     """Test that workflow operations persist data correctly."""
 
-    def test_github_pr_updates(self, env_vars, mock_github_api):
+    def test_github_pr_updates(self, env_vars, mock_apis):
         """Test that GitHub PR updates include correct details."""
+        _, mock_jira_call = mock_apis
+
         result1 = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/132",
             pr_number=132,
@@ -284,6 +294,8 @@ class TestWorkflowPersistence:
             summary="First PR",
             reviewers=["user1"],
         )
+
+        _reset_jira_mock(mock_jira_call)
 
         result2 = execute_post_pr_workflow(
             pr_url="https://github.com/test/other-repo/pull/133",
@@ -296,24 +308,24 @@ class TestWorkflowPersistence:
         assert result1.success is True
         assert result2.success is True
 
-        # Verify first PR update
         task_op1 = next(op for op in result1.operations if op.operation == "task_update")
         assert task_op1.details["owner"] == "RedHatInsights"
         assert task_op1.details["repo"] == "hcc-ai-assistant"
         assert task_op1.details["pr_number"] == 132
         assert task_op1.details["reviewers_requested"] == ["user1"]
 
-        # Verify second PR update
         task_op2 = next(op for op in result2.operations if op.operation == "task_update")
         assert task_op2.details["owner"] == "test"
         assert task_op2.details["repo"] == "other-repo"
         assert task_op2.details["pr_number"] == 133
         assert task_op2.details["reviewers_requested"] == ["user2", "user3"]
 
-    def test_memory_accumulation(self, env_vars, temp_dir, mock_github_api):
+    def test_memory_accumulation(self, env_vars, temp_dir, mock_apis):
         """Test that memories accumulate over multiple executions."""
-        # Execute workflow 3 times
+        _, mock_jira_call = mock_apis
+
         for i in range(3):
+            _reset_jira_mock(mock_jira_call)
             result = execute_post_pr_workflow(
                 pr_url=f"https://github.com/RedHatInsights/hcc-ai-assistant/pull/{134 + i}",
                 pr_number=134 + i,
@@ -322,7 +334,6 @@ class TestWorkflowPersistence:
             )
             assert result.success is True
 
-        # Verify all memories are stored
         memory_store = Path(os.environ["POST_PR_MEMORY_STORE"])
         assert memory_store.exists()
 
@@ -334,14 +345,18 @@ class TestWorkflowPersistence:
                 assert memory["ticket_id"] == f"TICKET-{467 + i}"
                 assert memory["pr_url"] == f"https://github.com/RedHatInsights/hcc-ai-assistant/pull/{134 + i}"
 
-    def test_bot_status_overwrite(self, env_vars, mock_github_api):
+    def test_bot_status_overwrite(self, env_vars, mock_apis):
         """Test that bot status is overwritten on each execution."""
+        _, mock_jira_call = mock_apis
+
         result1 = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/137",
             pr_number=137,
             ticket_id="TICKET-470",
             summary="First",
         )
+
+        _reset_jira_mock(mock_jira_call)
 
         result2 = execute_post_pr_workflow(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/138",
@@ -353,12 +368,10 @@ class TestWorkflowPersistence:
         assert result1.success is True
         assert result2.success is True
 
-        # Verify status file contains latest status
         status_file = Path("/tmp/bot_status.json")
         assert status_file.exists()
 
         with open(status_file, "r") as f:
             status = json.load(f)
             assert status["status"] == "idle"
-            # Should be recent timestamp from second execution
             assert status["timestamp"]

--- a/.claude/skills/post-pr/tests/test_operations.py
+++ b/.claude/skills/post-pr/tests/test_operations.py
@@ -187,8 +187,9 @@ class TestTaskUpdate:
         assert result.details["jira_ticket"] == "TICKET-GL1"
 
         labels_call = mock_run.call_args_list[0]
-        assert "--hostname" in labels_call[0][0]
-        assert "gitlab.cee.redhat.com" in labels_call[0][0]
+        cli_args = labels_call[0][0]
+        hostname_idx = cli_args.index("--hostname")
+        assert cli_args[hostname_idx + 1] == "gitlab.cee.redhat.com"
 
 
 class TestJiraTransitionIssue:

--- a/.claude/skills/post-pr/tests/test_operations.py
+++ b/.claude/skills/post-pr/tests/test_operations.py
@@ -1,6 +1,7 @@
 """Unit tests for post-PR operations."""
 
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -26,40 +27,48 @@ def temp_dir():
 def operations(temp_dir):
     """Create PostPROperations instance with temp file paths."""
     return PostPROperations(
-        github_token="test-github-token",
-        jira_url="https://test-jira.example.com",
-        jira_token="test-jira-token",
-        jira_email="test@example.com",
         slack_webhook="https://hooks.slack.com/test",
         memory_store_path=str(temp_dir / "memory.json"),
+        jira_url="https://test-jira.example.com",
         dry_run=False,
     )
 
 
+def _mock_subprocess_run(responses):
+    """Create a side_effect function for subprocess.run that returns responses in order.
+
+    Each response is a dict with: stdout, stderr (optional), returncode (default 0).
+    """
+    call_index = [0]
+
+    def side_effect(args, **kwargs):
+        idx = call_index[0]
+        call_index[0] += 1
+        if idx >= len(responses):
+            resp = responses[-1]
+        else:
+            resp = responses[idx]
+        result = Mock(spec=subprocess.CompletedProcess)
+        result.stdout = resp.get("stdout", "")
+        result.stderr = resp.get("stderr", "")
+        result.returncode = resp.get("returncode", 0)
+        return result
+
+    return side_effect
+
+
 class TestTaskUpdate:
-    """Test task_update operation (GitHub PR updates)."""
+    """Test task_update operation (GitHub PR updates via gh CLI)."""
 
-    @patch("scripts.post_pr_operations.httpx.Client")
-    def test_task_update_success(self, mock_client_class, operations):
-        """Test successful GitHub PR update."""
-        # Mock HTTP responses
-        mock_client = Mock()
-        mock_client_class.return_value.__enter__.return_value = mock_client
-
-        # Mock successful responses
-        mock_post_response = Mock()
-        mock_post_response.raise_for_status = Mock()
-
-        mock_get_response = Mock()
-        mock_get_response.raise_for_status = Mock()
-        mock_get_response.json.return_value = {"body": "Existing PR description"}
-
-        mock_patch_response = Mock()
-        mock_patch_response.raise_for_status = Mock()
-
-        mock_client.post.return_value = mock_post_response
-        mock_client.get.return_value = mock_get_response
-        mock_client.patch.return_value = mock_patch_response
+    @patch("scripts.post_pr_operations.subprocess.run")
+    def test_task_update_github_success(self, mock_run, operations):
+        """Test successful GitHub PR update via gh CLI."""
+        mock_run.side_effect = _mock_subprocess_run([
+            {"stdout": json.dumps([{"name": "code-review"}, {"name": "awaiting-review"}])},
+            {"stdout": json.dumps({"body": "Existing PR description"})},
+            {"stdout": json.dumps({"body": "Updated description"})},
+            {"stdout": json.dumps({"requested_reviewers": [{"login": "user1"}, {"login": "user2"}]})},
+        ])
 
         result = operations.task_update(
             pr_url="https://github.com/RedHatInsights/hcc-ai-assistant/pull/123",
@@ -78,37 +87,29 @@ class TestTaskUpdate:
         assert result.details["reviewers_requested"] == ["user1", "user2"]
         assert "code-review" in result.details["labels_added"]
 
-        # Verify labels API call
-        labels_call = mock_client.post.call_args_list[0]
-        assert labels_call[0][0] == "https://api.github.com/repos/RedHatInsights/hcc-ai-assistant/issues/123/labels"
-        assert labels_call[1]["json"]["labels"] == ["code-review", "awaiting-review"]
-        assert "token test-github-token" in labels_call[1]["headers"]["Authorization"]
+        labels_call = mock_run.call_args_list[0]
+        assert "repos/RedHatInsights/hcc-ai-assistant/issues/123/labels" in labels_call[0][0]
+        assert labels_call[1].get("input") is not None
+        labels_payload = json.loads(labels_call[1]["input"])
+        assert labels_payload["labels"] == ["code-review", "awaiting-review"]
 
-        # Verify GET PR call
-        get_call = mock_client.get.call_args
-        assert get_call[0][0] == "https://api.github.com/repos/RedHatInsights/hcc-ai-assistant/pulls/123"
+        get_call = mock_run.call_args_list[1]
+        assert "repos/RedHatInsights/hcc-ai-assistant/pulls/123" in get_call[0][0]
 
-        # Verify PATCH PR description call
-        patch_call = mock_client.patch.call_args
-        assert patch_call[0][0] == "https://api.github.com/repos/RedHatInsights/hcc-ai-assistant/pulls/123"
-        assert "TICKET-456" in patch_call[1]["json"]["body"]
-        assert "https://test-jira.example.com/browse/TICKET-456" in patch_call[1]["json"]["body"]
+        patch_call = mock_run.call_args_list[2]
+        assert "PATCH" in patch_call[0][0]
+        patch_payload = json.loads(patch_call[1]["input"])
+        assert "TICKET-456" in patch_payload["body"]
+        assert "https://test-jira.example.com/browse/TICKET-456" in patch_payload["body"]
 
-        # Verify reviewers API call
-        reviewers_call = mock_client.post.call_args_list[1]
-        assert (
-            reviewers_call[0][0]
-            == "https://api.github.com/repos/RedHatInsights/hcc-ai-assistant/pulls/123/requested_reviewers"
-        )
-        assert reviewers_call[1]["json"]["reviewers"] == ["user1", "user2"]
+        reviewers_call = mock_run.call_args_list[3]
+        assert "requested_reviewers" in " ".join(reviewers_call[0][0])
+        reviewers_payload = json.loads(reviewers_call[1]["input"])
+        assert reviewers_payload["reviewers"] == ["user1", "user2"]
 
     def test_task_update_dry_run(self, temp_dir):
         """Test GitHub PR update in dry-run mode."""
         operations = PostPROperations(
-            github_token="test-token",
-            jira_url="https://test.atlassian.net",
-            jira_token="test-jira-token",
-            jira_email="test@example.com",
             slack_webhook="https://hooks.slack.com/test",
             memory_store_path=str(temp_dir / "memory.json"),
             dry_run=True,
@@ -122,26 +123,14 @@ class TestTaskUpdate:
         assert result.details["owner"] == "test"
         assert result.details["repo"] == "repo"
 
-    @patch("scripts.post_pr_operations.httpx.Client")
-    def test_task_update_no_reviewers(self, mock_client_class, operations):
+    @patch("scripts.post_pr_operations.subprocess.run")
+    def test_task_update_no_reviewers(self, mock_run, operations):
         """Test GitHub PR update without reviewers."""
-        # Mock HTTP responses
-        mock_client = Mock()
-        mock_client_class.return_value.__enter__.return_value = mock_client
-
-        mock_post_response = Mock()
-        mock_post_response.raise_for_status = Mock()
-
-        mock_get_response = Mock()
-        mock_get_response.raise_for_status = Mock()
-        mock_get_response.json.return_value = {"body": "Existing PR description"}
-
-        mock_patch_response = Mock()
-        mock_patch_response.raise_for_status = Mock()
-
-        mock_client.post.return_value = mock_post_response
-        mock_client.get.return_value = mock_get_response
-        mock_client.patch.return_value = mock_patch_response
+        mock_run.side_effect = _mock_subprocess_run([
+            {"stdout": json.dumps([{"name": "code-review"}])},
+            {"stdout": json.dumps({"body": "Existing PR description"})},
+            {"stdout": json.dumps({"body": "Updated"})},
+        ])
 
         result = operations.task_update(
             pr_url="https://github.com/test/repo/pull/3", pr_number=3, ticket_id="TICKET-111", reviewers=None
@@ -149,71 +138,75 @@ class TestTaskUpdate:
 
         assert result.status == OperationStatus.SUCCESS
         assert result.details["reviewers_requested"] == []
-
-        # Verify API calls: labels + get PR + patch PR (no reviewers call)
-        assert mock_client.post.call_count == 1  # labels only
-        assert mock_client.get.call_count == 1  # get PR
-        assert mock_client.patch.call_count == 1  # update PR
-
-    def test_task_update_no_github_token(self, temp_dir, monkeypatch):
-        """Test GitHub PR update fails without token."""
-        # Clear env vars that would provide fallback tokens
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        monkeypatch.delenv("GH_TOKEN", raising=False)
-
-        operations = PostPROperations(
-            github_token="",
-            jira_url="https://test.atlassian.net",
-            jira_token="test-jira-token",
-            jira_email="test@example.com",
-            slack_webhook="https://hooks.slack.com/test",
-            memory_store_path=str(temp_dir / "memory.json"),
-        )
-
-        result = operations.task_update(
-            pr_url="https://github.com/test/repo/pull/4", pr_number=4, ticket_id="TICKET-222", reviewers=None
-        )
-
-        assert result.status == OperationStatus.FAILED
-        assert "GitHub token not configured" in result.message
+        assert mock_run.call_count == 3  # labels, get PR, patch PR
 
     def test_task_update_invalid_url(self, operations):
-        """Test GitHub PR update with invalid URL."""
+        """Test PR update with invalid URL."""
         result = operations.task_update(
             pr_url="https://invalid.com/not/a/pr", pr_number=5, ticket_id="TICKET-333", reviewers=None
         )
 
         assert result.status == OperationStatus.FAILED
-        assert "Invalid GitHub PR URL" in result.message
+        assert "Unsupported PR URL" in result.message
+
+    @patch("scripts.post_pr_operations.subprocess.run")
+    def test_task_update_gh_cli_failure(self, mock_run, operations):
+        """Test GitHub PR update when gh CLI fails."""
+        mock_run.side_effect = _mock_subprocess_run([
+            {"returncode": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        ])
+
+        result = operations.task_update(
+            pr_url="https://github.com/test/repo/pull/99", pr_number=99, ticket_id="TICKET-999", reviewers=None
+        )
+
+        assert result.status == OperationStatus.FAILED
+        assert "Failed to add labels" in result.message
+
+    @patch("scripts.post_pr_operations.subprocess.run")
+    def test_task_update_gitlab_success(self, mock_run, operations):
+        """Test successful GitLab MR update via glab CLI."""
+        mock_run.side_effect = _mock_subprocess_run([
+            {"stdout": json.dumps({"labels": ["code-review", "awaiting-review"]})},
+            {"stdout": json.dumps({"description": "Existing MR description"})},
+            {"stdout": json.dumps({"description": "Updated"})},
+            {"stdout": json.dumps([{"id": 42, "username": "reviewer1"}])},
+            {"stdout": json.dumps({"reviewers": [{"id": 42}]})},
+        ])
+
+        result = operations.task_update(
+            pr_url="https://gitlab.cee.redhat.com/insights-qe/test-repo/-/merge_requests/5",
+            pr_number=5,
+            ticket_id="TICKET-GL1",
+            reviewers=["reviewer1"],
+        )
+
+        assert result.status == OperationStatus.SUCCESS
+        assert result.details["owner"] == "insights-qe"
+        assert result.details["repo"] == "test-repo"
+        assert result.details["jira_ticket"] == "TICKET-GL1"
+
+        labels_call = mock_run.call_args_list[0]
+        assert "--hostname" in labels_call[0][0]
+        assert "gitlab.cee.redhat.com" in labels_call[0][0]
 
 
 class TestJiraTransitionIssue:
-    """Test jira_transition_issue operation."""
+    """Test jira_transition_issue operation (via MCP)."""
 
-    @patch("scripts.post_pr_operations.httpx.Client")
-    def test_jira_transition_success(self, mock_client_class, operations):
-        """Test successful JIRA transition."""
-        # Mock HTTP responses
-        mock_client = Mock()
-        mock_client_class.return_value.__enter__.return_value = mock_client
-
-        # Mock GET transitions response
-        mock_get_response = Mock()
-        mock_get_response.raise_for_status = Mock()
-        mock_get_response.json.return_value = {
-            "transitions": [
-                {"id": "11", "to": {"name": "In Progress"}},
-                {"id": "21", "to": {"name": "Code Review"}},
-                {"id": "31", "to": {"name": "Done"}},
-            ]
-        }
-
-        # Mock POST transition response
-        mock_post_response = Mock()
-        mock_post_response.raise_for_status = Mock()
-
-        mock_client.get.return_value = mock_get_response
-        mock_client.post.return_value = mock_post_response
+    @patch("scripts.post_pr_operations.jira_call")
+    def test_jira_transition_success(self, mock_jira_call, operations):
+        """Test successful JIRA transition via MCP."""
+        mock_jira_call.side_effect = [
+            {
+                "transitions": [
+                    {"id": "11", "to": {"name": "In Progress"}},
+                    {"id": "21", "to": {"name": "Code Review"}},
+                    {"id": "31", "to": {"name": "Done"}},
+                ]
+            },
+            {"success": True},
+        ]
 
         result = operations.jira_transition_issue(ticket_id="TICKET-123", target_status="Code Review")
 
@@ -221,121 +214,73 @@ class TestJiraTransitionIssue:
         assert result.operation == "jira_transition_issue"
         assert "TICKET-123" in result.message
         assert result.details["status"] == "Code Review"
-        assert "jira_url" in result.details
 
-        # Verify GET request to fetch available transitions (API v3 with Basic auth)
-        mock_client.get.assert_called_once_with(
-            "https://test-jira.example.com/rest/api/3/issue/TICKET-123/transitions",
-            headers={
-                "Authorization": "Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LWppcmEtdG9rZW4=",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
-            timeout=30.0,
-        )
+        assert mock_jira_call.call_count == 2
+        mock_jira_call.assert_any_call("jira_get_transitions", {"issue_key": "TICKET-123"})
+        mock_jira_call.assert_any_call("jira_transition_issue", {"issue_key": "TICKET-123", "transition_id": "21"})
 
-        # Verify POST request to execute the transition with correct transition ID
-        mock_client.post.assert_called_once_with(
-            "https://test-jira.example.com/rest/api/3/issue/TICKET-123/transitions",
-            headers={
-                "Authorization": "Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LWppcmEtdG9rZW4=",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
-            json={"transition": {"id": "21"}},  # ID for "Code Review"
-            timeout=30.0,
-        )
-
-    def test_jira_transition_no_token(self, temp_dir, monkeypatch):
-        """Test JIRA transition fails without token."""
-        monkeypatch.delenv("POST_PR_JIRA_TOKEN", raising=False)
-        operations = PostPROperations(
-            github_token="test-token",
-            jira_url="https://test.atlassian.net",
-            jira_token="",
-            jira_email="test@example.com",
-            slack_webhook="https://hooks.slack.com/test",
-            memory_store_path=str(temp_dir / "memory.json"),
-        )
+    @patch("scripts.post_pr_operations.jira_call")
+    def test_jira_transition_mcp_unavailable(self, mock_jira_call, operations):
+        """Test JIRA transition fails when MCP returns None."""
+        mock_jira_call.return_value = None
 
         result = operations.jira_transition_issue(ticket_id="TICKET-456")
 
         assert result.status == OperationStatus.FAILED
-        assert "JIRA token not configured" in result.message
+        assert "Failed to get transitions" in result.message
 
-    @patch("scripts.post_pr_operations.httpx.Client")
-    def test_jira_transition_invalid_status(self, mock_client_class, operations):
+    @patch("scripts.post_pr_operations.jira_call")
+    def test_jira_transition_invalid_status(self, mock_jira_call, operations):
         """Test JIRA transition fails when target status doesn't exist."""
-        # Mock HTTP responses
-        mock_client = Mock()
-        mock_client_class.return_value.__enter__.return_value = mock_client
-
-        mock_get_response = Mock()
-        mock_get_response.raise_for_status = Mock()
-        mock_get_response.json.return_value = {
+        mock_jira_call.return_value = {
             "transitions": [
                 {"id": "11", "to": {"name": "In Progress"}},
                 {"id": "21", "to": {"name": "Code Review"}},
             ]
         }
-
-        mock_client.get.return_value = mock_get_response
 
         result = operations.jira_transition_issue(ticket_id="TICKET-999", target_status="Nonexistent Status")
 
         assert result.status == OperationStatus.FAILED
         assert "Cannot transition to 'Nonexistent Status'" in result.message
         assert "Available transitions:" in result.message
-        # Verify POST was never called since transition wasn't found
-        mock_client.post.assert_not_called()
+        assert mock_jira_call.call_count == 1
 
-    @patch("scripts.post_pr_operations.httpx.Client")
-    def test_jira_transition_custom_status(self, mock_client_class, operations):
+    @patch("scripts.post_pr_operations.jira_call")
+    def test_jira_transition_custom_status(self, mock_jira_call, operations):
         """Test JIRA transition to custom status."""
-        # Mock HTTP responses
-        mock_client = Mock()
-        mock_client_class.return_value.__enter__.return_value = mock_client
-
-        mock_get_response = Mock()
-        mock_get_response.raise_for_status = Mock()
-        mock_get_response.json.return_value = {
-            "transitions": [
-                {"id": "11", "to": {"name": "In Progress"}},
-                {"id": "21", "to": {"name": "Code Review"}},
-            ]
-        }
-
-        mock_post_response = Mock()
-        mock_post_response.raise_for_status = Mock()
-
-        mock_client.get.return_value = mock_get_response
-        mock_client.post.return_value = mock_post_response
+        mock_jira_call.side_effect = [
+            {
+                "transitions": [
+                    {"id": "11", "to": {"name": "In Progress"}},
+                    {"id": "21", "to": {"name": "Code Review"}},
+                ]
+            },
+            {"success": True},
+        ]
 
         result = operations.jira_transition_issue(ticket_id="TICKET-789", target_status="In Progress")
 
         assert result.status == OperationStatus.SUCCESS
         assert result.details["status"] == "In Progress"
+        mock_jira_call.assert_any_call("jira_transition_issue", {"issue_key": "TICKET-789", "transition_id": "11"})
 
-        # Verify correct transition ID was used for "In Progress"
-        mock_client.post.assert_called_once()
-        call_args = mock_client.post.call_args
-        assert call_args[1]["json"]["transition"]["id"] == "11"
+    def test_jira_transition_dry_run(self, operations):
+        """Test JIRA transition in dry-run mode skips MCP calls."""
+        operations.dry_run = True
+        result = operations.jira_transition_issue(ticket_id="TICKET-DRY")
+
+        assert result.status == OperationStatus.SUCCESS
+        assert result.details["status"] == "Code Review"
 
 
 class TestJiraAddComment:
-    """Test jira_add_comment operation."""
+    """Test jira_add_comment operation (via MCP)."""
 
-    @patch("scripts.post_pr_operations.httpx.Client")
-    def test_jira_add_comment_success(self, mock_client_class, operations):
-        """Test successful JIRA comment."""
-        # Mock HTTP responses
-        mock_client = Mock()
-        mock_client_class.return_value.__enter__.return_value = mock_client
-
-        mock_post_response = Mock()
-        mock_post_response.raise_for_status = Mock()
-
-        mock_client.post.return_value = mock_post_response
+    @patch("scripts.post_pr_operations.jira_call")
+    def test_jira_add_comment_success(self, mock_jira_call, operations):
+        """Test successful JIRA comment via MCP."""
+        mock_jira_call.return_value = {"id": "12345"}
 
         result = operations.jira_add_comment(
             ticket_id="TICKET-123", pr_url="https://github.com/test/repo/pull/1", summary="Test PR summary"
@@ -347,54 +292,31 @@ class TestJiraAddComment:
         assert "Test PR summary" in result.details["comment"]
         assert "https://github.com/test/repo/pull/1" in result.details["comment"]
 
-        # Verify POST request with ADF format comment (API v3 with Basic auth)
-        expected_comment_adf = {
-            "body": {
-                "type": "doc",
-                "version": 1,
-                "content": [
-                    {
-                        "type": "paragraph",
-                        "content": [
-                            {"type": "text", "text": "Pull Request created: https://github.com/test/repo/pull/1"}
-                        ],
-                    },
-                    {
-                        "type": "paragraph",
-                        "content": [{"type": "text", "text": "Summary: Test PR summary"}],
-                    },
-                ],
-            }
-        }
-        mock_client.post.assert_called_once_with(
-            "https://test-jira.example.com/rest/api/3/issue/TICKET-123/comment",
-            headers={
-                "Authorization": "Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LWppcmEtdG9rZW4=",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
-            json=expected_comment_adf,
-            timeout=30.0,
-        )
+        mock_jira_call.assert_called_once_with("jira_add_comment", {
+            "issue_key": "TICKET-123",
+            "body": "Pull Request created: https://github.com/test/repo/pull/1\n\nSummary: Test PR summary",
+        })
 
-    def test_jira_add_comment_no_token(self, temp_dir, monkeypatch):
-        """Test JIRA comment fails without token."""
-        monkeypatch.delenv("POST_PR_JIRA_TOKEN", raising=False)
-        operations = PostPROperations(
-            github_token="test-token",
-            jira_url="https://test.atlassian.net",
-            jira_token="",
-            jira_email="test@example.com",
-            slack_webhook="https://hooks.slack.com/test",
-            memory_store_path=str(temp_dir / "memory.json"),
-        )
+    @patch("scripts.post_pr_operations.jira_call")
+    def test_jira_add_comment_mcp_fails(self, mock_jira_call, operations):
+        """Test JIRA comment fails when MCP returns None."""
+        mock_jira_call.return_value = None
 
         result = operations.jira_add_comment(
             ticket_id="TICKET-456", pr_url="https://github.com/test/repo/pull/2", summary="Test"
         )
 
         assert result.status == OperationStatus.FAILED
-        assert "JIRA token not configured" in result.message
+        assert "Failed to add comment" in result.message
+
+    def test_jira_add_comment_dry_run(self, operations):
+        """Test JIRA comment in dry-run mode skips MCP calls."""
+        operations.dry_run = True
+        result = operations.jira_add_comment(
+            ticket_id="TICKET-DRY", pr_url="https://github.com/test/repo/pull/3", summary="Dry run"
+        )
+
+        assert result.status == OperationStatus.SUCCESS
 
 
 class TestSlackNotify:
@@ -403,7 +325,6 @@ class TestSlackNotify:
     @patch("scripts.post_pr_operations.httpx.Client")
     def test_slack_notify_success(self, mock_client_class, operations):
         """Test successful Slack notification."""
-        # Mock HTTP responses
         mock_client = Mock()
         mock_client_class.return_value.__enter__.return_value = mock_client
 
@@ -421,28 +342,21 @@ class TestSlackNotify:
         assert "#test-channel" in result.message
         assert result.details["channel"] == "#test-channel"
 
-        # Verify Slack webhook POST call
         mock_client.post.assert_called_once()
         call_args = mock_client.post.call_args
 
-        # Verify webhook URL
         assert call_args[0][0] == "https://hooks.slack.com/test"
-
-        # Verify timeout
         assert call_args[1]["timeout"] == 30.0
 
-        # Verify message structure
         message_json = call_args[1]["json"]
         assert message_json["channel"] == "#test-channel"
         assert message_json["text"] == "New PR created: #1"
         assert "attachments" in message_json
         assert len(message_json["attachments"]) == 1
 
-        # Verify attachment details
         attachment = message_json["attachments"][0]
         assert attachment["color"] == "good"
 
-        # Verify fields in attachment
         fields = attachment["fields"]
         assert len(fields) == 2
         assert fields[0]["title"] == "PR"
@@ -456,10 +370,6 @@ class TestSlackNotify:
         """Test Slack notification fails without webhook."""
         monkeypatch.delenv("POST_PR_SLACK_WEBHOOK", raising=False)
         operations = PostPROperations(
-            github_token="test-token",
-            jira_url="https://test.atlassian.net",
-            jira_token="test-jira-token",
-            jira_email="test@example.com",
             slack_webhook="",
             memory_store_path=str(temp_dir / "memory.json"),
         )
@@ -474,7 +384,6 @@ class TestSlackNotify:
     @patch("scripts.post_pr_operations.httpx.Client")
     def test_slack_notify_default_channel(self, mock_client_class, operations):
         """Test Slack notification with default channel."""
-        # Mock HTTP responses
         mock_client = Mock()
         mock_client_class.return_value.__enter__.return_value = mock_client
 
@@ -488,7 +397,6 @@ class TestSlackNotify:
         assert result.status == OperationStatus.SUCCESS
         assert result.details["channel"] == "#hcc-ai-assistant"
 
-        # Verify default channel was used in the message
         call_args = mock_client.post.call_args
         message_json = call_args[1]["json"]
         assert message_json["channel"] == "#hcc-ai-assistant"
@@ -513,7 +421,6 @@ class TestMemoryStore:
         assert result.operation == "memory_store"
         assert result.details["learnings"] == learnings
 
-        # Verify file was written
         memory_file = Path(operations.memory_store_path)
         assert memory_file.exists()
         with open(memory_file, "r") as f:
@@ -524,21 +431,18 @@ class TestMemoryStore:
 
     def test_memory_store_append(self, operations):
         """Test memory storage appends to existing file."""
-        # First entry
         operations.memory_store(
             pr_url="https://github.com/test/repo/pull/1",
             ticket_id="TICKET-123",
             learnings={"patterns": ["Pattern 1"]},
         )
 
-        # Second entry
         operations.memory_store(
             pr_url="https://github.com/test/repo/pull/2",
             ticket_id="TICKET-456",
             learnings={"patterns": ["Pattern 2"]},
         )
 
-        # Verify both entries exist
         with open(operations.memory_store_path, "r") as f:
             memories = json.load(f)
             assert len(memories) == 2
@@ -548,10 +452,6 @@ class TestMemoryStore:
     def test_memory_store_dry_run(self, temp_dir):
         """Test memory storage in dry-run mode."""
         operations = PostPROperations(
-            github_token="test-token",
-            jira_url="https://test.atlassian.net",
-            jira_token="test-jira-token",
-            jira_email="test@example.com",
             slack_webhook="https://hooks.slack.com/test",
             memory_store_path=str(temp_dir / "memory.json"),
             dry_run=True,
@@ -562,7 +462,6 @@ class TestMemoryStore:
         )
 
         assert result.status == OperationStatus.SUCCESS
-        # File should not be created in dry-run mode
         assert not Path(operations.memory_store_path).exists()
 
 
@@ -578,7 +477,6 @@ class TestBotStatusUpdate:
         assert "idle" in result.message
         assert result.details["status"] == "idle"
 
-        # Verify status file was written
         status_file = Path("/tmp/bot_status.json")
         assert status_file.exists()
         with open(status_file, "r") as f:
@@ -595,10 +493,6 @@ class TestBotStatusUpdate:
     def test_bot_status_update_dry_run(self, temp_dir):
         """Test bot status update in dry-run mode."""
         operations = PostPROperations(
-            github_token="test-token",
-            jira_url="https://test.atlassian.net",
-            jira_token="test-jira-token",
-            jira_email="test@example.com",
             slack_webhook="https://hooks.slack.com/test",
             memory_store_path=str(temp_dir / "memory.json"),
             dry_run=True,
@@ -622,7 +516,7 @@ class TestOperationResult:
         assert result.status == OperationStatus.SUCCESS
         assert result.message == "Test message"
         assert result.details == {"key": "value"}
-        assert result.timestamp  # Should have a timestamp
+        assert result.timestamp
 
     def test_operation_result_failed_status(self):
         """Test OperationResult with failed status."""
@@ -659,3 +553,40 @@ class TestWorkflowResult:
         assert len(result_dict["operations"]) == 2
         assert result_dict["operations"][0]["status"] == "success"
         assert result_dict["operations"][1]["status"] == "failed"
+
+
+class TestParseURL:
+    """Test URL parsing for GitHub and GitLab."""
+
+    def test_parse_github_url(self, operations):
+        """Test parsing GitHub PR URL."""
+        info = operations._parse_pr_url("https://github.com/RedHatInsights/hcc-ai-assistant/pull/123")
+        assert info["host"] == "github"
+        assert info["owner"] == "RedHatInsights"
+        assert info["repo"] == "hcc-ai-assistant"
+
+    def test_parse_gitlab_url(self, operations):
+        """Test parsing GitLab MR URL."""
+        info = operations._parse_pr_url(
+            "https://gitlab.cee.redhat.com/insights-qe/test-repo/-/merge_requests/5"
+        )
+        assert info["host"] == "gitlab"
+        assert info["hostname"] == "gitlab.cee.redhat.com"
+        assert info["owner"] == "insights-qe"
+        assert info["repo"] == "test-repo"
+        assert info["project_path"] == "insights-qe/test-repo"
+
+    def test_parse_gitlab_nested_url(self, operations):
+        """Test parsing GitLab MR URL with nested groups."""
+        info = operations._parse_pr_url(
+            "https://gitlab.cee.redhat.com/service/platform/backend/-/merge_requests/42"
+        )
+        assert info["host"] == "gitlab"
+        assert info["owner"] == "service/platform"
+        assert info["repo"] == "backend"
+        assert info["project_path"] == "service/platform/backend"
+
+    def test_parse_unsupported_url(self, operations):
+        """Test parsing unsupported URL raises error."""
+        with pytest.raises(ValueError, match="Unsupported PR URL"):
+            operations._parse_pr_url("https://bitbucket.org/team/repo/pull-requests/1")

--- a/.claude/skills/post-pr/tests/test_operations.py
+++ b/.claude/skills/post-pr/tests/test_operations.py
@@ -587,6 +587,21 @@ class TestParseURL:
         assert info["repo"] == "backend"
         assert info["project_path"] == "service/platform/backend"
 
+    def test_parse_github_issues_url_rejected(self, operations):
+        """Test that GitHub issues URL is rejected (not a PR)."""
+        with pytest.raises(ValueError, match="Invalid GitHub PR URL"):
+            operations._parse_pr_url("https://github.com/org/repo/issues/123")
+
+    def test_parse_selfhosted_gitlab_url(self, operations):
+        """Test parsing self-hosted GitLab MR URL (detected by path pattern)."""
+        info = operations._parse_pr_url(
+            "https://gitlab.internal.example.com/team/project/-/merge_requests/10"
+        )
+        assert info["host"] == "gitlab"
+        assert info["hostname"] == "gitlab.internal.example.com"
+        assert info["owner"] == "team"
+        assert info["repo"] == "project"
+
     def test_parse_unsupported_url(self, operations):
         """Test parsing unsupported URL raises error."""
         with pytest.raises(ValueError, match="Unsupported PR URL"):


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #154 — the post-pr skill was still trying to use direct API tokens (Jira, GitHub, GitLab) that are no longer available in the container.

- **Jira**: Replaced `httpx` token auth with shared `jira_call()` MCP client
- **GitHub**: Replaced `httpx` + `GITHUB_TOKEN` with `gh api` CLI (pre-authenticated)
- **GitLab**: Added new `glab api --hostname` support (didn't exist before)
- **Slack**: Kept `httpx` — webhook URL is self-contained, no separate auth needed

Removes `github_token` parameter from constructor, workflow function, and CLI args. All 69 tests pass (up from 35 — added URL parsing, GitLab MR, and CLI failure tests).

RHCLOUD-47706

## Test plan

- [x] `uv run pytest -v` — all 69 tests pass
- [x] Container tested end-to-end by Martin
- [x] Verify `gh api` calls work in container
- [x] Verify `glab api` calls work for GitLab repos
- [x] Verify Slack webhook still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)