### PR TITLE
fix(bot): fix bot startup crash looping during copy files

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -155,26 +155,41 @@ def sync_config_repo() -> Path | None:
     return agent_dir
 
 
+def _copytree_content_only(src: Path, dst: Path, **kwargs) -> None:
+    """copytree using copyfile (content-only) to avoid EPERM from chmod/copystat
+    under OpenShift arbitrary UIDs on overlay FS.  Re-raises real file copy
+    errors but suppresses directory copystat failures (always emitted by
+    copytree internals).
+    """
+    try:
+        shutil.copytree(src, dst, copy_function=shutil.copyfile, **kwargs)
+    except shutil.Error as exc:
+        real_errors = [e for e in exc.args[0] if not os.path.isdir(e[0])]
+        if real_errors:
+            raise shutil.Error(real_errors) from None
+
+
 def apply_remote_config(script_dir: Path, agent_dir: Path) -> None:
     """Overlay remote agent config onto working directory."""
     logger = logging.getLogger(__name__)
 
     remote_personas = agent_dir / "personas"
     if remote_personas.is_dir():
-        shutil.copytree(remote_personas, script_dir / "personas", dirs_exist_ok=True)
+        _copytree_content_only(
+            remote_personas, script_dir / "personas", dirs_exist_ok=True,
+        )
         logger.info("Applied remote personas")
 
     remote_repos = agent_dir / "project-repos.json"
     if remote_repos.is_file():
-        shutil.copy2(remote_repos, script_dir / "project-repos.json")
+        shutil.copyfile(remote_repos, script_dir / "project-repos.json")
         logger.info("Applied remote project-repos.json")
 
     remote_skills = agent_dir / "skills"
     if remote_skills.is_dir():
-        shutil.copytree(
+        _copytree_content_only(
             remote_skills, script_dir / ".claude" / "skills",
-            dirs_exist_ok=True,
-            ignore=shutil.ignore_patterns(".gitkeep"),
+            dirs_exist_ok=True, ignore=shutil.ignore_patterns(".gitkeep"),
         )
         logger.info("Applied remote custom skills")
 


### PR DESCRIPTION
### Fix EPERM crash in `apply_remote_config` under OpenShift

### Problem

The bot crash-loops on startup with `shutil.Error: [Errno 1] Operation not permitted` when `apply_remote_config` tries to overlay remote config (personas, skills, project-repos.json) onto image-baked files.

Root cause: `shutil.copytree` uses `copy2` by default, which calls `copystat` → `chmod` on destination files. Under OpenShift's restricted SCC, the container runs as an arbitrary UID that lacks `CAP_FOWNER`. The files are owned by `botuser` (baked in via `COPY` + `chown` in the Dockerfile), so `chmod` fails with `EPERM` even though group-write permissions (`g+rwX`, GID 0) allow normal content reads and writes. The `chmod` is unnecessary — files only need to be readable by Claude Code, and the image already sets appropriate permissions.

### Fix

- Add `_copytree_content_only` helper that uses `shutil.copyfile` (content-only, no metadata) as the copy function
- Filter out directory-level `copystat` errors (always emitted by `copytree` internals via `os.path.isdir` check on the error source path) while re-raising any real file copy failures
- Replace `copy2` with `copyfile` for single-file copies (`project-repos.json`)
- No Dockerfile changes needed

### Testing

Verified directly on the crash-looping OpenShift pod and a debug container by running targeted filesystem operation tests:

- `shutil.copyfile` (content write to existing image-layer file) — **OK**
- `open(f, 'wb').write()` (overwrite existing) — **OK**
- Create + delete new file in image-layer dir — **OK**
- `os.unlink` on image-layer file — **OK**
- Read/write in `data/` (runtime-created dir) — **OK**
- `os.chmod(f, 0o644)` — **EPERM**

This confirms `chmod` is the only failing operation, and `copyfile` (which skips it entirely) is the correct fix.

### Why Python fix over Dockerfile fix

A Dockerfile-level fix is possible — changing ownership of overlayable paths to `0:0` so the arbitrary UID (which is in GID 0) can `chmod` them. However the Python approach is better for three reasons:
 1. **`copyfile` is more correct** — the source files come from a git-cloned config repo. Preserving their permissions and timestamps via `copy2` is meaningless and unintended. Content-only copy is what we actually want.
 2. **Dockerfile ownership is fragile** — every new overlayable config path would need the same `chown 0:0` treatment added to the Dockerfile, and forgetting is a silent failure that only surfaces at runtime in OpenShift.
 3. **Simpler invariant** — "we copy content only" is one rule in one place vs "we carefully set ownership on every overlaid path in the Dockerfile and hope nobody adds a new one without the special chown."