### PR TITLE
feat(config): remote config sync mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ sa-key.json
 .gitconfig
 .DS_STORE
 .tmp-*
+# Remote config repo clone (synced at runtime)
+data/remote-config/

--- a/bot/config.py
+++ b/bot/config.py
@@ -49,6 +49,14 @@ def load_mcp_servers(script_dir: Path) -> dict:
         for name, cfg in data.get("mcpServers", {}).items():
             servers[name] = _resolve_env_vars(cfg)
 
+    merged_mcp = script_dir / "data" / "merged-mcp.json"
+    if merged_mcp.exists():
+        with open(merged_mcp) as f:
+            data = json.load(f)
+        for name, cfg in data.get("mcpServers", {}).items():
+            if name not in servers:
+                servers[name] = _resolve_env_vars(cfg)
+
     for mcp_file in sorted(script_dir.glob("personas/*/mcp.json")):
         with open(mcp_file) as f:
             data = json.load(f)

--- a/bot/run.py
+++ b/bot/run.py
@@ -104,6 +104,88 @@ def setup_logging() -> None:
     )
 
 
+REMOTE_CONFIG_DIR = DATA_DIR / "remote-config"
+
+
+def sync_config_repo(script_dir: Path) -> Path | None:
+    """Clone or pull BOT_CONFIG_REPO. Returns agent config dir or None."""
+    logger = logging.getLogger(__name__)
+    repo_url = os.environ.get("BOT_CONFIG_REPO")
+    if not repo_url:
+        return None
+
+    config_dir = REMOTE_CONFIG_DIR
+    try:
+        if (config_dir / ".git").exists():
+            subprocess.run(
+                ["git", "-C", str(config_dir), "pull", "--ff-only"],
+                capture_output=True, timeout=30, check=False,
+            )
+        else:
+            config_dir.parent.mkdir(parents=True, exist_ok=True)
+            subprocess.run(
+                ["git", "clone", "--depth", "1", repo_url, str(config_dir)],
+                capture_output=True, timeout=60, check=False,
+            )
+    except subprocess.TimeoutExpired:
+        logger.warning("Config repo sync timed out — using built-in config")
+        return None
+    except Exception as exc:
+        logger.warning("Config repo sync failed: %s — using built-in config", exc)
+        return None
+
+    sub = os.environ.get("BOT_CONFIG_PATH", "rehor-config")
+    agent_dir = config_dir / sub / "agent"
+    if not agent_dir.is_dir():
+        logger.warning("Config repo has no %s/agent/ dir — using built-in config", sub)
+        return None
+
+    return agent_dir
+
+
+def apply_remote_config(script_dir: Path, agent_dir: Path) -> None:
+    """Overlay remote agent config onto working directory."""
+    logger = logging.getLogger(__name__)
+
+    remote_personas = agent_dir / "personas"
+    if remote_personas.is_dir():
+        shutil.copytree(remote_personas, script_dir / "personas", dirs_exist_ok=True)
+        logger.info("Applied remote personas")
+
+    remote_repos = agent_dir / "project-repos.json"
+    if remote_repos.is_file():
+        shutil.copy2(remote_repos, script_dir / "project-repos.json")
+        logger.info("Applied remote project-repos.json")
+
+    remote_skills = agent_dir / "skills"
+    if remote_skills.is_dir():
+        shutil.copytree(
+            remote_skills, script_dir / ".claude" / "skills",
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns(".gitkeep"),
+        )
+        logger.info("Applied remote custom skills")
+
+    remote_mcp = agent_dir / "mcp.json"
+    if remote_mcp.is_file():
+        import json
+        bot_mcp_path = script_dir / "bot" / "mcp.json"
+        try:
+            with open(bot_mcp_path) as f:
+                built_in = json.load(f)
+            with open(remote_mcp) as f:
+                custom = json.load(f)
+            for name, cfg in custom.get("mcpServers", {}).items():
+                if name not in built_in.get("mcpServers", {}):
+                    built_in.setdefault("mcpServers", {})[name] = cfg
+            with open(bot_mcp_path, "w") as f:
+                json.dump(built_in, f, indent=2)
+                f.write("\n")
+            logger.info("Merged remote MCP servers")
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to merge remote MCP config: %s", exc)
+
+
 LOW_DISK_THRESHOLD_MB = 512
 
 
@@ -212,6 +294,10 @@ def main() -> None:
 
     try:
         while True:
+            remote_agent_dir = sync_config_repo(SCRIPT_DIR)
+            if remote_agent_dir:
+                apply_remote_config(SCRIPT_DIR, remote_agent_dir)
+
             logger.info("Running agent cycle...")
 
             try:

--- a/bot/run.py
+++ b/bot/run.py
@@ -3,6 +3,7 @@
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -107,7 +108,7 @@ def setup_logging() -> None:
 REMOTE_CONFIG_DIR = DATA_DIR / "remote-config"
 
 
-def sync_config_repo(script_dir: Path) -> Path | None:
+def sync_config_repo() -> Path | None:
     """Clone or pull BOT_CONFIG_REPO. Returns agent config dir or None."""
     logger = logging.getLogger(__name__)
     repo_url = os.environ.get("BOT_CONFIG_REPO")
@@ -117,16 +118,27 @@ def sync_config_repo(script_dir: Path) -> Path | None:
     config_dir = REMOTE_CONFIG_DIR
     try:
         if (config_dir / ".git").exists():
-            subprocess.run(
+            r = subprocess.run(
                 ["git", "-C", str(config_dir), "pull", "--ff-only"],
                 capture_output=True, timeout=30, check=False,
             )
+            if r.returncode != 0:
+                logger.warning(
+                    "git pull failed (rc=%d): %s",
+                    r.returncode, r.stderr.decode().strip(),
+                )
         else:
             config_dir.parent.mkdir(parents=True, exist_ok=True)
-            subprocess.run(
+            r = subprocess.run(
                 ["git", "clone", "--depth", "1", repo_url, str(config_dir)],
                 capture_output=True, timeout=60, check=False,
             )
+            if r.returncode != 0:
+                logger.warning(
+                    "git clone failed (rc=%d): %s",
+                    r.returncode, r.stderr.decode().strip(),
+                )
+                return None
     except subprocess.TimeoutExpired:
         logger.warning("Config repo sync timed out — using built-in config")
         return None
@@ -168,20 +180,20 @@ def apply_remote_config(script_dir: Path, agent_dir: Path) -> None:
 
     remote_mcp = agent_dir / "mcp.json"
     if remote_mcp.is_file():
-        import json
-        bot_mcp_path = script_dir / "bot" / "mcp.json"
+        merged_path = DATA_DIR / "merged-mcp.json"
         try:
-            with open(bot_mcp_path) as f:
+            with open(script_dir / "bot" / "mcp.json") as f:
                 built_in = json.load(f)
             with open(remote_mcp) as f:
                 custom = json.load(f)
             for name, cfg in custom.get("mcpServers", {}).items():
                 if name not in built_in.get("mcpServers", {}):
                     built_in.setdefault("mcpServers", {})[name] = cfg
-            with open(bot_mcp_path, "w") as f:
-                json.dump(built_in, f, indent=2)
-                f.write("\n")
-            logger.info("Merged remote MCP servers")
+            new_content = json.dumps(built_in, indent=2) + "\n"
+            existing = merged_path.read_text() if merged_path.exists() else ""
+            if new_content != existing:
+                merged_path.write_text(new_content)
+                logger.info("Merged remote MCP servers → %s", merged_path)
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Failed to merge remote MCP config: %s", exc)
 
@@ -294,7 +306,7 @@ def main() -> None:
 
     try:
         while True:
-            remote_agent_dir = sync_config_repo(SCRIPT_DIR)
+            remote_agent_dir = sync_config_repo()
             if remote_agent_dir:
                 apply_remote_config(SCRIPT_DIR, remote_agent_dir)
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -27,6 +27,10 @@ parameters:
   value: "false"
 - name: BOT_INSTANCE_ID
   value: ""
+- name: BOT_CONFIG_REPO
+  value: ""
+- name: BOT_CONFIG_PATH
+  value: "rehor-config"
 - name: GCP_PROJECT_ID
   required: true
 - name: GCP_REGION
@@ -404,6 +408,10 @@ objects:
             value: ${BOT_INCLUDE_BACKLOG}
           - name: BOT_INSTANCE_ID
             value: ${BOT_INSTANCE_ID}
+          - name: BOT_CONFIG_REPO
+            value: ${BOT_CONFIG_REPO}
+          - name: BOT_CONFIG_PATH
+            value: ${BOT_CONFIG_PATH}
           - name: BOT_DASHBOARD_URL
             value: http://devbot-memory-server:8080/api/bot-status
           - name: COSTS_API_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,8 @@ services:
       - SSO_PASSWORD
       - BOT_LABEL=${BOT_LABEL:-hcc-ai-framework}
       - BOT_INSTANCE_ID=${BOT_INSTANCE_ID:-}
+      - BOT_CONFIG_REPO=${BOT_CONFIG_REPO:-}
+      - BOT_CONFIG_PATH=${BOT_CONFIG_PATH:-rehor-config}
       - BOT_MEMORY_URL=http://memory-server:8080/mcp
       - COSTS_API_URL=http://memory-server:8080/api/costs
       - BOT_DASHBOARD_URL=http://memory-server:8080/api/bot-status

--- a/rehor-config/agent/mcp.json
+++ b/rehor-config/agent/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "type": "http",
+      "url": "${JIRA_MCP_URL}"
+    }
+  }
+}

--- a/rehor-config/agent/personas/backend/prompt.md
+++ b/rehor-config/agent/personas/backend/prompt.md
@@ -1,0 +1,36 @@
+## Backend Guidelines
+
+You are working on a backend service. Backend repos may be Go or Node.js — check `go.mod` or `package.json` to determine the language.
+
+### General
+
+- Follow existing patterns in the codebase.
+- Ensure proper error handling — never silently ignore errors.
+- Use the LSP tool to check for type errors and trace code paths.
+- Run tests before committing. Fix any failures you introduce.
+- Read the repo's `CLAUDE.md` and any docs in `docs/` for repo-specific conventions (test patterns, ID generators, API patterns).
+
+### Go repos
+
+- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.7)"` (replace with needed version). Available versions are pre-installed in the container. If the required version is not available, skip local build/test and note that CI will verify.
+- Use `make test` (or `go test ./... -v`) to run tests.
+- Use `make build` to verify the project compiles.
+- Use `go vet ./...` to check for issues.
+- Use `gofmt -w .` to format code (or verify formatting).
+- Follow Go conventions: exported names are PascalCase, unexported are camelCase.
+- Handle errors explicitly — no `_` for error returns unless justified.
+- Use table-driven tests where multiple similar test cases exist.
+- Be aware of GORM gotchas: `Updates` with a struct skips zero-value fields (`false`, `0`, `""`). Use `map[string]interface{}` for updates that set zero values.
+
+### Node.js repos
+
+- Use `npm test` to run tests. Use `npm run lint` to lint.
+- Use `npm run build` or `npm run typecheck` to verify compilation.
+- Never call CLI tools directly (`npx jest`, `npx tsc`) — always use npm scripts.
+
+### Dev environment
+
+- Backend repos often have a local database via Docker Compose. Check `local/` or `docker-compose*.yml` for infra setup.
+- Check for `.env` or `.env.example` files for required environment variables.
+- Use `make dev` or `npm run dev` to start the development server.
+- Some repos require an identity header for local API requests — check docs for generation scripts (e.g. `make generate-identity`).

--- a/rehor-config/agent/personas/config/prompt.md
+++ b/rehor-config/agent/personas/config/prompt.md
@@ -1,0 +1,48 @@
+## Config Repo Guidelines
+
+Config repo (e.g. app-interface).
+
+### Cloning
+- Large repos → `--depth 1`, deepen w/ `git fetch --deepen=50` as needed.
+
+### Before Changes
+- Read repo `CLAUDE.md`/`AGENTS.md` — strict validation rules.
+- Understand schema + structure before modifying.
+
+### Dev
+- YAML/JSON files for env settings, deploy params, service config.
+- Follow existing structure + naming exactly.
+- Run validation/linting (`make validate`, `make bundle validate`) before commit.
+- Do NOT invent/guess values — verify against schema or existing examples.
+- Conventional commits: `fix(app-interface): update frontend deployment config`.
+
+### Rebasing — app-interface
+
+App-interface has **automatic rebase**. Do NOT proactively rebase MRs.
+
+Only rebase when ALL true:
+1. Pipeline **failed**
+2. Failure = merge conflicts (not code issue)
+3. No auto-rebase happened recently (CI re-ran in last hour → wait)
+
+MR shows `need_rebase` but pipeline passing/running → **leave it alone**.
+
+### Blue-green RDS upgrades
+
+Strict multi-MR sequence. Each MR does ONE thing. Never combine steps.
+
+**Key rules:**
+- `blue_green_deployment` section = NEW (green) instance config.
+- Main spec (outside `blue_green_deployment`) = ORIGINAL (blue) instance.
+- **NEVER add instance overrides (`instance_class`, `allocated_storage`) to main spec** during switchover/delete. Would resize live prod DB.
+- Main spec updates → **cleanup MR only** (after old instance deleted + `blue_green_deployment` removed).
+
+**MR sequence (each must merge + verify before next):**
+
+1. **Create** — add `blue_green_deployment` section + target param group file.
+2. **Switchover** — ONLY: `switchover: true`. Nothing else.
+3. **Wait** — verify switchover success. Jira comment confirming.
+4. **Delete** — ONLY: `delete: true`. Removes old instance.
+5. **Cleanup** — remove `blue_green_deployment`, update main spec w/ new instance config, re-enable `deletion_protection`, remove `apply_immediately`.
+
+Prod: add status page maintenance MR before switchover.

--- a/rehor-config/agent/personas/cve/prompt.md
+++ b/rehor-config/agent/personas/cve/prompt.md
@@ -1,0 +1,68 @@
+## CVE Remediation
+
+Fixing security vulnerability (CVE).
+
+### Check if already fixed
+
+`npm audit` or check current version vs fixed version in ticket. Already at/above fixed version → Jira comment confirming fixed (include version) → transition "Done" → stop.
+
+### Determine source
+
+1. **npm pkg** — in `package.json`/`package-lock.json`
+2. **Base image dep** — from container image, not npm
+
+### npm CVEs
+
+- Direct or transitive? `npm ls <pkg>`
+- Direct → bump version in `package.json`
+- Transitive → upgrade parent dep. No fix available → add `overrides` in `package.json`
+- `npm install` → regenerate lock file
+- Run tests
+- Commit both `package.json` + `package-lock.json`
+
+### Non-npm CVEs (base image) — frontend only
+
+Frontend apps inherit base image from `build-tools` → CVE can't be fixed in app repo.
+
+- Jira comment: base image CVE from `build-tools`, needs fix there
+- `build-tools` in `project-repos.json` → check if already updated
+
+Backend repos → investigate + fix normally (own base images).
+
+### Verification — npm
+
+- `npm audit` → confirm resolved
+- Full test suite
+- LSP `get_diagnostics` if upgraded pkg has API changes
+
+### Verification — container image scanning
+
+After CVE fix → verify image clean w/ Buildah + Grype.
+
+#### Build & scan (fix verification)
+
+```bash
+buildah build -t <repo>:scan .
+buildah push <repo>:scan oci-archive:/tmp/<repo>.tar
+grype oci-archive:/tmp/<repo>.tar --only-fixed
+rm -f /tmp/<repo>.tar
+buildah rmi <repo>:scan
+```
+
+Multiple Dockerfiles → use plain `Dockerfile` (not `.hermetic`).
+`--only-fixed` → only CVEs w/ known fixes. Verify ticket CVE gone.
+
+#### Scan existing Quay images (investigation)
+
+```bash
+grype registry:quay.io/<namespace>/<image>:<tag> --only-fixed
+```
+
+No build needed — grype pulls from registry directly.
+
+#### Report results
+
+Grype summary in PR description + Jira comment. Table format:
+```
+| CVE | Package | Installed | Fixed | Severity |
+```

--- a/rehor-config/agent/personas/frontend/mcp.json
+++ b/rehor-config/agent/personas/frontend/mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "hcc-patternfly-data-view": {
+      "command": "hcc-pf-mcp",
+      "args": []
+    },
+    "chrome-devtools": {
+      "command": "chrome-devtools-mcp",
+      "args": [
+        "--browserUrl", "http://127.0.0.1:9222",
+        "--acceptInsecureCerts"
+      ]
+    }
+  }
+}

--- a/rehor-config/agent/personas/frontend/prompt.md
+++ b/rehor-config/agent/personas/frontend/prompt.md
@@ -1,0 +1,154 @@
+## Frontend Guidelines
+
+Frontend app in Red Hat Hybrid Cloud Console ecosystem.
+
+### Before changes
+- `npm install` first. Fails → STOP, report on Jira, do not proceed.
+
+### Development
+- PatternFly components. Use `hcc-patternfly-data-view` MCP for docs/examples/source.
+- React best practices, existing codebase patterns.
+- TypeScript. All new code properly typed.
+- LSP `get_diagnostics` before committing.
+- Check PatternFly docs via MCP for correct API usage.
+- **npm scripts only** — `npm test`, `npm run lint`, `npm run build`. Never `npx jest`/`npx eslint`/`npx tsc`/`tsx` directly. Check `package.json` for scripts.
+
+### Verification — MANDATORY for UI changes
+
+**MUST visually verify every UI change before PR.** Ticket touches anything visual → build, start dev proxy, navigate, screenshot. No exceptions.
+
+**Do NOT use Storybook/Chromatic.** Dev proxy + `chrome-devtools` MCP only — real screenshots in actual HCC env.
+
+Same when reviewer asks for screenshots.
+
+#### Architecture
+
+Dev proxy (Caddy) on port 1337 routes:
+- App assets → local static file server (build output)
+- Everything else → `console.stage.redhat.com`
+
+Chrome navigates `https://stage.foo.redhat.com:1337/` → resolves 127.0.0.1 via container `extra_hosts`.
+
+#### Steps
+
+0. **Kill stale**: `lsof -ti :1337,:8003,:9912 | xargs kill 2>/dev/null || true`
+
+1. **Build**: `npm run build`
+
+2. **Static file server** — serve build output (check `webpack.config` or `vite.config` for output dir — usually `dist/` or `build/`):
+
+   insights-chrome (shell): `nohup npx http-server ./dist -p 9912 -c-1 -a :: --cors=\* > /tmp/http-server.log 2>&1 &`
+
+   Regular apps (federated modules): `nohup npx http-server ./dist -p 8003 -c-1 -a :: --cors=\* > /tmp/http-server.log 2>&1 &`
+
+   **MUST use `nohup`** — without it, http-server dies when the shell session ends.
+
+   **insights-chrome only**: Create symlinks so `/apps/chrome/*` paths resolve:
+   ```bash
+   mkdir -p dist/apps/chrome
+   for f in dist/*; do [ "$(basename "$f")" = "apps" ] && continue; ln -sf "../../$(basename "$f")" "dist/apps/chrome/$(basename "$f")"; done
+   ```
+
+3. **Routes config** — write `/tmp/dev-proxy-routes.json`:
+
+   insights-chrome:
+   ```json
+   {"/apps/chrome*": {"url": "http://127.0.0.1:9912", "is_chrome": true}}
+   ```
+
+   Regular apps — app name from `package.json` `insights.appname` or `fec.config.js` `appUrl`:
+   ```json
+   {"/apps/<app-name>*": {"url": "http://127.0.0.1:8003"}}
+   ```
+
+   Optional local API: add `"/api/<app-name>/*": {"url": "http://127.0.0.1:8000", "rh-identity-headers": true}`
+
+4. **Start proxy**: `nohup bash -c 'ROUTES_JSON_PATH=/tmp/dev-proxy-routes.json start-dev-proxy.sh' > /tmp/caddy.log 2>&1 &`
+
+   Wait few seconds for Caddy. App at `https://stage.foo.redhat.com:1337/`.
+
+   First load slow (2-3 min) — federated modules fetched from stage w/o cache. Be patient.
+
+5. **Navigate**: chrome-devtools MCP `navigate_page` → affected page URL.
+
+6. **SSO login** — two-step:
+   - Read creds from `/home/botuser/app/.credentials` (JSON: `{"sso": {"username": "...", "password": "..."}}`). Env vars are unset at startup.
+   - Snapshot → find username field + "Next" btn.
+   - `fill` username → `click` "Next".
+   - `wait_for` `["Password"]` → `fill` password → `click` "Log in".
+   - Wait redirect.
+
+7. **Wait for SPA**: `wait_for` `["Hi!", "Welcome to", "Favorites"]` timeout **180000ms** (3 min). Timeout → screenshot to check. Header showing = chrome loaded, content still loading. Confirm full render w/ another screenshot.
+
+8. **Screenshots**: "before" + "after". Compare w/ mockups if ticket has them.
+
+9. **Upload to PR** — never commit screenshots, never base64 data URIs:
+   - Save `/tmp/RHCLOUD-12345-after.png`.
+   - Fork name from `project-repos.json` `url` field.
+   - Ensure release: `gh release create bot-screenshots --repo <fork> --title "Bot Screenshots" --notes "Automated"` (if missing)
+   - Upload: `gh release upload bot-screenshots /tmp/RHCLOUD-12345-after.png --repo <fork> --clobber`
+   - PR comment: `gh pr comment <n> --repo <upstream> --body "### After fix\n![after](https://github.com/<fork>/releases/download/bot-screenshots/RHCLOUD-12345-after.png)"`
+
+10. **Stop everything** — mandatory: `lsof -ti :1337,:8003,:9912 | xargs kill`. Verify: should return nothing.
+
+### Verification for non-UI changes
+- Kill stale: `lsof -ti :1337,:8003,:9912 | xargs kill 2>/dev/null || true`
+- If ticket has repro steps → build + proxy (steps 1-4), verify no visual regressions via chrome-devtools MCP.
+- **Always stop all servers**: `lsof -ti :1337,:8003,:9912 | xargs kill`
+
+### Playwright e2e tests
+
+Run Playwright tests if the repo has them (`playwright.config.ts` exists). Do this **after** visual verification, with dev proxy already running.
+
+#### Prerequisites
+
+Dev proxy + http-server must be running (steps 0-4 above). If not already started, start them first.
+
+#### Patch playwright.config.ts
+
+Playwright launches its own Chromium — it needs proxy + host resolver args to work in the container. Patch `playwright.config.ts` before running:
+
+Add `launchOptions` to the `use` block:
+```typescript
+use: {
+  // ... existing config ...
+  launchOptions: {
+    args: [
+      '--proxy-server=http://proxy:3128',
+      '--proxy-bypass-list=*.foo.redhat.com;localhost;127.0.0.1',
+      '--host-resolver-rules=MAP stage.foo.redhat.com 127.0.0.1,MAP consent.trustarc.com 127.0.0.1',
+      '--ignore-certificate-errors',
+      '--no-sandbox',
+      '--disable-gpu',
+    ],
+  },
+}
+```
+
+Do NOT commit this patch — it's container-specific. `git checkout -- playwright.config.ts` after tests.
+
+#### Run tests
+
+```bash
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+export E2E_USER=$(python3.12 -c "import json; c=json.load(open('/home/botuser/app/.credentials')); print(c['sso']['username'])")
+export E2E_PASSWORD=$(python3.12 -c "import json; c=json.load(open('/home/botuser/app/.credentials')); print(c['sso']['password'])")
+
+npx playwright test --workers=1 --max-failures=1 --reporter=list
+```
+
+**`--workers=1` mandatory** — container can't spawn multiple Chrome instances.
+
+#### Failures
+
+- All pass → proceed to PR
+- Test failure → check `test-results/` for screenshots + videos. Fix code, re-run.
+- `EAGAIN` / `pthread_create` errors → resource limits, already mitigated by `--workers=1`
+- `Xvfb` errors → only affects Cypress, not Playwright. Ignore Cypress e2e, run Playwright only.
+
+#### Cleanup
+
+Revert playwright.config.ts patch: `git checkout -- playwright.config.ts`
+
+Stop servers (step 10 above).

--- a/rehor-config/agent/personas/operator/prompt.md
+++ b/rehor-config/agent/personas/operator/prompt.md
@@ -1,0 +1,14 @@
+## Operator Guidelines
+
+You are working on a Kubernetes operator written in Go.
+
+### Before making any changes
+- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.7)"` (replace with needed version). Available versions are pre-installed in the container.
+- Run `go mod tidy` to ensure dependencies are up to date.
+- If it fails, STOP immediately. Report the failure on the Jira ticket and do not proceed.
+
+### Development
+- Follow existing Go patterns and conventions in the codebase.
+- Use the LSP tool to check for type errors before committing.
+- Run `make test` or `go test ./...` to run the test suite.
+- Ensure CRD types and generated code are in sync — run `make generate` and `make manifests` if you modify API types.

--- a/rehor-config/agent/personas/rbac/prompt.md
+++ b/rehor-config/agent/personas/rbac/prompt.md
@@ -1,0 +1,100 @@
+## RBAC (insights-rbac) Guidelines
+
+You are working on **insights-rbac**, a Django 5.2 + Django REST Framework service that provides Role-Based Access Control for the Hybrid Cloud Console. The stack includes PostgreSQL 16, Redis, and Celery (worker + scheduler).
+
+### Project Structure
+
+```
+rbac/                    # Django project root (APP_HOME)
+  rbac/                  # Django settings module (settings.py, urls.py, middleware.py, wsgi.py)
+  management/            # Django management app (roles, groups, permissions, policies)
+  api/                   # API app (tenant model, common utilities, serializers)
+tests/                   # Test suite (mirrors app structure: tests/management/, tests/api/, etc.)
+scripts/                 # Utility scripts (entrypoint, DB setup, Kafka, ephemeral cluster)
+```
+
+### Dev Environment
+
+The dev environment runs via Docker Compose. Prerequisites:
+
+1. Create the docker network: `docker network create rbac-network`
+2. Start with dev mode: `DEVELOPMENT=True docker-compose up`
+3. Run migrations: `docker exec -it rbac_server python /opt/rbac/rbac/manage.py migrate`
+4. Seed default roles: `docker exec -it rbac_server python /opt/rbac/rbac/manage.py seeds`
+
+**Dev mode** (`DEVELOPMENT=True`) enables the `DevelopmentIdentityHeaderMiddleware` which auto-injects an `x-rh-identity` header with a fake org admin user (org_id=11111, username=user_dev). No auth headers needed for local API calls.
+
+The server is exposed on **port 9080** (maps to 8080 inside the container). The DB is on port 15432.
+
+### API Endpoints
+
+Base path: `/api/rbac/v1/`
+
+| Endpoint | Methods | Notes |
+|----------|---------|-------|
+| `roles/` | GET, POST | List/create roles |
+| `roles/<uuid>/` | GET, PUT, PATCH, DELETE | Role detail |
+| `roles/<uuid>/access/` | GET | Role access permissions |
+| `groups/` | GET, POST | List/create groups |
+| `groups/<uuid>/` | GET, PUT, PATCH, DELETE | Group detail |
+| `groups/<uuid>/principals/` | GET, POST, DELETE | Group membership |
+| `groups/<uuid>/roles/` | GET, POST, DELETE | Group role assignments |
+| `access/` | GET | Requires `?application=` query param |
+| `permissions/` | GET | List permissions |
+| `permissions/options/` | GET | Permission filter options |
+| `principals/` | GET | List principals |
+| `cross-account-requests/` | GET, POST | Cross-account access requests |
+| `auditlogs/` | GET | Audit log entries |
+
+V2 endpoints are available at `/api/rbac/v2/`.
+
+### Testing
+
+- **Fast tests** (no coverage): `make unittest-fast` (uses `tox -e py312-fast`)
+- **Full tests** (with coverage): `make unittest`
+- **Profile tests**: `make unittest-profile` (shows slowest tests)
+- Tests use Django's test framework with `TestCase` classes
+- Test DB is auto-created by Django test runner (separate from dev DB)
+- Tests run against a local PostgreSQL, not the Docker Compose DB
+
+When modifying code, run relevant test modules:
+```bash
+tox -e py312-fast -- tests/management/test_role_viewset.py
+```
+
+### Linting and Formatting
+
+- **Lint**: `make lint` (runs `tox -elint`)
+- **Format**: `make format` (runs `black -t py312 -l 119`)
+- **Typecheck**: `make typecheck` (runs `mypy`)
+- Line length: 119 characters
+- Python target: 3.12
+
+### Code Conventions
+
+- Uses Pipenv for dependency management (`Pipfile`, `Pipfile.lock`)
+- Django settings in `rbac/rbac/settings.py`, reads from environment variables
+- Identity/auth handled via `x-rh-identity` header (base64-encoded JSON) parsed in `rbac/rbac/middleware.py`
+- Multi-tenancy via `Tenant` model keyed on `org_id`
+- System roles are seeded and marked `system=True` — do not modify these directly
+- Custom permissions use the format `app:resource:action` (e.g. `approval:requests:read`)
+- Celery tasks are in `management/tasks.py`, broker is Redis
+- The worker connects to Redis via the `redis` hostname in Docker Compose (not localhost)
+
+### Key Files
+
+- `rbac/rbac/settings.py` — all Django settings and env var configuration
+- `rbac/rbac/middleware.py` — identity header parsing, tenant resolution
+- `rbac/rbac/dev_middleware.py` — development identity injection (auto org_id=11111)
+- `rbac/management/role/` — role views, serializers, definer
+- `rbac/management/group/` — group views, serializers
+- `rbac/management/permission/` — permission views
+- `rbac/management/seeds.py` — default role/group seeding logic
+- `rbac/api/models.py` — Tenant and other core models
+
+### Common Pitfalls
+
+- The `rbac-network` Docker network must exist before `docker-compose up` — it's external.
+- Redis health check task in the worker logs connection errors to `localhost:6379` — this is a known issue in the health check code, not a real problem. The Celery broker connects to `redis:6379` correctly.
+- Migrations must be run manually after first `docker-compose up` — the entrypoint only starts gunicorn.
+- `DEVELOPMENT` env var defaults to `False` — must be explicitly set to `True` for auth bypass.

--- a/rehor-config/agent/personas/rds-upgrade/prompt.md
+++ b/rehor-config/agent/personas/rds-upgrade/prompt.md
@@ -1,0 +1,62 @@
+## RDS Blue-Green Upgrade Guidelines
+
+Multi-step infra process across multiple cycles. Track progress in task metadata + summary. Each cycle resumes where last left off.
+
+### Overview
+
+RDS EOL upgrades use blue-green deployments in app-interface. Stage needs 4-5 MRs (incl. optional param group prep), prod needs 5-6 (extra status page MR).
+
+### MR Sequence — Stage
+
+0. **Source param group prep** — check source param group for `rds.logical_replication = 1`. Missing → MR to add. MUST merge + wait for AWS apply (pending-reboot) BEFORE blue-green MR. CI dry-run validates against live AWS state.
+1. **Create blue-green** — add `blue_green` section + target (postgres17) param group file. Target MUST include `rds.logical_replication = 1` + `rds.force_ssl = 1` (both `apply_method: pending-reboot`). Copy other params from source.
+2. **Switchover** — ONLY: `switchover: true`. No other changes. No instance overrides to main spec.
+3. **Delete** — ONLY: `delete: true`. No other changes. Removes old instance.
+4. **Cleanup** — remove `blue_green_deployment` section, update main spec w/ new instance config, re-enable `deletion_protection`, remove `apply_immediately`.
+
+### MR Sequence — Prod (same + status page)
+
+0. **Source param group prep** — same as stage.
+1. **Status page maintenance** — create maintenance incident before window.
+2. **Create blue-green deployment**
+3. **Switchover** — ONLY: `switchover: true`. Nothing else.
+4. **Delete** — ONLY: `delete: true`. Nothing else.
+5. **Cleanup** — remove blue-green config, update main spec, close status page incident.
+
+### Critical Rules
+
+- **Each MR does ONE thing.** Never combine switchover + delete or any other steps.
+- **Main spec = ORIGINAL (blue) instance.** Adding overrides (`instance_class`, `allocated_storage`) to main spec during switchover/delete would resize live prod DB. Only update main spec in cleanup MR after old instance gone.
+- **`blue_green_deployment` section = NEW (green) instance.** Instance type, storage, engine version, param group set in create step (step 1).
+- **Wait between steps.** Each MR must merge + verify before opening next.
+- **Do NOT proactively rebase app-interface MRs.** Auto-rebase built in. Only rebase when pipeline failed due to merge conflicts + no auto-rebase happened recently.
+
+### Multi-Cycle Workflow
+
+NOT a single-cycle task. Each MR may need review + merge before next.
+
+Track in `task_update` metadata:
+```json
+{
+  "last_step": "stage_mr1_opened",
+  "next_step": "wait_for_mr1_merge_then_open_mr2",
+  "environment": "stage",
+  "mrs_opened": [{"mr_number": 123, "phase": "blue_green_create", "status": "open"}],
+  "mrs_remaining": ["switchover", "delete", "cleanup"]
+}
+```
+
+Cycle behavior:
+- **First cycle**: Read ticket comments. Check source param group for `rds.logical_replication`. Missing → param group MR (step 0). Present → blue-green MR (step 1). Update task.
+- **Subsequent**: Check prev MR status. Merged → open next. Feedback → address. **Step 0 → 1**: after param group MR merges, wait one cycle for AWS apply.
+- **Between phases**: Stage complete before prod starts. Track `environment` in metadata.
+
+### MR Content
+
+Each MR modifies YAML in `data/services/insights/` or related paths. Follow existing patterns — `git log` for similar completed upgrades.
+
+Conventional commits: `fix(app-interface): RDS blue-green create for <service> stage`
+
+### Do NOT Skip These Tickets
+
+RDS upgrades = well-defined multi-step processes. Each MR = simple YAML change. Complexity = sequencing, handled by task tracking.

--- a/rehor-config/agent/personas/tooling/prompt.md
+++ b/rehor-config/agent/personas/tooling/prompt.md
@@ -1,0 +1,52 @@
+## Tooling & Build Infrastructure Guidelines
+
+You are working on a build/dev tooling repo — Dockerfiles, shell scripts, proxy configs, CI pipelines, and similar infrastructure that supports frontend and backend applications.
+
+### General
+
+- These repos are NOT application code. They are shared infrastructure used by many teams.
+- Changes here have a wide blast radius — a broken build image or proxy affects all frontend apps.
+- Follow existing patterns. These repos prioritize stability over cleverness.
+- Read the repo's `README.md` and any docs for repo-specific conventions.
+
+### Dockerfiles
+
+- Use multi-stage builds where appropriate.
+- Prefer UBI (Universal Base Image) base images for production.
+- Keep images minimal — only install what's needed.
+- Never hardcode secrets or tokens in Dockerfiles. Use build args or mounted secrets.
+- Pin base image versions to specific tags, not `latest`.
+- Run as non-root user where possible.
+
+### Shell scripts
+
+- Use `set -euo pipefail` at the top of scripts.
+- Quote all variables: `"${VAR}"` not `$VAR`.
+- Use `shellcheck` if available to lint scripts.
+- Add comments explaining non-obvious logic — these scripts are maintained by many people.
+- Test scripts locally before committing.
+
+### Proxy / Caddy / NGINX configs
+
+- Test config changes against a real running instance if possible.
+- Be careful with route ordering — more specific routes before catch-alls.
+- Document any new environment variables or config options.
+
+### Go plugins (e.g. Caddy modules)
+
+- Follow Go conventions: `go vet`, `gofmt`, table-driven tests.
+- Use `go build` to verify compilation.
+- Run `go test ./...` for any Go code.
+
+### Testing
+
+- For shell scripts: test edge cases (missing files, empty vars, special characters).
+- For Dockerfiles: build the image and verify it starts correctly.
+- For config changes: validate syntax before committing.
+- Run any existing test suites: check for `test/`, `Makefile` targets, or CI scripts.
+
+### CVE fixes in these repos
+
+- CVEs here are typically in base images or system packages, not application dependencies.
+- Fix by updating the base image tag or adding explicit `dnf update` / `apk upgrade` for affected packages.
+- Verify the CVE is actually resolved in the new image by checking package versions.

--- a/rehor-config/agent/project-repos.json
+++ b/rehor-config/agent/project-repos.json
@@ -1,0 +1,176 @@
+{
+  "insights-chrome": {
+    "url": "https://github.com/platex-rehor-bot/insights-chrome.git",
+    "upstream": "https://github.com/RedHatInsights/insights-chrome.git"
+  },
+  "astro-virtual-assistant-frontend": {
+    "url": "https://github.com/platex-rehor-bot/astro-virtual-assistant-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/astro-virtual-assistant-frontend.git"
+  },
+  "widget-layout": {
+    "url": "https://github.com/platex-rehor-bot/widget-layout.git",
+    "upstream": "https://github.com/RedHatInsights/widget-layout.git"
+  },
+  "widget-layout-backend": {
+    "url": "https://github.com/platex-rehor-bot/widget-layout-backend.git",
+    "upstream": "https://github.com/RedHatInsights/widget-layout-backend.git"
+  },
+  "notifications-frontend": {
+    "url": "https://github.com/platex-rehor-bot/notifications-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/notifications-frontend.git"
+  },
+  "frontend-operator": {
+    "url": "https://github.com/platex-rehor-bot/frontend-operator.git",
+    "upstream": "https://github.com/RedHatInsights/frontend-operator.git"
+  },
+  "app-interface": {
+    "url": "https://gitlab.cee.redhat.com/mmarosi/app-interface.git",
+    "upstream": "https://gitlab.cee.redhat.com/service/app-interface.git",
+    "host": "gitlab"
+  },
+  "quickstarts": {
+    "url": "https://github.com/platex-rehor-bot/quickstarts.git",
+    "upstream": "https://github.com/RedHatInsights/quickstarts.git"
+  },
+  "learning-resources": {
+    "url": "https://github.com/platex-rehor-bot/learning-resources.git",
+    "upstream": "https://github.com/RedHatInsights/learning-resources.git"
+  },
+  "payload-tracker-frontend": {
+    "url": "https://github.com/platex-rehor-bot/payload-tracker-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/payload-tracker-frontend.git"
+  },
+  "pdf-generator": {
+    "url": "https://github.com/platex-rehor-bot/pdf-generator.git",
+    "upstream": "https://github.com/RedHatInsights/pdf-generator.git"
+  },
+  "chrome-service-backend": {
+    "url": "https://github.com/platex-rehor-bot/chrome-service-backend.git",
+    "upstream": "https://github.com/RedHatInsights/chrome-service-backend.git"
+  },
+  "astro-virtual-assistant-v2": {
+    "url": "https://github.com/platex-rehor-bot/astro-virtual-assistant-v2.git",
+    "upstream": "https://github.com/RedHatInsights/astro-virtual-assistant-v2.git"
+  },
+  "insights-rbac": {
+    "url": "https://github.com/platex-rehor-bot/insights-rbac.git",
+    "upstream": "https://github.com/RedHatInsights/insights-rbac.git"
+  },
+  "javascript-clients": {
+    "url": "https://github.com/platex-rehor-bot/javascript-clients.git",
+    "upstream": "https://github.com/RedHatInsights/javascript-clients.git"
+  },
+  "frontend-components": {
+    "url": "https://github.com/platex-rehor-bot/frontend-components.git",
+    "upstream": "https://github.com/RedHatInsights/frontend-components.git"
+  },
+  "patchman-ui": {
+    "url": "https://github.com/platex-rehor-bot/patchman-ui.git",
+    "upstream": "https://github.com/RedHatInsights/patchman-ui.git"
+  },
+  "insights-advisor-frontend": {
+    "url": "https://github.com/platex-rehor-bot/insights-advisor-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/insights-advisor-frontend.git"
+  },
+  "ocp-advisor-frontend": {
+    "url": "https://github.com/platex-rehor-bot/ocp-advisor-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/ocp-advisor-frontend.git"
+  },
+  "insights-remediations-frontend": {
+    "url": "https://github.com/platex-rehor-bot/insights-remediations-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/insights-remediations-frontend.git"
+  },
+  "insights-inventory-frontend": {
+    "url": "https://github.com/platex-rehor-bot/insights-inventory-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/insights-inventory-frontend.git"
+  },
+  "malware-detection-frontend": {
+    "url": "https://github.com/platex-rehor-bot/malware-detection-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/malware-detection-frontend.git"
+  },
+  "vuln4shift-frontend": {
+    "url": "https://github.com/platex-rehor-bot/vuln4shift-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/vuln4shift-frontend.git"
+  },
+  "insights-frontend-builder-common": {
+    "url": "https://github.com/platex-rehor-bot/insights-frontend-builder-common.git",
+    "upstream": "https://github.com/RedHatInsights/insights-frontend-builder-common.git"
+  },
+  "frontend-development-proxy": {
+    "url": "https://github.com/platex-rehor-bot/frontend-development-proxy.git",
+    "upstream": "https://github.com/RedHatInsights/frontend-development-proxy.git"
+  },
+  "insights-rbac-ui": {
+    "url": "https://github.com/platex-rehor-bot/insights-rbac-ui.git",
+    "upstream": "https://github.com/RedHatInsights/insights-rbac-ui.git"
+  },
+  "user-preferences-frontend": {
+    "url": "https://github.com/platex-rehor-bot/user-preferences-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/user-preferences-frontend.git"
+  },
+  "caddy-ubi": {
+    "url": "https://gitlab.cee.redhat.com/mmarosi/caddy-ubi.git",
+    "upstream": "https://gitlab.cee.redhat.com/insights-platform/caddy-ubi.git",
+    "host": "gitlab"
+  },
+  "api-documentation-frontend": {
+    "url": "https://github.com/platex-rehor-bot/api-documentation-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/api-documentation-frontend.git"
+  },
+  "service-accounts": {
+    "url": "https://github.com/platex-rehor-bot/service-accounts.git",
+    "upstream": "https://github.com/RedHatInsights/service-accounts.git"
+  },
+  "hcc-ai-assistant": {
+    "url": "https://github.com/platex-rehor-bot/hcc-ai-assistant.git",
+    "upstream": "https://github.com/RedHatInsights/hcc-ai-assistant.git"
+  },
+  "valpop": {
+    "url": "https://github.com/platex-rehor-bot/valpop.git",
+    "upstream": "https://github.com/RedHatInsights/valpop.git"
+  },
+  "scheduler-ui": {
+    "url": "https://github.com/platex-rehor-bot/scheduler-ui.git",
+    "upstream": "https://github.com/RedHatInsights/scheduler-ui.git"
+  },
+  "frontend-assets": {
+    "url": "https://github.com/platex-rehor-bot/frontend-assets.git",
+    "upstream": "https://github.com/RedHatInsights/frontend-assets.git"
+  },
+  "frontend-test-utils": {
+    "url": "https://github.com/platex-rehor-bot/frontend-test-utils.git",
+    "upstream": "https://github.com/RedHatInsights/frontend-test-utils.git"
+  },
+  "platform-frontend-ai-toolkit": {
+    "url": "https://github.com/platex-rehor-bot/platform-frontend-ai-toolkit.git",
+    "upstream": "https://github.com/RedHatInsights/platform-frontend-ai-toolkit.git"
+  },
+  "frontend-asset-proxy": {
+    "url": "https://github.com/platex-rehor-bot/frontend-asset-proxy.git",
+    "upstream": "https://github.com/RedHatInsights/frontend-asset-proxy.git"
+  },
+  "javascript-clients-tests": {
+    "url": "https://github.com/platex-rehor-bot/javascript-clients-tests.git",
+    "upstream": "https://github.com/RedHatInsights/javascript-clients-tests.git"
+  },
+  "shared-workflows": {
+    "url": "https://github.com/platex-rehor-bot/shared-workflows.git",
+    "upstream": "https://github.com/RedHatInsights/shared-workflows.git"
+  },
+  "frontend-starter-app": {
+    "url": "https://github.com/platex-rehor-bot/frontend-starter-app.git",
+    "upstream": "https://github.com/RedHatInsights/frontend-starter-app.git"
+  },
+  "platform-frontend-ai-dev": {
+    "url": "https://github.com/platex-rehor-bot/platform-frontend-ai-dev.git",
+    "upstream": "https://github.com/RedHatInsights/platform-frontend-ai-dev.git"
+  },
+  "api-frontend": {
+    "url": "https://github.com/platex-rehor-bot/api-frontend.git",
+    "upstream": "https://github.com/RedHatInsights/api-frontend.git"
+  },
+  "cypress-e2e-image": {
+    "url": "https://github.com/platex-rehor-bot/cypress-e2e-image.git",
+    "upstream": "https://github.com/RedHatInsights/cypress-e2e-image.git"
+  }
+}


### PR DESCRIPTION
## RHCLOUD-47728

Adds remote config repo sync so bot instances can load personas, repos, skills, and MCP servers from an external git repo without rebuilding the container.

### What's new

**`rehor-config/agent/`** — initial HCC config directory:
- `personas/` — all current personas (frontend, backend, config, cve, operator, rbac, rds-upgrade, tooling)
- `project-repos.json` — full repo registry
- `mcp.json` — bot-level MCP server config
- `skills/` — empty dir for future custom skills

**`bot/run.py`** — sync mechanism:
- `sync_config_repo()` — clones (`--depth 1`) or pulls (`--ff-only`) the repo specified by `BOT_CONFIG_REPO` env var into `data/remote-config/`. `BOT_CONFIG_PATH` (default: `rehor-config`) specifies the subdirectory within the repo.
- `apply_remote_config()` — copies personas, project-repos.json into working dir. Skills and MCP servers are **additive only** — built-in core skills (triage, wrap-up, post-pr, new-work) and built-in MCP servers (mcp-atlassian) are never overwritten.
- Called at the start of each cycle, before `run_cycle()`
- Graceful failure: timeout/unreachable repo → warning logged, bot continues with built-in config

### Security boundaries (never overridden by remote config)
- `CLAUDE.md` — core workflow rules
- `.claude/settings.json` — hooks, permissions, sandbox
- `config.json` — model/interval settings
- Built-in skills and MCP servers

### Env vars
- `BOT_CONFIG_REPO` — git URL of config repo (optional)
- `BOT_CONFIG_PATH` — subdirectory within repo (default: `rehor-config`)