### PR TITLE
feat(RHCLOUD-47010): add option for push PR to read PR template

### DIFF
--- a/.claude/skills/push-and-pr/README.md
+++ b/.claude/skills/push-and-pr/README.md
@@ -123,6 +123,32 @@ ruff check --fix .
 uv run python scripts/push_and_pr_operations.py "Test PR" "Test description" --dry-run
 ```
 
+## PR Template Support
+
+The skill can discover and use a repo's PR template to structure the PR body.
+
+### Finding Templates
+
+```bash
+python3 scripts/push_and_pr_operations.py --find-template
+```
+
+Searches these locations in order (first match wins):
+1. `.github/pull_request_template.md`
+2. `.github/PULL_REQUEST_TEMPLATE.md`
+3. `pull_request_template.md`
+4. `PULL_REQUEST_TEMPLATE.md`
+5. `.github/PULL_REQUEST_TEMPLATE/default.md`
+
+Exit 0 and prints template content if found. Exit 1 if no template exists.
+
+### Workflow
+
+1. Run `--find-template` to discover the repo's PR template
+2. If found, fill in each section (description, checklist, AI disclosure, etc.)
+3. Pass the filled template as the `body` argument to the main command
+4. If not found, use freeform format (ticket key + changes summary)
+
 ## Error Handling
 
 All operations follow fail-fast behavior:

--- a/.claude/skills/push-and-pr/SKILL.md
+++ b/.claude/skills/push-and-pr/SKILL.md
@@ -13,7 +13,30 @@ allowed-tools:
   - Read
 ---
 
-Run the push-and-pr script after committing changes:
+## Template-aware PR body
+
+Before creating the PR, check if the repo has a PR template and use it to structure the body.
+
+**Step 1 — Discover template:**
+
+```bash
+python3 .claude/skills/push-and-pr/scripts/push_and_pr_operations.py --find-template 2>&1
+```
+
+- Exit 0 → template found, raw content printed to stdout.
+- Exit 1 → no template found, use freeform format (ticket key + changes summary).
+
+**Step 2 — Fill template sections:**
+
+If a template was found, fill in each section before passing as `<PR_BODY>`:
+- Remove HTML comments (`<!-- ... -->`) and replace with actual content.
+- **Description/Summary** → what changed, why, Jira ticket link `[KEY](url)`.
+- **Checklist** → mark completed items `[x]`, leave others `[ ]`.
+- **AI disclosure** → "Assisted by: Claude Code".
+- **Screenshots** → reference uploaded screenshot URLs (if applicable).
+- **Other sections** → fill based on heading context; write "N/A" if not applicable.
+
+**Step 3 — Push and create PR:**
 
 ```bash
 python3 .claude/skills/push-and-pr/scripts/push_and_pr_operations.py "<PR_TITLE>" "<PR_BODY>" 2>&1

--- a/.claude/skills/push-and-pr/scripts/push_and_pr_operations.py
+++ b/.claude/skills/push-and-pr/scripts/push_and_pr_operations.py
@@ -35,6 +35,15 @@ class RepositoryConfig:
     fork_url: Optional[str] = None
 
 
+PR_TEMPLATE_PATHS = [
+    ".github/pull_request_template.md",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    "pull_request_template.md",
+    "PULL_REQUEST_TEMPLATE.md",
+    ".github/PULL_REQUEST_TEMPLATE/default.md",
+]
+
+
 class PushAndPROperations:
     """Handles push and PR creation operations."""
 
@@ -213,6 +222,36 @@ class PushAndPROperations:
                 return owner_repo
 
         return url  # Fallback to original URL
+
+    @staticmethod
+    def find_pr_template(repo_dir: Optional[Path] = None) -> OperationResult:
+        """
+        Search for a PR template in the repository.
+
+        Checks common locations in priority order and returns the first match.
+
+        Args:
+            repo_dir: Directory to search in. Defaults to cwd.
+
+        Returns:
+            OperationResult with data={"path": str, "content": str} if found,
+            or data={"path": None} if no template exists.
+        """
+        base = repo_dir or Path.cwd()
+        for template_path in PR_TEMPLATE_PATHS:
+            full_path = base / template_path
+            if full_path.is_file():
+                try:
+                    content = full_path.read_text(encoding="utf-8")
+                    return OperationResult(
+                        True,
+                        f"Found PR template at {template_path}",
+                        data={"path": str(template_path), "content": content},
+                    )
+                except OSError as e:
+                    return OperationResult(False, f"Failed to read {template_path}: {e}")
+
+        return OperationResult(True, "No PR template found", data={"path": None})
 
     def sync_fork(self) -> OperationResult:
         """
@@ -504,11 +543,28 @@ def execute_push_and_pr_workflow(title: str, body: str, dry_run: bool = False) -
 def main():
     """CLI entrypoint for the push-and-pr skill."""
     parser = argparse.ArgumentParser(description="Push branch and create PR/MR")
-    parser.add_argument("title", help="PR/MR title")
-    parser.add_argument("body", help="PR/MR body/description")
+    parser.add_argument("title", nargs="?", help="PR/MR title")
+    parser.add_argument("body", nargs="?", help="PR/MR body/description")
     parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
+    parser.add_argument(
+        "--find-template",
+        action="store_true",
+        help="Find and print the repo's PR template, then exit. Exit 0 if found, 1 if not.",
+    )
 
     args = parser.parse_args()
+
+    if args.find_template:
+        result = PushAndPROperations.find_pr_template()
+        if result.success and result.data and result.data.get("path"):
+            print(result.data["content"], end="")
+            sys.exit(0)
+        else:
+            print(result.message, file=sys.stderr)
+            sys.exit(1)
+
+    if not args.title or not args.body:
+        parser.error("title and body are required when not using --find-template")
 
     exit_code = execute_push_and_pr_workflow(title=args.title, body=args.body, dry_run=args.dry_run)
     sys.exit(exit_code)

--- a/.claude/skills/push-and-pr/tests/test_operations.py
+++ b/.claude/skills/push-and-pr/tests/test_operations.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from scripts.push_and_pr_operations import (
+    PR_TEMPLATE_PATHS,
     PushAndPROperations,
     RepositoryConfig,
 )
@@ -654,3 +655,90 @@ class TestDryRun:
 
         assert result.success is True
         mock_run.assert_called_once()
+
+
+class TestFindPRTemplate:
+    """Test find_pr_template static method."""
+
+    def test_finds_github_template(self, temp_dir):
+        """Test finding .github/pull_request_template.md (most common location)."""
+        github_dir = temp_dir / ".github"
+        github_dir.mkdir()
+        template = github_dir / "pull_request_template.md"
+        template.write_text("## Description\n<!-- what and why -->\n")
+
+        result = PushAndPROperations.find_pr_template(repo_dir=temp_dir)
+
+        assert result.success is True
+        assert result.data["path"] == ".github/pull_request_template.md"
+        assert "## Description" in result.data["content"]
+
+    def test_finds_root_uppercase_template(self, temp_dir):
+        """Test finding PULL_REQUEST_TEMPLATE.md in repo root (no .github/ dir)."""
+        template = temp_dir / "PULL_REQUEST_TEMPLATE.md"
+        template.write_text("# PR Template\n")
+
+        result = PushAndPROperations.find_pr_template(repo_dir=temp_dir)
+
+        assert result.success is True
+        assert result.data["path"] in ("PULL_REQUEST_TEMPLATE.md", "pull_request_template.md")
+
+    def test_finds_root_template(self, temp_dir):
+        """Test finding pull_request_template.md in repo root."""
+        template = temp_dir / "pull_request_template.md"
+        template.write_text("Root template\n")
+
+        result = PushAndPROperations.find_pr_template(repo_dir=temp_dir)
+
+        assert result.success is True
+        assert result.data["path"] in ("pull_request_template.md", "PULL_REQUEST_TEMPLATE.md")
+
+    def test_finds_default_template_in_subdirectory(self, temp_dir):
+        """Test finding .github/PULL_REQUEST_TEMPLATE/default.md."""
+        template_dir = temp_dir / ".github" / "PULL_REQUEST_TEMPLATE"
+        template_dir.mkdir(parents=True)
+        template = template_dir / "default.md"
+        template.write_text("Default template\n")
+
+        result = PushAndPROperations.find_pr_template(repo_dir=temp_dir)
+
+        assert result.success is True
+        assert result.data["path"] == ".github/PULL_REQUEST_TEMPLATE/default.md"
+
+    def test_no_template_found(self, temp_dir):
+        """Test graceful handling when no template exists."""
+        result = PushAndPROperations.find_pr_template(repo_dir=temp_dir)
+
+        assert result.success is True
+        assert result.data["path"] is None
+        assert "No PR template found" in result.message
+
+    def test_priority_order_github_over_root(self, temp_dir):
+        """Test that .github/ template is found before root template."""
+        github_dir = temp_dir / ".github"
+        github_dir.mkdir()
+        (github_dir / "pull_request_template.md").write_text("github dir\n")
+        (temp_dir / "PULL_REQUEST_TEMPLATE.md").write_text("root dir\n")
+
+        result = PushAndPROperations.find_pr_template(repo_dir=temp_dir)
+
+        assert result.success is True
+        assert ".github/" in result.data["path"]
+        assert result.data["content"] == "github dir\n"
+
+    def test_uses_cwd_when_no_repo_dir(self):
+        """Test that find_pr_template defaults to cwd."""
+        with patch("scripts.push_and_pr_operations.Path.cwd") as mock_cwd:
+            mock_cwd.return_value = Path("/nonexistent/path")
+            result = PushAndPROperations.find_pr_template()
+
+        assert result.success is True
+        assert result.data["path"] is None
+
+    def test_template_paths_constant(self):
+        """Test that PR_TEMPLATE_PATHS contains expected entries."""
+        assert ".github/pull_request_template.md" in PR_TEMPLATE_PATHS
+        assert ".github/PULL_REQUEST_TEMPLATE.md" in PR_TEMPLATE_PATHS
+        assert "pull_request_template.md" in PR_TEMPLATE_PATHS
+        assert "PULL_REQUEST_TEMPLATE.md" in PR_TEMPLATE_PATHS
+        assert ".github/PULL_REQUEST_TEMPLATE/default.md" in PR_TEMPLATE_PATHS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,8 @@ Before starting work, `jira_get_issue` → check issue links:
 
     **CRITICAL**: glab URL-encodes newlines if description is passed inline. ALWAYS use heredoc `$(cat <<'EOF' ... EOF)` for multiline descriptions.
 
-    Parse PR/MR number + URL from JSON response. Title ≤50 chars. Body = ticket key + changes summary.
+    Parse PR/MR number + URL from JSON response. Title ≤50 chars.
+    **PR body**: Use the `/push-and-pr` skill's `--find-template` to discover the repo's PR template. If found, fill in each section (see SKILL.md for details). If not found, fall back to freeform: ticket key + changes summary.
     Readonly repos: include config changes in Jira comment.
 
 11. **Track PRs**: `task_update` status `pr_open`, `pr_number`, `pr_url`, `summary`, `last_addressed`. Multi-repo: `metadata.prs`:


### PR DESCRIPTION
### Description
[RHCLOUD-47010](https://issues.redhat.com/browse/RHCLOUD-47010)

Read PR template of repository, if it is provided use that template when creating PR. If not use free flow format. This PR adjusts the push and PR skill so we save some tokens.

---

### Blast radius
None

---

### Rollback plan
None

---

### Checklist
- [x] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images pinned to specific tags, not `latest`

### AI disclosure
Assisted by: Claude Code


[RHCLOUD-47010]: https://redhat.atlassian.net/browse/RHCLOUD-47010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ