### PR TITLE
feat(dashboard): multi-instance view with drill-down

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -59,6 +59,18 @@ header {
   object-fit: cover;
 }
 
+.header-home {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  cursor: pointer;
+}
+.header-home:hover {
+  text-decoration: none;
+  opacity: 0.85;
+}
+
 .header-title {
   font-size: 24px;
   font-weight: 700;
@@ -66,6 +78,20 @@ header {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+}
+
+.instance-selector {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+}
+.instance-selector:focus {
+  border-color: var(--accent);
 }
 
 .header-right {
@@ -272,6 +298,112 @@ header {
 }
 .banner-toggle:hover {
   color: var(--text);
+}
+
+/* Breadcrumb */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  margin-bottom: 12px;
+  color: var(--text-dim);
+}
+.breadcrumb a {
+  color: var(--accent);
+  font-weight: 500;
+}
+.breadcrumb-sep {
+  color: var(--text-dim);
+  opacity: 0.5;
+}
+.breadcrumb-current {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* Instance grid */
+.instance-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.instance-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  border-left: 3px solid var(--border);
+}
+.instance-card:hover {
+  border-color: var(--text-dim);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+.instance-card.state-working {
+  border-left-color: var(--yellow);
+}
+.instance-card.state-idle {
+  border-left-color: var(--green);
+}
+.instance-card.state-error {
+  border-left-color: var(--red);
+}
+
+.instance-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.instance-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.instance-name {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.instance-message {
+  font-size: 13px;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.instance-card-meta {
+  display: flex;
+  gap: 10px;
+  font-size: 13px;
+  margin-bottom: 10px;
+}
+
+.instance-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-dim);
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.instance-tasks {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.instance-updated {
+  color: var(--text-dim);
 }
 
 /* Tab nav */

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,29 +1,91 @@
-import { useEffect, useState, useCallback } from 'react';
-import { HashRouter, Routes, Route, NavLink, Navigate } from 'react-router-dom';
+import { lazy, Suspense, useEffect, useState, useCallback } from 'react';
+import { HashRouter, Routes, Route, NavLink, Navigate, useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { WSProvider, useWS } from './hooks/useWebSocket';
-import type { BotStatus } from './types';
-import { fetchStats, fetchBotStatus } from './api';
+import type { BotInstance } from './types';
+import { fetchStats, fetchInstances } from './api';
 import BotBanner from './components/BotBanner';
 import Toasts from './components/Toasts';
-import Tasks from './pages/Tasks';
-import Memories from './pages/Memories';
-import Search from './pages/Search';
-import Costs from './pages/Costs';
-import EmbeddingMap from './pages/EmbeddingMap';
-import ArchivedTasks from './pages/ArchivedTasks';
+
+const Instances = lazy(() => import('./pages/Instances'));
+const Tasks = lazy(() => import('./pages/Tasks'));
+const Memories = lazy(() => import('./pages/Memories'));
+const Search = lazy(() => import('./pages/Search'));
+const Costs = lazy(() => import('./pages/Costs'));
+const EmbeddingMap = lazy(() => import('./pages/EmbeddingMap'));
+const ArchivedTasks = lazy(() => import('./pages/ArchivedTasks'));
+
+function InstanceSelector({ instances, currentId }: { instances: BotInstance[]; currentId?: string }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    if (val === '__global__') {
+      navigate('/tasks');
+    } else if (val === '__instances__') {
+      navigate('/instances');
+    } else {
+      const subPath = location.pathname.match(/\/instances\/[^/]+\/(.*)/)?.[1] || 'tasks';
+      navigate(`/instances/${encodeURIComponent(val)}/${subPath}`);
+    }
+  };
+
+  return (
+    <select
+      className="instance-selector"
+      value={currentId || '__global__'}
+      onChange={handleChange}
+    >
+      <option value="__global__">All instances</option>
+      <option value="__instances__">Overview</option>
+      {instances.map((inst) => (
+        <option key={inst.instance_id} value={inst.instance_id}>
+          {inst.instance_id} — {inst.state.toUpperCase()}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function InstanceScoped() {
+  const { id } = useParams<{ id: string }>();
+  const instanceId = decodeURIComponent(id || '');
+  const base = `/instances/${encodeURIComponent(instanceId)}`;
+
+  return (
+    <>
+      <nav className="tab-nav">
+        <NavLink to={`${base}/tasks`}>Tasks</NavLink>
+        <NavLink to={`${base}/archived`}>Archive</NavLink>
+        <NavLink to={`${base}/memories`}>Memories</NavLink>
+        <NavLink to={`${base}/search`}>Search</NavLink>
+        <NavLink to={`${base}/costs`}>Costs</NavLink>
+        <NavLink to={`${base}/viz`}>Viz</NavLink>
+      </nav>
+      <Suspense fallback={null}>
+        <Routes>
+          <Route path="tasks" element={<Tasks instanceId={instanceId} />} />
+          <Route path="archived" element={<ArchivedTasks instanceId={instanceId} />} />
+          <Route path="memories" element={<Memories />} />
+          <Route path="search" element={<Search />} />
+          <Route path="costs" element={<Costs />} />
+          <Route path="viz" element={<EmbeddingMap />} />
+          <Route path="" element={<Navigate to="tasks" replace />} />
+        </Routes>
+      </Suspense>
+    </>
+  );
+}
 
 function AppInner() {
   const [stats, setStats] = useState<{ tasks: number; memories: number }>({ tasks: 0, memories: 0 });
-  const [botStatus, setBotStatus] = useState<BotStatus>({
-    state: 'unknown',
-    message: 'Loading...',
-    jira_key: null,
-    repo: null,
-    instance_id: null,
-    cycle_start: null,
-    updated_at: new Date().toISOString(),
-  });
+  const [instances, setInstances] = useState<BotInstance[]>([]);
   const { connected, onEvent } = useWS();
+  const location = useLocation();
+
+  const instanceMatch = location.pathname.match(/\/instances\/([^/]+)/);
+  const currentInstanceId = instanceMatch ? decodeURIComponent(instanceMatch[1]) : undefined;
+  const currentInstance = instances.find((i) => i.instance_id === currentInstanceId);
 
   const loadStats = useCallback(async () => {
     try {
@@ -35,15 +97,23 @@ function AppInner() {
     }
   }, []);
 
+  const loadInstances = useCallback(async () => {
+    try {
+      setInstances(await fetchInstances());
+    } catch {
+      // ignore
+    }
+  }, []);
+
   useEffect(() => {
     loadStats();
-    fetchBotStatus().then((s: BotStatus) => setBotStatus(s)).catch(() => {});
-  }, [loadStats]);
+    loadInstances();
+  }, [loadStats, loadInstances]);
 
   useEffect(() => {
     const unsub = onEvent((event) => {
       if (event.type === 'bot_status') {
-        setBotStatus(event.data);
+        loadInstances();
       }
       if (
         event.type === 'task_added' ||
@@ -53,17 +123,21 @@ function AppInner() {
         event.type === 'memory_deleted'
       ) {
         loadStats();
+        loadInstances();
       }
     });
     return unsub;
-  }, [onEvent, loadStats]);
+  }, [onEvent, loadStats, loadInstances]);
 
   return (
     <div className="app">
       <header>
         <div className="header-left">
-          <img src="/static/icon.png" alt="" className="header-icon" />
-          <h1 className="header-title">Řehoř</h1>
+          <Link to="/instances" className="header-home">
+            <img src="/static/icon.png" alt="" className="header-icon" />
+            <h1 className="header-title">Řehoř</h1>
+          </Link>
+          <InstanceSelector instances={instances} currentId={currentInstanceId} />
         </div>
         <div className="header-right">
           <div className="stats-bar">
@@ -74,28 +148,44 @@ function AppInner() {
         </div>
       </header>
 
-      <BotBanner status={botStatus} />
+      {currentInstance && (
+        <BotBanner status={{
+          state: currentInstance.state,
+          message: currentInstance.message,
+          jira_key: currentInstance.jira_key,
+          repo: currentInstance.repo,
+          instance_id: currentInstance.instance_id,
+          cycle_start: currentInstance.cycle_start,
+          updated_at: currentInstance.updated_at,
+        }} />
+      )}
+
       <Toasts />
 
-      <nav className="tab-nav">
-        <NavLink to="/tasks">Tasks</NavLink>
-        <NavLink to="/archived">Archive</NavLink>
-        <NavLink to="/memories">Memories</NavLink>
-        <NavLink to="/search">Search</NavLink>
-        <NavLink to="/costs">Costs</NavLink>
-        <NavLink to="/viz">Viz</NavLink>
-      </nav>
-
       <main>
-        <Routes>
-          <Route path="/tasks" element={<Tasks />} />
-          <Route path="/archived" element={<ArchivedTasks />} />
-          <Route path="/memories" element={<Memories />} />
-          <Route path="/search" element={<Search />} />
-          <Route path="/costs" element={<Costs />} />
-          <Route path="/viz" element={<EmbeddingMap />} />
-          <Route path="/" element={<Navigate to="/tasks" replace />} />
-        </Routes>
+        {!currentInstanceId && (
+          <nav className="tab-nav">
+            <NavLink to="/tasks">Tasks</NavLink>
+            <NavLink to="/archived">Archive</NavLink>
+            <NavLink to="/memories">Memories</NavLink>
+            <NavLink to="/search">Search</NavLink>
+            <NavLink to="/costs">Costs</NavLink>
+            <NavLink to="/viz">Viz</NavLink>
+          </nav>
+        )}
+        <Suspense fallback={null}>
+          <Routes>
+            <Route path="/instances/:id/*" element={<InstanceScoped />} />
+            <Route path="/instances" element={<Instances />} />
+            <Route path="/tasks" element={<Tasks />} />
+            <Route path="/archived" element={<ArchivedTasks />} />
+            <Route path="/memories" element={<Memories />} />
+            <Route path="/search" element={<Search />} />
+            <Route path="/costs" element={<Costs />} />
+            <Route path="/viz" element={<EmbeddingMap />} />
+            <Route path="/" element={<Navigate to="/instances" replace />} />
+          </Routes>
+        </Suspense>
       </main>
     </div>
   );

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -1,3 +1,5 @@
+import type { BotInstance } from './types';
+
 export async function fetchStats() {
   return (await fetch('/api/stats')).json();
 }
@@ -6,10 +8,15 @@ export async function fetchBotStatus() {
   return (await fetch('/api/bot-status')).json();
 }
 
-export async function fetchTasks(params: { status?: string; exclude_status?: string; limit?: number; offset?: number }) {
+export async function fetchInstances(): Promise<BotInstance[]> {
+  return (await fetch('/api/instances')).json();
+}
+
+export async function fetchTasks(params: { status?: string; exclude_status?: string; limit?: number; offset?: number; instance_id?: string }) {
   const qs = new URLSearchParams();
   if (params.status) qs.set('status', params.status);
   if (params.exclude_status) qs.set('exclude_status', params.exclude_status);
+  if (params.instance_id) qs.set('instance_id', params.instance_id);
   qs.set('limit', String(params.limit ?? 20));
   qs.set('offset', String(params.offset ?? 0));
   return (await fetch('/api/tasks?' + qs)).json();

--- a/dashboard/src/pages/ArchivedTasks.tsx
+++ b/dashboard/src/pages/ArchivedTasks.tsx
@@ -8,7 +8,7 @@ import Pagination from '../components/Pagination';
 
 const LIMIT = 20;
 
-export default function ArchivedTasks() {
+export default function ArchivedTasks({ instanceId }: { instanceId?: string }) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
@@ -17,10 +17,10 @@ export default function ArchivedTasks() {
   const { onEvent } = useWS();
 
   const load = useCallback(async () => {
-    const res = await fetchTasks({ status: 'archived', limit: LIMIT, offset });
+    const res = await fetchTasks({ status: 'archived', limit: LIMIT, offset, instance_id: instanceId });
     setTasks(res.items || []);
     setTotal(res.total || 0);
-  }, [offset]);
+  }, [offset, instanceId]);
 
   useEffect(() => {
     load();

--- a/dashboard/src/pages/Instances.tsx
+++ b/dashboard/src/pages/Instances.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { BotInstance } from '../types';
+import { fetchInstances } from '../api';
+import { useWS } from '../hooks/useWebSocket';
+import { timeAgo, JIRA_BASE } from '../utils';
+
+export default function Instances() {
+  const [instances, setInstances] = useState<BotInstance[]>([]);
+  const navigate = useNavigate();
+  const { onEvent } = useWS();
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchInstances();
+      setInstances(data);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    return onEvent((event) => {
+      if (event.type === 'bot_status') {
+        setInstances((prev) => {
+          const id = event.data.instance_id;
+          if (!id) return prev;
+          const idx = prev.findIndex((i) => i.instance_id === id);
+          if (idx >= 0) {
+            const updated = [...prev];
+            updated[idx] = { ...updated[idx], ...event.data };
+            return updated;
+          }
+          return [...prev, { ...event.data, active_tasks: 0, max_tasks: 10 }];
+        });
+      }
+      if (event.type === 'task_added' || event.type === 'task_updated' || event.type === 'task_archived') {
+        load();
+      }
+    });
+  }, [onEvent, load]);
+
+  return (
+    <div>
+      {instances.length === 0 && (
+        <div className="empty-state">No bot instances found</div>
+      )}
+      <div className="instance-grid">
+        {instances.map((inst) => (
+          <div
+            key={inst.instance_id}
+            className={`instance-card state-${inst.state}`}
+            onClick={() => navigate(`/instances/${encodeURIComponent(inst.instance_id)}/tasks`)}
+          >
+            <div className="instance-card-header">
+              <div className="instance-name-row">
+                <span className={`indicator-dot ${inst.state}`}>
+                  <span className="ping-ring" />
+                </span>
+                <span className="instance-name">{inst.instance_id}</span>
+              </div>
+              <span className={`state-badge ${inst.state}`}>
+                {inst.state.toUpperCase()}
+              </span>
+            </div>
+
+            <div className="instance-message" key={inst.message}>
+              {inst.message}
+            </div>
+
+            <div className="instance-card-meta">
+              {inst.jira_key && (
+                <a
+                  href={JIRA_BASE + inst.jira_key}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="banner-jira"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {inst.jira_key}
+                </a>
+              )}
+              {inst.repo && <span className="banner-repo">{inst.repo}</span>}
+            </div>
+
+            <div className="instance-card-footer">
+              <span className="instance-tasks">
+                {inst.active_tasks}/{inst.max_tasks} tasks
+              </span>
+              <span className="instance-updated" title={inst.updated_at}>
+                {timeAgo(inst.updated_at)}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/Tasks.tsx
+++ b/dashboard/src/pages/Tasks.tsx
@@ -17,7 +17,7 @@ const STATUS_OPTIONS = [
 
 const LIMIT = 20;
 
-export default function Tasks() {
+export default function Tasks({ instanceId }: { instanceId?: string }) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [total, setTotal] = useState(0);
   const [status, setStatus] = useState('');
@@ -27,10 +27,16 @@ export default function Tasks() {
   const { onEvent } = useWS();
 
   const load = useCallback(async () => {
-    const res = await fetchTasks({ status: status || undefined, exclude_status: status ? undefined : 'archived', limit: LIMIT, offset });
+    const res = await fetchTasks({
+      status: status || undefined,
+      exclude_status: status ? undefined : 'archived',
+      limit: LIMIT,
+      offset,
+      instance_id: instanceId,
+    });
     setTasks(res.items || []);
     setTotal(res.total || 0);
-  }, [status, offset]);
+  }, [status, offset, instanceId]);
 
   useEffect(() => {
     load();

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -35,6 +35,18 @@ export interface Memory {
   similarity?: number;
 }
 
+export interface BotInstance {
+  instance_id: string;
+  state: 'working' | 'idle' | 'error' | 'unknown';
+  message: string;
+  jira_key: string | null;
+  repo: string | null;
+  cycle_start: string | null;
+  updated_at: string;
+  active_tasks: number;
+  max_tasks: number;
+}
+
 export interface BotStatus {
   state: 'working' | 'idle' | 'error' | 'unknown';
   message: string;

--- a/memory-server/src/api.py
+++ b/memory-server/src/api.py
@@ -15,33 +15,64 @@ async def api_tasks(request: Request) -> JSONResponse:
     status = request.query_params.get("status")
     limit = int(request.query_params.get("limit", "20"))
     offset = int(request.query_params.get("offset", "0"))
+    instance_id = request.query_params.get("instance_id")
 
     exclude = request.query_params.get("exclude_status")
 
+    instance_clause = ""
+    instance_params: list = []
+    if instance_id:
+        instance_clause = " AND instance_id = $__idx__"
+        instance_params = [instance_id]
+
     if status:
+        base_params = [status]
+        where = "WHERE status = $1::task_status"
+        if instance_id:
+            idx = len(base_params) + 1
+            where += f" AND instance_id = ${idx}"
+            base_params.append(instance_id)
+
         total = await pool.fetchval(
-            "SELECT COUNT(*) FROM tasks WHERE status = $1::task_status", status
+            f"SELECT COUNT(*) FROM tasks {where}", *base_params
         )
-        # Archived tasks sort by last_addressed (≈ archive time); others by created_at
         order_col = "last_addressed" if status == "archived" else "created_at"
+        base_params.extend([limit, offset])
         rows = await pool.fetch(
-            f"SELECT * FROM tasks WHERE status = $1::task_status ORDER BY {order_col} DESC LIMIT $2 OFFSET $3",
-            status, limit, offset,
+            f"SELECT * FROM tasks {where} ORDER BY {order_col} DESC LIMIT ${len(base_params) - 1} OFFSET ${len(base_params)}",
+            *base_params,
         )
     elif exclude:
+        base_params = [exclude]
+        where = "WHERE status != $1::task_status"
+        if instance_id:
+            idx = len(base_params) + 1
+            where += f" AND instance_id = ${idx}"
+            base_params.append(instance_id)
+
         total = await pool.fetchval(
-            "SELECT COUNT(*) FROM tasks WHERE status != $1::task_status", exclude
+            f"SELECT COUNT(*) FROM tasks {where}", *base_params
         )
+        base_params.extend([limit, offset])
         rows = await pool.fetch(
-            "SELECT * FROM tasks WHERE status != $1::task_status ORDER BY created_at DESC LIMIT $2 OFFSET $3",
-            exclude, limit, offset,
+            f"SELECT * FROM tasks {where} ORDER BY created_at DESC LIMIT ${len(base_params) - 1} OFFSET ${len(base_params)}",
+            *base_params,
         )
     else:
-        total = await pool.fetchval("SELECT COUNT(*) FROM tasks")
-        rows = await pool.fetch(
-            "SELECT * FROM tasks ORDER BY created_at DESC LIMIT $1 OFFSET $2",
-            limit, offset,
-        )
+        if instance_id:
+            total = await pool.fetchval(
+                "SELECT COUNT(*) FROM tasks WHERE instance_id = $1", instance_id
+            )
+            rows = await pool.fetch(
+                "SELECT * FROM tasks WHERE instance_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+                instance_id, limit, offset,
+            )
+        else:
+            total = await pool.fetchval("SELECT COUNT(*) FROM tasks")
+            rows = await pool.fetch(
+                "SELECT * FROM tasks ORDER BY created_at DESC LIMIT $1 OFFSET $2",
+                limit, offset,
+            )
 
     # Fetch latest Slack notification per task
     jira_keys = [r["jira_key"] for r in rows]
@@ -298,6 +329,40 @@ async def api_bot_status_update(request: Request) -> JSONResponse:
         "updated_at": row["updated_at"].isoformat(),
     }
     await bus.publish(Event("bot_status", result))
+    return JSONResponse(result)
+
+
+async def api_instances(request: Request) -> JSONResponse:
+    """GET /api/instances — list all bot instances with aggregated task counts."""
+    pool = get_pool()
+    instance_rows = await pool.fetch(
+        "SELECT * FROM bot_instances ORDER BY updated_at DESC"
+    )
+    # Count active tasks per instance
+    task_counts = await pool.fetch(
+        """
+        SELECT instance_id, COUNT(*) AS active
+        FROM tasks
+        WHERE status IN ('in_progress', 'pr_open', 'pr_changes')
+        AND instance_id IS NOT NULL
+        GROUP BY instance_id
+        """
+    )
+    counts_map = {r["instance_id"]: r["active"] for r in task_counts}
+
+    result = []
+    for r in instance_rows:
+        result.append({
+            "instance_id": r["instance_id"],
+            "state": r["state"],
+            "message": r["message"],
+            "jira_key": r["jira_key"],
+            "repo": r["repo"],
+            "cycle_start": r["cycle_start"].isoformat() if r["cycle_start"] else None,
+            "updated_at": r["updated_at"].isoformat(),
+            "active_tasks": counts_map.get(r["instance_id"], 0),
+            "max_tasks": 10,
+        })
     return JSONResponse(result)
 
 

--- a/memory-server/src/schema.sql
+++ b/memory-server/src/schema.sql
@@ -129,6 +129,28 @@ CREATE TABLE IF NOT EXISTS org_members (
     UNIQUE(username, org)
 );
 
+-- Multi-instance bot status tracking
+CREATE TABLE IF NOT EXISTS bot_instances (
+    instance_id     TEXT PRIMARY KEY,
+    state           TEXT NOT NULL DEFAULT 'idle',
+    message         TEXT NOT NULL DEFAULT '',
+    jira_key        TEXT,
+    repo            TEXT,
+    cycle_start     TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Migrate existing bot_status row into bot_instances (if instance_id is set)
+DO $$ BEGIN
+    INSERT INTO bot_instances (instance_id, state, message, jira_key, repo, cycle_start, updated_at)
+    SELECT instance_id, state, message, jira_key, repo, cycle_start, updated_at
+    FROM bot_status
+    WHERE id = 1 AND instance_id IS NOT NULL
+    ON CONFLICT (instance_id) DO NOTHING;
+EXCEPTION
+    WHEN undefined_table THEN NULL;
+END $$;
+
 -- Only create index if table has enough rows (ivfflat needs data)
 -- On first startup with empty table, queries fall back to sequential scan
 -- Re-run this after seeding data:

--- a/memory-server/src/server.py
+++ b/memory-server/src/server.py
@@ -75,7 +75,7 @@ async def asset_files(request: Request) -> FileResponse:
 
 
 # REST API for the dashboard
-from .api import api_tasks, api_task_delete, api_task_unarchive, api_memories, api_memory_get, api_memory_search, api_memory_embeddings, api_memory_delete, api_tags, api_stats, api_bot_status, api_costs, api_analytics
+from .api import api_tasks, api_task_delete, api_task_unarchive, api_memories, api_memory_get, api_memory_search, api_memory_embeddings, api_memory_delete, api_tags, api_stats, api_bot_status, api_instances, api_costs, api_analytics
 
 mcp.custom_route("/api/tasks", methods=["GET"])(api_tasks)
 mcp.custom_route("/api/tasks/{jira_key:path}", methods=["DELETE"])(api_task_delete)
@@ -86,6 +86,7 @@ mcp.custom_route("/api/memories/embeddings", methods=["GET"])(api_memory_embeddi
 mcp.custom_route("/api/memories/{id}", methods=["GET"])(api_memory_get)
 mcp.custom_route("/api/memories/{id}", methods=["DELETE"])(api_memory_delete)
 mcp.custom_route("/api/bot-status", methods=["GET", "POST"])(api_bot_status)
+mcp.custom_route("/api/instances", methods=["GET"])(api_instances)
 mcp.custom_route("/api/costs", methods=["GET", "POST"])(api_costs)
 mcp.custom_route("/api/tags", methods=["GET"])(api_tags)
 mcp.custom_route("/api/stats", methods=["GET"])(api_stats)

--- a/memory-server/src/tools/tasks.py
+++ b/memory-server/src/tools/tasks.py
@@ -250,6 +250,7 @@ def register_task_tools(mcp: FastMCP):
         repo: The repo being worked in (if any).
         instance_id: Bot instance name for multi-instance setups."""
         pool = get_pool()
+        # Legacy singleton update (backward compat)
         row = await pool.fetchrow(
             """
             UPDATE bot_status SET state = $1, message = $2, jira_key = $3, repo = $4,
@@ -260,12 +261,30 @@ def register_task_tools(mcp: FastMCP):
             """,
             state, message, jira_key, repo, instance_id,
         )
+        # Multi-instance upsert
+        if instance_id:
+            await pool.execute(
+                """
+                INSERT INTO bot_instances (instance_id, state, message, jira_key, repo, cycle_start, updated_at)
+                VALUES ($1, $2, $3, $4, $5,
+                    CASE WHEN $2 = 'working' THEN NOW() ELSE NULL END,
+                    NOW())
+                ON CONFLICT (instance_id) DO UPDATE SET
+                    state = $2, message = $3, jira_key = $4, repo = $5,
+                    cycle_start = CASE
+                        WHEN bot_instances.state = 'idle' AND $2 = 'working' THEN NOW()
+                        ELSE bot_instances.cycle_start
+                    END,
+                    updated_at = NOW()
+                """,
+                instance_id, state, message, jira_key, repo,
+            )
         result = {
             "state": row["state"],
             "message": row["message"],
             "jira_key": row["jira_key"],
             "repo": row["repo"],
-            "instance_id": row.get("instance_id"),
+            "instance_id": row.get("instance_id") or instance_id,
             "cycle_start": row["cycle_start"].isoformat() if row["cycle_start"] else None,
             "updated_at": row["updated_at"].isoformat(),
         }


### PR DESCRIPTION
## RHCLOUD-47727

Adds a two-level dashboard hierarchy: master instance overview → drill-down to instance detail.

### Backend
- New `bot_instances` table with `instance_id` PK for multi-instance status tracking
- `bot_status_update` MCP tool upserts into both `bot_instances` and legacy `bot_status`
- New `GET /api/instances` endpoint with aggregated active task counts
- `GET /api/tasks` now supports `instance_id` query param filtering

### Frontend
- Instance overview page with live-updating cards (state indicator, task count, JIRA link)
- Nested routing: `/instances/:id/tasks`, `/instances/:id/archived`, etc.
- Instance selector dropdown in header for quick switching
- Per-instance task/archive filtering via `instanceId` prop
- Lazy-loaded route pages (main bundle 1202KB → 232KB)
- Clickable header icon returns to instance overview

### Routing
- `/instances` — card grid overview of all bot instances
- `/instances/:id/*` — instance-scoped views (tasks, archive, memories, search, costs, viz)
- `/tasks`, `/archived`, etc. — global aggregate views (all instances)