### PR TITLE
docs: update README and architecture for current state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ sa-key.json
 .ssh/
 .gitconfig
 .DS_STORE
+docker-compose.override.yml
 .tmp-*
 # Remote config repo clone (synced at runtime)
 data/remote-config/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,7 +18,6 @@ graph TB
         Repos["repos/<br/>(cloned on demand)"]
 
         subgraph MCP["MCP Servers"]
-            JiraMCP["Jira MCP<br/>(stdio)"]
             MemMCP["Memory Server<br/>(streamable HTTP)"]
             Chrome["Chrome DevTools<br/>(stdio)"]
         end
@@ -27,6 +26,7 @@ graph TB
             Squid["Squid<br/>(port 3128)"]
             Executor["Executor Server<br/>(gRPC)"]
             VertexProxy["Vertex Auth Proxy<br/>(port 8443)"]
+            JiraMCP["mcp-atlassian<br/>(port 8444)"]
         end
     end
 
@@ -37,9 +37,9 @@ graph TB
     Runner -- "prompt" --> Agent
     Agent -- "result" --> Runner
     Runner -- "cost data" --> MemMCP
-    Agent <--> JiraMCP
     Agent <--> MemMCP
     Agent <--> Chrome
+    Agent -- "Jira (streamable HTTP)" --> JiraMCP
     Agent -- "git push / gh / glab / gpg" --> Executor
     Agent -- "Vertex AI requests" --> VertexProxy
     Agent -- "HTTP/HTTPS" --> Squid
@@ -48,7 +48,6 @@ graph TB
     JiraMCP --> Jira
     MemMCP --> PG
     Squid --> GHGL
-    Squid --> Jira
     VertexProxy --> Vertex
 ```
 
@@ -60,10 +59,11 @@ The Python process that orchestrates the agent loop. It is **not** the brains �
 
 | File | Role |
 |------|------|
-| `run.py` | Main loop: parse args, load config, lock file, poll forever |
+| `run.py` | Main loop: parse args, load config, lock file, remote config sync, poll forever |
 | `agent.py` | Wraps the Claude Agent SDK `query()` call. Streams messages, logs tool calls, extracts work context (jira_key, repo, work_type) from MCP tool interceptions |
 | `config.py` | Loads `config.json` and merges persona MCP configs |
 | `costs.py` | Posts per-cycle cost data to the memory server REST API |
+| `merge.py` | Remote config merge engine — merges remote config repo contents with built-in bot config while protecting security-critical settings |
 
 **Cycle flow:**
 1. Runner calls `run_cycle()` with the primary label and config
@@ -89,16 +89,17 @@ The agent has no persistent state between cycles. All state is stored in the mem
 
 The agent communicates with external systems through [Model Context Protocol](https://modelcontextprotocol.io/) servers:
 
-| Server | Transport | Purpose |
-|--------|-----------|---------|
-| **mcp-atlassian** | stdio | Jira CRUD: search tickets, read/update issues, transitions, comments, sprints |
-| **bot-memory** | streamable HTTP | Task tracking (10 concurrent max) + RAG memory (vector search over past learnings) |
-| **chrome-devtools** | stdio | Browser automation for visual verification — navigate pages, take screenshots |
-| **hcc-patternfly-data-view** | stdio | PatternFly component docs (only loaded for frontend persona repos) |
+| Server | Transport | Runs in | Purpose |
+|--------|-----------|---------|---------|
+| **mcp-atlassian** | streamable HTTP (port 8444) | **Proxy** | Jira CRUD: search tickets, read/update issues, transitions, comments, sprints |
+| **bot-memory** | streamable HTTP (port 8080) | Memory server | Task tracking (10 concurrent max) + RAG memory (vector search over past learnings) + Slack notifications |
+| **chrome-devtools** | stdio | Bot | Browser automation for visual verification — navigate pages, take screenshots |
+| **hcc-patternfly-data-view** | stdio | Bot | PatternFly component docs (only loaded for frontend persona repos) |
 
-MCP servers are configured in two places:
-- `.mcp.json` — project-level servers (Jira, memory, browser) loaded every cycle
-- `personas/*/mcp.json` — per-persona servers loaded only when that persona is active
+MCP servers are configured in:
+- `bot/mcp.json` — bot-specific servers (mcp-atlassian via `JIRA_MCP_URL`)
+- `.mcp.json` — project-level servers (memory, browser) loaded every cycle
+- Remote config `agent/mcp.json` — additional per-instance servers
 
 ### Skills (`.claude/skills/`)
 
@@ -108,7 +109,11 @@ Skills are shell scripts that pre-gather data and inject it into the agent's con
 |-------|---------|
 | `/triage` | Pre-fetches all active tasks, PR/MR statuses (CI, reviews, conflicts), and Jira comments. Groups by action bucket (MERGED, CI_FAIL, CONFLICTS, FEEDBACK, INTERRUPTED, CLEAN). Agent uses this instead of calling `task_list` + `gh pr view` + `jira_get_issue` individually. |
 | `/new-work` | Pre-fetches unassigned Jira candidates from current sprint (+ backlog), ordered by priority, with full context and `repo:` label matching against `project-repos.json`. |
+| `/claim-ticket` | Claims a Jira ticket: assigns to bot, transitions to "In Progress", adds to active sprint. |
+| `/push-and-pr` | Pushes branch and creates PR/MR via GitHub/GitLab API (not `gh pr create` which doesn't work through the thin client). |
+| `/post-pr` | Post-PR actions: Jira transition to "Code Review", Jira comment with PR link, update linked issues. |
 | `/wrap-up` | Handles post-merge cleanup: task archival, Jira transition to "Release Pending", Jira comment, Slack notification, branch deletion. |
+| `/gh-release-upload` | Uploads screenshots to GitHub releases for embedding in PR comments (avoids committing images to repos). |
 
 ### Memory Server (`memory-server/`)
 
@@ -118,6 +123,8 @@ A FastMCP + Starlette application backed by PostgreSQL with pgvector. Serves two
 - `task_add`, `task_update`, `task_get`, `task_list`, `task_remove`, `task_check_capacity` — structured work tracking with status, PR links, branch names, progress metadata
 - `memory_store`, `memory_search`, `memory_list`, `memory_delete` — RAG knowledge base with auto-generated embeddings for semantic search
 - `bot_status_update` — live status banner for the dashboard
+- `slack_notify` — post notifications to team Slack (48h cooldown per ticket)
+- `check_org_member`, `store_org_member` — GitHub org membership verification cache
 
 **2. REST API + Dashboard** (port 8080) — web UI for humans:
 - Task and memory browsing with detail panels
@@ -130,9 +137,9 @@ Runs as two Docker containers:
 - `postgres` — pgvector/pgvector:pg17 (port 5433 externally, 5432 internally)
 - `memory-server` — Python app (port 8080)
 
-### Personas (`personas/`)
+### Personas (remote config)
 
-Domain-specific guidelines that tell the agent how to work in different types of repos. Each persona is a markdown file with coding standards, testing commands, and conventions.
+Domain-specific guidelines that tell the agent how to work in different types of repos. Each persona is a markdown file with coding standards, testing commands, and conventions. Personas live in the **remote config repo** under `agent/personas/<type>/prompt.md` — they are synced at startup via `BOT_CONFIG_REPO`.
 
 | Persona | Applies to | Key Details |
 |---------|------------|-------------|
@@ -143,12 +150,13 @@ Domain-specific guidelines that tell the agent how to work in different types of
 | `config` | Config/YAML repos (e.g. app-interface) | GitLab fork workflow, read-only or MR-based |
 | `cve` | CVE remediation (any repo) | Dependency upgrades, base image updates, grype scanning |
 | `tooling` | Build/dev infrastructure | Dockerfiles, shell scripts, proxy configs |
+| `rds-upgrade` | RDS blue-green upgrades | Layers on `config` persona |
 
 Personas are NOT hardcoded to repos. The bot dynamically selects the best-fit persona(s) based on the ticket description and the repo's tech stack (e.g. `package.json` → frontend, `go.mod` → backend/operator, Dockerfile-only → tooling). CVE persona layers on top of the base persona.
 
 ### Target Repos (`repos/`)
 
-Cloned on demand when the bot picks up a ticket. Repo metadata is in `project-repos.json`:
+Cloned on demand when the bot picks up a ticket. Repo metadata is in the remote config repo's `agent/project-repos.json` (synced at startup via `BOT_CONFIG_REPO`):
 
 ```json
 {
@@ -282,9 +290,9 @@ Most secrets never enter the bot container at all — they live exclusively in t
 | `GITLAB_TOKEN` | Proxy | Thin client shims forward glab CLI commands over gRPC; git credential helper for HTTPS push/pull to GitLab |
 | `GPG_PRIVATE_KEY_B64` | Proxy | Git invokes gpg shim → proxy signs the commit |
 | `GOOGLE_SA_KEY_B64` | Proxy | Vertex auth proxy injects OAuth2 tokens transparently |
-| `JIRA_API_TOKEN` | Bot | Resolved into MCP server config at startup, then stripped from env |
+| `JIRA_API_TOKEN` | Proxy | mcp-atlassian runs in proxy container on port 8444; bot connects via streamable HTTP |
 
-The only secret that enters the bot container is the Jira API token (needed by the mcp-atlassian MCP server). `sanitize_env()` in `bot/config.py` removes it from `os.environ` after MCP config resolution. All git operations use HTTPS with credential helpers that route through the proxy — no SSH keys are used.
+No secrets enter the bot container. All git operations use HTTPS with credential helpers that route through the proxy — no SSH keys are used.
 
 ### Layer 4: Network Firewall (Squid Proxy)
 
@@ -299,20 +307,23 @@ graph LR
     end
 
     subgraph Bridge["external network (internet)"]
-        Proxy["Proxy<br/>(Squid + Executor<br/>+ Vertex Auth)"]
+        Proxy["Proxy<br/>(Squid + Executor<br/>+ Vertex Auth<br/>+ Jira MCP)"]
     end
 
-    Internet["Internet<br/>(github.com, Jira,<br/>Vertex AI, etc.)"]
+    Internet["Internet<br/>(github.com,<br/>Vertex AI, etc.)"]
+    Jira["Jira Cloud"]
 
     Bot -- "HTTP/HTTPS<br/>(HTTP_PROXY)" --> Proxy
     Bot -- "gh/glab/gpg<br/>(gRPC)" --> Proxy
     Bot -- "Vertex AI<br/>(port 8443)" --> Proxy
+    Bot -- "Jira MCP<br/>(port 8444)" --> Proxy
+    Proxy --> Jira
     Bot --> MemSrv
     MemSrv --> PG
     Proxy --> Internet
 ```
 
-Allowed domains: `*.github.com`, `*.githubusercontent.com`, `*.redhat.com` (covers GitLab), `*.atlassian.net`, `*.googleapis.com`, `*.npmjs.org`, `pypi.org`, `files.pythonhosted.org`, `*.fedoraproject.org`.
+Allowed domains: `*.github.com`, `*.githubusercontent.com`, `*.redhat.com` (covers GitLab), `*.googleapis.com`, `*.npmjs.org`, `pypi.org`, `files.pythonhosted.org`, `*.fedoraproject.org`. Jira traffic goes through the mcp-atlassian server in the proxy (port 8444), not through Squid.
 
 Even if an attacker bypasses all other layers, there is no network route to exfiltrate data to unauthorized hosts.
 
@@ -361,7 +372,7 @@ The proxy:
 | Service | Auth Method | Runs in | Config |
 |---------|-------------|---------|--------|
 | Claude (Vertex AI) | GCP service account → OAuth2 Bearer | **Proxy** | SA key decoded from `GOOGLE_SA_KEY_B64`, Vertex auth proxy on port 8443 injects tokens |
-| Jira | API token | Bot | `JIRA_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN` in `.env` |
+| Jira | API token | **Proxy** | `JIRA_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN` → mcp-atlassian on port 8444; bot connects via `JIRA_MCP_URL` |
 | GitHub | PAT (`GH_TOKEN`) | **Proxy** | Config file at `~/.config/gh/hosts.yml` in proxy container |
 | GitLab | PAT (`GITLAB_TOKEN`) | **Proxy** | Config file at `~/.config/glab-cli/config.yml` in proxy container |
 | GPG signing | Private key | **Proxy** | Imported from `GPG_PRIVATE_KEY_B64` at proxy startup |
@@ -385,7 +396,7 @@ This keeps the deployment simple — one memory server serves all bot instances,
 
 Both images use Red Hat UBI9 base images:
 
-- **Bot container** (`Dockerfile`) — `ubi9/ubi` with Python 3.12, Node.js 22 (NodeSource), Chromium headless (EPEL), gh/glab/gpg thin client shims, uv. Runs as non-root `botuser` (Claude Code rejects root). Entrypoint configures git credential helpers (routing through thin client shims to the proxy), starts Chromium in background, then launches the bot runner. All secrets (GH_TOKEN, GITLAB_TOKEN, GPG key, SA key) live in the proxy container — the bot never sees them. Git uses HTTPS with credential helpers, not SSH.
+- **Bot container** (`Dockerfile`) — `ubi9/ubi` with Python 3.12, Node.js 22 (official binary tarball), Chromium headless (via Playwright), Go (multiple versions), gh/glab/gpg thin client shims, bubblewrap (sandbox), uv. Runs as non-root `botuser` (Claude Code rejects root). Entrypoint syncs remote config repo, configures git credential helpers (routing through thin client shims to the proxy), and launches the bot runner. All secrets live in the proxy container — the bot never sees them. Git uses HTTPS with credential helpers, not SSH. Runner instances can be built from `Dockerfile.runner` via git submodule (see README).
 
 - **Memory server** (`memory-server/Dockerfile`) — multi-stage build. Stage 1: `ubi9/nodejs-22` builds the React dashboard. Stage 2: `ubi9/python-312-minimal` runs the FastMCP app with dashboard assets baked in.
 
@@ -397,9 +408,9 @@ Both images use Red Hat UBI9 base images:
 
 ### What stays the same
 
-- `CLAUDE.md` and personas — baked into the bot image or mounted as a ConfigMap
-- `project-repos.json` — mounted as config
-- `.mcp.json` — mounted, with URLs pointing to cluster-internal services (e.g. `http://memory-server:8080`)
+- `CLAUDE.md` — baked into the bot image
+- Personas and `project-repos.json` — synced at startup from `BOT_CONFIG_REPO` (remote config repo)
+- `.mcp.json` — baked in, with URLs pointing to cluster-internal services (e.g. `http://memory-server:8080`)
 - Cost tracking — same REST API, just different base URL
 
 ### Network topology (target)
@@ -409,7 +420,7 @@ graph TB
     subgraph Cluster["Cluster (Kubernetes / OpenShift)"]
         BotA["Bot Pod<br/>(label A)"]
         BotB["Bot Pod<br/>(label B)"]
-        ProxyPod["Proxy Pod<br/>(Squid + Executor<br/>+ Vertex Auth)"]
+        ProxyPod["Proxy Pod<br/>(Squid + Executor<br/>+ Vertex Auth<br/>+ Jira MCP)"]
 
         subgraph MemPod["Memory Server Pod"]
             MemApp["Memory App<br/>(MCP + REST API)"]
@@ -442,7 +453,7 @@ Chromium headless runs inside each bot pod on port 9222.
 | GitLab PAT | `GITLAB_TOKEN` | **Proxy** — glab CLI + git credential helper (HTTPS) |
 | GPG private key (base64) | `GPG_PRIVATE_KEY_B64` | **Proxy** — commit signing via executor |
 | GCP service account key (base64) | `GOOGLE_SA_KEY_B64` | **Proxy** — Vertex AI auth proxy |
-| Jira credentials | `JIRA_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN` | Bot — mcp-atlassian MCP server |
+| Jira credentials | `JIRA_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN` | **Proxy** — mcp-atlassian MCP server (port 8444) |
 | RDS PostgreSQL credentials | `DATABASE_URL` | Memory server |
 
 ### Scaling

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -233,7 +233,7 @@ Or manually ensure the ticket has:
 
 Required labels:
 - **Primary label** — matches the bot instance: `hcc-ai-framework` or `hcc-ai-platform-accessmanagement`
-- **`repo:<name>`** — must match a key in `project-repos.json` (e.g. `repo:insights-rbac`, `repo:notifications-frontend`)
+- **`repo:<name>`** — must match a key in the remote config's `project-repos.json` (e.g. `repo:insights-rbac`, `repo:notifications-frontend`)
 
 Optional:
 - `needs-investigation` — bot investigates and reports findings instead of implementing

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An autonomous developer agent that picks groomed Jira tickets, implements them, opens PRs, and maintains them through review — all without human intervention. It runs in a polling loop using the Claude Agent SDK (Python) and integrates with Jira, GitHub/GitLab, and a persistent memory system.
 
+**Detailed docs:** [Architecture](ARCHITECTURE.md) | [Setup](SETUP.md) | [Operations](OPERATIONS.md)
+
 ## Prerequisites
 
 Before setting up the bot, make sure you have the following installed:
@@ -16,7 +18,7 @@ Before setting up the bot, make sure you have the following installed:
 | [gh](https://cli.github.com/) | GitHub CLI | `brew install gh` then `gh auth login` |
 | [glab](https://gitlab.com/gitlab-org/cli) | GitLab CLI (only for GitLab repos) | `brew install glab` then `glab auth login --hostname gitlab.cee.redhat.com` |
 
-The bot also uses the [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) MCP server for Jira integration (configured in `.mcp.json`).
+The bot also uses the [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) MCP server for Jira integration — it runs inside the proxy container in Docker mode (see [Architecture](#architecture-credential-isolation)).
 
 ### Authentication
 
@@ -113,7 +115,7 @@ Tickets must be explicitly groomed. The bot never picks random backlog items.
 ### Required labels
 
 - **Primary label** (e.g. `hcc-ai-framework`, `hcc-ai-platform-accessmanagement`) — marks the ticket as bot-eligible for a specific team. The bot only picks up tickets with its configured label.
-- **`repo:<name>`** — identifies the target repo (must match a key in `project-repos.json`). A ticket can have multiple `repo:` labels for cross-repo work.
+- **`repo:<name>`** — identifies the target repo (must match a key in the remote config's `project-repos.json`). A ticket can have multiple `repo:` labels for cross-repo work.
 
 ### Optional labels
 
@@ -148,7 +150,7 @@ All repos use forks by default. The bot pushes to the fork and opens PRs/MRs tar
    ```bash
    gh repo fork RedHatInsights/my-repo --clone=false
    ```
-2. Add to `project-repos.json`:
+2. Add to the remote config repo's `project-repos.json`:
    ```json
    "my-repo": {
      "url": "https://github.com/platex-rehor-bot/my-repo.git",
@@ -164,45 +166,90 @@ The bot clones repos automatically when it picks up a ticket. It fetches from `u
 
 Personas are NOT hardcoded to repos. The bot dynamically selects the best-fit persona(s) based on the ticket description and the repo's tech stack (e.g. `package.json` → `frontend`, `go.mod` → `backend`/`operator`, Dockerfile-only → `tooling`, config repo → `config`). For CVE tickets, the `cve` persona layers on top of the base persona.
 
+## Remote config
+
+Personas, `project-repos.json`, per-persona MCP servers, and custom skills live in a **remote config repo** rather than being baked into the bot image. This allows updating bot behavior without rebuilding.
+
+At startup, `run.py` clones/pulls the repo specified by `BOT_CONFIG_REPO` and merges its contents using the **merge engine** (`bot/merge.py`):
+
+- Remote personas, project-repos entries, MCP servers, and skills are added to the bot's runtime config
+- Bot-critical settings (security hooks, core skills, sandbox permissions, core MCP servers) are **protected** and cannot be overridden by remote config
+- The merge engine produces a report of what was added, overridden, or protected
+
+Set the repo URL via env var:
+```bash
+BOT_CONFIG_REPO=https://github.com/your-org/your-config-repo
+```
+
+The config repo should contain an `agent/` directory with:
+```
+agent/
+  project-repos.json   # Repo label → git URL mapping
+  personas/            # Per-repo-type guidelines (frontend/, backend/, etc.)
+  mcp.json             # Additional MCP servers
+  skills/              # Custom skills
+```
+
+## Running as a runner instance (Dockerfile.runner)
+
+For creating **new bot instances** with custom personas and config, the repo includes `Dockerfile.runner` — a full build template designed for use via git submodule.
+
+Runner repos add dev-bot as a submodule and build from `Dockerfile.runner`, which provides two extension points:
+
+- **`setup.sh`** (required) — custom build steps (install packages, write config, etc.)
+- **`instance/`** (optional) — extra files COPYed to `/home/botuser/app/instance/`
+
+### Setting up a runner repo
+
+```bash
+# 1. Create your runner repo
+mkdir my-bot-instance && cd my-bot-instance
+git init
+
+# 2. Add dev-bot as a submodule
+git submodule add https://github.com/RedHatInsights/platform-frontend-ai-dev.git dev-bot
+
+# 3. Create setup.sh (required)
+cat > setup.sh << 'EOF'
+#!/bin/bash
+set -e
+echo "my-bot-instance" > /home/botuser/app/.instance-id
+# Add custom build steps here (dnf install, config, etc.)
+EOF
+
+# 4. Create instance/ directory (optional)
+mkdir -p instance
+
+# 5. Build
+docker build -f dev-bot/Dockerfile.runner -t my-bot-instance:local .
+```
+
+To update to the latest dev-bot: `git submodule update --remote dev-bot`
+
+### Local development with docker-compose
+
+To test a runner image in docker-compose, create a `docker-compose.override.yml` (gitignored):
+
+```yaml
+services:
+  bot:
+    image: my-bot-instance:local
+    build: !reset null
+```
+
 ## Running the services
 
-### Option A: Bot on host, memory server in Docker (recommended)
+### Option A: OpenShift (recommended)
 
-The recommended setup for development. The bot runs directly on your machine while the memory server runs in Docker.
-
-#### 1. Configure `.env`
-
-Copy `.env.example` to `.env` and fill in your credentials. All identity and auth settings are driven by `.env` — at startup, `run.py` reads these and auto-configures git identity and credential helpers.
-
-**Git identity** — set `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` to commit as the bot account. If unset, your local git config is used.
-
-**GPG signing** — import the bot's GPG key (`gpg --import <key-file>`), then set `GPG_SIGNING_KEY` to the key ID. If unset, commits are not signed. In Docker, GPG keys are imported automatically in the proxy container from `GPG_PRIVATE_KEY_B64`.
-
-**CLI auth** — set `GH_TOKEN` and/or `GITLAB_TOKEN`, or log in manually:
-```bash
-gh auth login                                       # GitHub
-glab auth login --hostname gitlab.cee.redhat.com    # GitLab
-```
-
-> **Note**: In Docker, all secrets (`GH_TOKEN`, `GITLAB_TOKEN`, `GPG_PRIVATE_KEY_B64`, `GOOGLE_SA_KEY_B64`) are injected into the **proxy container**, not the bot. The bot uses thin client shims that forward CLI commands to the proxy over gRPC, and the Vertex AI auth proxy (port 8443) injects OAuth2 tokens transparently. See [Architecture](#architecture-credential-isolation).
-
-#### 2. Start the services
-
-```bash
-# Start memory server + postgres
-make memory-server
-
-# Run bot on host (uses localhost:8080 for memory server)
-make run LABEL=hcc-ai-framework
-```
+The production deployment. Bot, proxy, and memory server run as separate pods with full credential isolation and network policies. See `deploy/template.yaml` and `OPERATIONS.md` for details.
 
 ### Option B: Full stack in Docker
 
-For production-like deployments or CI — everything runs in containers with credential isolation (see [Architecture](#architecture-credential-isolation)):
+For local development — everything runs in containers with credential isolation (see [Architecture](#architecture-credential-isolation)):
 
 ```bash
 # Set secrets (or add to .env — see SOP.md for details)
-# CLI tokens + GPG key + SA key → proxy container (credential isolation)
+# CLI tokens + GPG key + SA key + Jira creds → proxy container (credential isolation)
 export GH_TOKEN=<your-pat>
 export GITLAB_TOKEN=<your-gitlab-pat>
 export GPG_PRIVATE_KEY_B64=$(base64 -i .ssh/gpg-private.asc)
@@ -217,6 +264,23 @@ BOT_LABEL=hcc-ai-platform-accessmanagement make docker-up
 
 # Stop
 make docker-down
+```
+
+All secrets (`GH_TOKEN`, `GITLAB_TOKEN`, `GPG_PRIVATE_KEY_B64`, `GOOGLE_SA_KEY_B64`, `JIRA_API_TOKEN`) are injected into the **proxy container**, not the bot. The bot uses thin client shims that forward CLI commands to the proxy over gRPC, the Vertex AI auth proxy (port 8443) injects OAuth2 tokens transparently, and the Jira MCP server (mcp-atlassian) runs in the proxy on port 8444. See [Architecture](#architecture-credential-isolation).
+
+### Option C: Bot on host (advanced)
+
+Running the bot directly on your machine bypasses the security harness (proxy-based credential isolation, Squid allowlist, bash hooks enforcement). This mode requires manual setup of git identity, GPG signing, and CLI auth, and is not recommended for production use.
+
+```bash
+# 1. Configure .env with credentials (see Authentication above)
+cp .env.example .env
+
+# 2. Start memory server + postgres
+make memory-server
+
+# 3. Run bot on host (uses localhost:8080 for memory server)
+make run LABEL=hcc-ai-framework
 ```
 
 ### Memory server + dashboard
@@ -257,11 +321,11 @@ This launches Chrome on port 9222 with a separate profile. Edit the script to us
 }
 ```
 
-MCP servers are configured in `.mcp.json` (project-level) and `personas/*/mcp.json` (per-persona tools).
+MCP servers are configured in `.mcp.json` (project-level). Remote config repos can provide additional MCP servers via `agent/mcp.json`.
 
 ## Personas
 
-Each repo has one or more personas that provide domain-specific guidelines. Personas live in `personas/<type>/prompt.md`:
+Personas provide domain-specific guidelines for different repo types. They live in the remote config repo under `agent/personas/<type>/prompt.md`:
 
 | Persona | Scope |
 |---------|-------|
@@ -272,6 +336,21 @@ Each repo has one or more personas that provide domain-specific guidelines. Pers
 | `config` | Config repos (app-interface). Read-only or GitLab MR workflow. |
 | `cve` | CVE remediation — dependency upgrades, base image updates, security scanning. |
 | `tooling` | Build/dev infrastructure — Dockerfiles, shell scripts, proxy configs. |
+| `rds-upgrade` | RDS blue-green upgrades in app-interface. Layers on `config`. |
+
+## Skills
+
+The bot has built-in skills (Claude Code slash commands) in `.claude/skills/`:
+
+| Skill | Purpose |
+|-------|---------|
+| `triage` | Pre-gathers all active task statuses, PR/MR states, CI, reviews, Jira comments |
+| `new-work` | Fetches unassigned sprint candidates with full context |
+| `claim-ticket` | Claims a Jira ticket (assign, transition, sprint) |
+| `push-and-pr` | Pushes branch and creates PR/MR via API |
+| `post-pr` | Post-PR actions (Jira transition, comments, linked issues) |
+| `wrap-up` | Handles PR merge cleanup (archival, Jira transition, Slack, branch deletion) |
+| `gh-release-upload` | Uploads screenshots to GitHub releases for PR comments |
 
 ## Memory system
 
@@ -309,7 +388,7 @@ make costs-week      # Last 7 days
 ./costs.sh backfill     # Import from bot.log
 ```
 
-The dashboard at http://localhost:8080 also shows cost charts with per-cycle breakdowns by work type.
+The dashboard at http://localhost:8080 shows cost breakdowns, per-cycle metrics, task status, memory search, and a 3D embedding visualization.
 
 ## Architecture: Credential Isolation
 
@@ -330,6 +409,7 @@ graph LR
         Squid["Squid<br/>(port 3128)<br/>domain allowlist"]
         Exec["executor-server<br/>(gRPC)<br/>policy allowlist"]
         VertexAuth["Vertex Auth Proxy<br/>(port 8443)<br/>OAuth2 token injection"]
+        JiraMCP["mcp-atlassian<br/>(port 8444)<br/>Jira API"]
         Bins["gh-real / glab-real<br/>gpg (with keys)"]
     end
 
@@ -339,10 +419,11 @@ graph LR
     GitPush -- "gRPC" --> Exec
     Exec --> Bins
     VertexReq -- "HTTP :8443" --> VertexAuth
+    SDK -- "HTTP :8444" --> JiraMCP
     SDK -- "HTTP_PROXY :3128" --> Squid
 
     VertexAuth -- "HTTPS + Bearer" --> VertexAPI["Vertex AI"]
-    Squid --> Internet["GitHub / GitLab<br/>Jira / npm / etc."]
+    Squid --> Internet["GitHub / GitLab<br/>npm / etc."]
 ```
 
 ### How it works
@@ -352,6 +433,7 @@ graph LR
 - **Git credential helpers** are configured globally so `git push` transparently authenticates via the thin client → proxy path.
 - **GPG commit signing** works the same way — git invokes `gpg --sign` which routes through the thin client to the proxy's GPG keyring.
 - **Vertex AI auth proxy** (port 8443) — the bot sends unauthenticated requests to the proxy's embedded HTTP server. The proxy injects OAuth2 Bearer tokens from the GCP service account, rewrites dummy project/region values to real ones, enforces a model allowlist, and forwards to the Vertex AI API. The bot never sees the SA key or tokens.
+- **Jira MCP server** (port 8444) — mcp-atlassian runs inside the proxy container with the Jira API token. The bot connects via streamable HTTP transport — no Jira credentials in the bot container.
 - **HTTP/HTTPS traffic** is routed through Squid with a domain allowlist — the bot container has no direct internet access.
 - **Bash hooks** (`.claude/hooks/validate-bash.sh`) block dangerous commands (curl, eval, credential reads) as an additional defense layer.
 
@@ -362,14 +444,17 @@ graph LR
 | GH_TOKEN / GITLAB_TOKEN | - | yes |
 | GPG private key | - | yes |
 | GCP service account key | - | yes |
+| Jira API token | - | yes |
 | gh / glab CLIs (real) | - | yes |
 | gh / glab / gpg (thin client) | yes | - |
 | Squid proxy | - | yes |
 | Vertex AI auth proxy | - | yes |
+| mcp-atlassian (Jira MCP) | - | yes |
 | Agent SDK + bot code | yes | - |
-| Jira API token | yes* | - |
 
-\* Jira token still resides in the bot container. Planned isolation: [RHCLOUD-47287](https://redhat.atlassian.net/browse/RHCLOUD-47287) (MCP air-lock for Jira).
+### Dev proxy (local UI verification)
+
+The `dev-proxy/` directory contains a custom Caddy build for local UI verification against stage environments. The bot starts it when it needs to verify frontend changes against a running HCC stage deployment.
 
 ### Deployment
 
@@ -383,22 +468,30 @@ dev-bot/
   pyproject.toml         # Python project config (uv workspace root)
   Makefile               # Common commands
   bot/                   # Agent runner (Python package)
-    run.py               # Main loop entry point
+    run.py               # Main loop + remote config sync
     agent.py             # SDK query invocation per cycle
     config.py            # Config loading + MCP server merging
     costs.py             # Cost tracking
+    merge.py             # Remote config merge engine (protected-key registry)
   config.json            # Model, polling intervals, Jira config
-  project-repos.json     # Repo label -> git URL + persona mapping
   CLAUDE.md              # Full agent instructions (the bot's brain)
   .mcp.json              # MCP server connections (Jira, memory, browser)
   .env                   # Credentials (not committed)
+  Dockerfile             # Bot container image
+  Dockerfile.runner      # Runner instance template (used via git submodule)
+  docker-compose.yml     # Full stack: bot + proxy + memory server + postgres
+  entrypoint.sh          # Container entrypoint (remote config sync + bot start)
   init.sh                # Installs LSP, downloads BrowserMCP, starts memory server
   costs.sh               # Cost report CLI
   start-chromium.sh      # Launch Chrome with remote debugging
-  proxy/                 # Credential-bearing proxy (Squid + executor + Vertex auth)
-    Dockerfile           # Squid + gh-real/glab-real + executor binaries
+  .claude/               # Claude Code config
+    settings.json        # Permissions + sandbox config
+    hooks/               # Bash validation hooks (security)
+    skills/              # Built-in skills (triage, claim-ticket, push-and-pr, etc.)
+  proxy/                 # Credential-bearing proxy (Squid + executor + Vertex auth + Jira MCP)
+    Dockerfile           # Squid + gh-real/glab-real + executor + mcp-atlassian
     squid.conf           # Domain allowlist
-    start.sh             # Process manager (Squid + executor-server)
+    start.sh             # Process manager (Squid + executor-server + mcp-atlassian)
     executor/            # gRPC executor + Vertex auth proxy (Go)
       proto/             # Protobuf service definition
       gen/               # Generated gRPC code
@@ -407,26 +500,23 @@ dev-bot/
       policy.go          # CLI command allowlist engine
       vertex.go          # Vertex AI reverse proxy (URL rewrite + token injection)
       vertex_policy.go   # Vertex AI model allowlist engine
+  dev-proxy/             # Custom Caddy for local UI verification against stage
+    Caddyfile            # Reverse proxy config
+    main.go              # Caddy with custom modules
+    start-proxy.sh       # Start script
   memory-server/         # Persistent memory + task tracking
     src/
       server.py          # FastMCP + Starlette + WebSocket
-      tools/             # MCP tools (task_*, memory_*)
+      tools/             # MCP tools (task_*, memory_*, slack_notify)
       api.py             # REST API for the dashboard
       static/            # Dashboard UI (React + Vite, built assets)
     docker-compose.yml   # PostgreSQL (pgvector) + memory server
-  personas/              # Per-repo-type guidelines
-    frontend/            # React/TS/PatternFly + PatternFly MCP
-    backend/             # Go/Node backend
-    rbac/                # Django/DRF RBAC service
-    operator/            # Kubernetes operator
-    config/              # Config repo
-    cve/                 # CVE remediation
-    tooling/             # Dockerfiles, scripts, proxy configs
   prompts/               # Interactive prompts (grooming, etc.)
   dashboard/             # Dashboard source (React + Vite + TypeScript)
   deploy/                # OpenShift deployment template
-  repos/                 # Cloned target repos (created on demand)
+  tests/                 # Bot unit tests (merge engine, etc.)
   scripts/               # Utility scripts
+  repos/                 # Cloned target repos (created on demand, gitignored)
 ```
 
 ## Example

--- a/SETUP.md
+++ b/SETUP.md
@@ -45,7 +45,7 @@ For org repos, an org admin must invite the bot account to the appropriate team.
 
 ### 2.1 Secrets
 
-These secrets are needed for deployment. All live in the **proxy container** except Jira credentials (bot container).
+These secrets are needed for deployment. All live in the **proxy container** (including Jira credentials — mcp-atlassian runs in the proxy on port 8444).
 
 | Secret | How to generate | Lives in | Used for |
 |--------|----------------|----------|----------|
@@ -85,7 +85,7 @@ For OpenShift, store these as secrets and inject them as env vars into the pod.
 
 When running the bot locally alongside your personal GitHub account, use separate `gh` auth contexts or set `GH_TOKEN` in `.env` to the bot's PAT. The bot uses HTTPS with credential helpers for all git operations — no SSH configuration needed.
 
-Fork URLs in `project-repos.json` use HTTPS:
+Fork URLs in the remote config's `project-repos.json` use HTTPS:
 
 ```json
 "pdf-generator": {


### PR DESCRIPTION
## Summary

- **README.md**: Added doc links at top (Architecture, Setup, Operations). Reordered deployment options: OpenShift (recommended) → Docker Compose → bot-on-host (advanced, with security harness warning). Added sections for Remote Config, Dockerfile.runner, Skills. Updated all references from local `project-repos.json`/`personas/` to remote config. Updated Jira MCP to proxy container. Updated cost tracking to mention full dashboard features.
- **ARCHITECTURE.md**: Moved Jira MCP from bot (stdio) to proxy (streamable HTTP, port 8444) in all diagrams and tables. Added `merge.py`, missing skills (claim-ticket, push-and-pr, post-pr, gh-release-upload), slack_notify, org membership tools. Updated container image description, credential tables, and network diagrams.
- **OPERATIONS.md**: Updated `project-repos.json` references to remote config.
- **SETUP.md**: Updated Jira credentials to proxy container, `project-repos.json` references to remote config.
- **.gitignore**: Added `docker-compose.override.yml`.

## Test plan

- [x] Verify markdown renders correctly on GitHub
- [x] Verify mermaid diagrams render in ARCHITECTURE.md
- [x] Cross-check "What lives where" table against actual docker-compose.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)