### PR TITLE
feat(sleep): deterministic skill-based sleep signaling

### DIFF
--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -13,6 +13,8 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+SLEEP_FILE = Path(__file__).resolve().parent.parent.parent.parent / "data" / "cycle-sleep.json"
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from jira_mcp import jira_call
 
@@ -186,6 +188,8 @@ def main():
     candidates = get_candidates()
     if not candidates:
         print("NO CANDIDATES FOUND")
+        SLEEP_FILE.parent.mkdir(parents=True, exist_ok=True)
+        SLEEP_FILE.write_text(json.dumps({"recommended_sleep": 3600, "reason": "no_eligible_work"}))
         return
 
     print(f"NEW WORK CANDIDATES ({len(candidates)})")

--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -13,10 +13,9 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-SLEEP_FILE = Path(__file__).resolve().parent.parent.parent.parent / "data" / "cycle-sleep.json"
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from jira_mcp import jira_call
+from paths import SLEEP_FILE
 
 PROJECT_REPOS = Path(__file__).resolve().parent.parent.parent.parent / "project-repos.json"
 BOT_LABEL = os.environ.get("BOT_LABEL", "")

--- a/.claude/skills/paths.py
+++ b/.claude/skills/paths.py
@@ -1,0 +1,6 @@
+"""Shared path constants for skill scripts."""
+
+from pathlib import Path
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
+SLEEP_FILE = DATA_DIR / "cycle-sleep.json"

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -13,6 +13,8 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+SLEEP_FILE = Path(__file__).resolve().parent.parent.parent.parent / "data" / "cycle-sleep.json"
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from jira_mcp import jira_call
 
@@ -420,6 +422,9 @@ def main():
     total = len(merged) + len(closed) + len(ci_fail) + len(conflict) + len(feedback) + len(interrupted)
     if total == 0:
         print("-> all clean -> Priority 2")
+        if active_n >= max_n:
+            SLEEP_FILE.parent.mkdir(parents=True, exist_ok=True)
+            SLEEP_FILE.write_text(json.dumps({"recommended_sleep": 3600, "reason": "at_capacity_all_clean"}))
     else:
         print(f"-> {total} task(s) need work. Top bucket first. ONE/cycle.")
 

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -13,10 +13,9 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-SLEEP_FILE = Path(__file__).resolve().parent.parent.parent.parent / "data" / "cycle-sleep.json"
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from jira_mcp import jira_call
+from paths import SLEEP_FILE
 
 MEMORY_URL = os.environ.get("BOT_MEMORY_URL", "http://localhost:8080").rstrip("/mcp").rstrip("/")
 PROJECT_REPOS = Path(__file__).resolve().parent.parent.parent.parent / "project-repos.json"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,12 @@ ONE item per cycle. Priority order:
 - Cycle end: `idle`, "Cycle complete. Sleeping..." or "No work found. Sleeping..."
 - Error: `error`, "<what went wrong>"
 
+**Sleep signaling**: Skills write `data/cycle-sleep.json` to tell the Python runner how long to sleep. The agent does NOT need to manage this — it's automatic:
+- `/triage` writes `recommended_sleep: 3600` when at capacity + all tasks clean (nothing actionable)
+- `/new-work` writes `recommended_sleep: 3600` when no eligible candidates found
+- No signal file = standard 300s sleep (work was done)
+- The runner reads and deletes the file after each cycle
+
 ### Triage (start of every cycle)
 
 Invoke `/triage` skill first. It runs a script that pre-gathers all active tasks, PR/MR statuses (state, CI, reviews, merge conflicts), Jira comments, PR comments, and capacity — grouped by action bucket (MERGED, CI_FAIL, CONFLICTS, FEEDBACK, INTERRUPTED, CLEAN).

--- a/bot/run.py
+++ b/bot/run.py
@@ -3,6 +3,7 @@
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -156,12 +157,42 @@ def sync_config_repo() -> Path | None:
 
 
 
+SLEEP_SIGNAL_FILE = DATA_DIR / "cycle-sleep.json"
 LOW_DISK_THRESHOLD_MB = 512
+
+
+def _read_sleep_signal(config: Config) -> int:
+    """Read sleep duration from skill-written signal file.
+
+    Skills write data/cycle-sleep.json with {"recommended_sleep": N, "reason": "..."}.
+    No file = standard interval (work was done). File is always deleted after reading.
+    """
+    logger = logging.getLogger(__name__)
+    sleep_seconds = config.interval
+
+    if SLEEP_SIGNAL_FILE.exists():
+        try:
+            sig = json.loads(SLEEP_SIGNAL_FILE.read_text())
+            sleep_seconds = sig.get("recommended_sleep", config.interval)
+            reason = sig.get("reason", "")
+            logger.info("Sleep signal: %ds (%s)", sleep_seconds, reason)
+        except Exception:
+            logger.warning("Bad sleep signal file, using default %ds", config.interval)
+        finally:
+            SLEEP_SIGNAL_FILE.unlink(missing_ok=True)
+    else:
+        logger.info("No sleep signal, using default %ds", config.interval)
+
+    logger.info("Sleeping for %ds...", sleep_seconds)
+    time.sleep(sleep_seconds)
+    return sleep_seconds
 
 
 def cleanup_between_cycles(script_dir: Path) -> None:
     """Free disk space between cycles if below threshold."""
     logger = logging.getLogger(__name__)
+
+    SLEEP_SIGNAL_FILE.unlink(missing_ok=True)
 
     try:
         usage = shutil.disk_usage(str(script_dir))
@@ -292,27 +323,17 @@ def main() -> None:
                 result, ctx = None, None
 
             if result is not None:
-                no_work = record_cost(
+                record_cost(
                     costs_file=DATA_DIR / "costs.jsonl",
                     label=args.label,
                     result=result,
                     ctx=ctx,
                 )
             else:
-                no_work = False
                 logger.warning("Cycle produced no result")
 
-            cleanup_between_cycles(SCRIPT_DIR)
+            sleep_seconds = _read_sleep_signal(config)
 
-            if no_work:
-                logger.info(
-                    "No work found. Sleeping for %ds...", config.idle_interval
-                )
-                time.sleep(config.idle_interval)
-            else:
-                logger.info(
-                    "Cycle complete. Sleeping for %ds...", config.interval
-                )
-                time.sleep(config.interval)
+            cleanup_between_cycles(SCRIPT_DIR)
     finally:
         lock.release()


### PR DESCRIPTION
## Summary

- Skills now write `data/cycle-sleep.json` with recommended sleep duration instead of relying on fragile pattern matching of agent output text
- **Triage**: writes `recommended_sleep: 3600` when at capacity + all tasks clean
- **New-work**: writes `recommended_sleep: 3600` when no eligible candidates found
- No signal file = standard 300s sleep (work was done)
- Python runner reads and deletes the file after each cycle

RHCLOUD-47757