### PR TITLE
refactor(claim-ticket): env var board config

### DIFF
--- a/.claude/skills/claim-ticket/README.md
+++ b/.claude/skills/claim-ticket/README.md
@@ -26,7 +26,7 @@ When the bot picks up new work, this skill executes 8 operations in sequence:
 2. **get_transitions** - Get available transitions and find "In Progress" ID
 3. **assign_ticket** - Assign ticket to bot user
 4. **transition_to_in_progress** - Move ticket to "In Progress" status
-5. **resolve_board** - Determine correct board (platform-experience-ui label → 9297, else → 8070)
+5. **resolve_board** - Determine board from BOT_BOARD_ID or BOT_BOARD_NAME env var
 6. **get_active_sprint** - Get active sprint from the board
 7. **add_to_sprint** - Add ticket to active sprint
 8. **task_add** - Track ticket in memory server
@@ -99,9 +99,9 @@ export JIRA_API_TOKEN=your_api_token_here
 # Memory Server (required)
 export BOT_MEMORY_URL=https://memory-server.example.com
 
-# Board Configuration (optional, has defaults)
-export PLATFORM_UI_BOARD_ID=9297
-export DEFAULT_BOARD_ID=8070
+# Board Configuration (one of these required)
+export BOT_BOARD_ID=9297                          # Direct board ID (skips lookup)
+export BOT_BOARD_NAME="Platform Experience UI"    # Lookup board by name via Jira
 ```
 
 **Note:** Uses JIRA Cloud API v3 with Basic authentication (email + API token).
@@ -197,16 +197,13 @@ Managed with **uv** for fast, reliable dependency resolution.
 
 ## Board Resolution Logic
 
-The skill uses label-based board detection to eliminate trial-and-error:
+The skill resolves the board from environment variables (same pattern as new-work skill):
 
-1. Fetch ticket labels from JIRA
-2. Check if `platform-experience-ui` label is present
-   - **Yes**: Use Board 9297 (Platform Experience UI board)
-   - **No**: Use Board 8070 (default board)
-3. Get active sprint from the resolved board
-4. Add ticket to that sprint
-
-This eliminates the previous approach that required retries when hitting the wrong board.
+1. If `BOT_BOARD_ID` is set → use directly (no API call needed)
+2. If `BOT_BOARD_NAME` is set → lookup via `jira_get_agile_boards`
+3. Neither set → fail with error
+4. Get active sprint from the resolved board
+5. Add ticket to that sprint
 
 ## Performance Optimizations
 
@@ -297,7 +294,7 @@ uv run pytest --cov=scripts --cov-report=term-missing -v
 |--------|--------------|---------------|
 | **Tool Calls** | ~10-15 (with retries) | 1 |
 | **API Calls** | 10-15 | 9 (8 with caching) |
-| **Board Detection** | Trial and error | Label-based, deterministic |
+| **Board Detection** | Trial and error | Env var config, deterministic |
 | **Account ID Lookup** | Every time | Cached after first call |
 | **Error Handling** | Retry with LLM | Fail-fast with clear errors |
 | **Execution Time** | ~30-60 seconds | ~2-5 seconds |

--- a/.claude/skills/claim-ticket/SKILL.md
+++ b/.claude/skills/claim-ticket/SKILL.md
@@ -31,7 +31,7 @@ The script executes 8 operations in sequence:
 2. **get_transitions** - Get available transitions via jira_get_transitions
 3. **assign_ticket** - Assign ticket via jira_update_issue
 4. **transition_to_in_progress** - Move to "In Progress" via jira_transition_issue
-5. **resolve_board** - Determine board from labels via jira_get_issue
+5. **resolve_board** - Determine board from BOT_BOARD_ID or BOT_BOARD_NAME env var
 6. **get_active_sprint** - Get active sprint via jira_get_sprints_from_board
 7. **add_to_sprint** - Add to sprint via jira_add_issues_to_sprint
 8. **task_add** - Track in memory server
@@ -49,9 +49,9 @@ export JIRA_MCP_URL=http://proxy:8090
 # Memory Server (required)
 export BOT_MEMORY_URL=https://memory-server.example.com
 
-# Board Configuration (optional, has defaults)
-export PLATFORM_UI_BOARD_ID=9297
-export DEFAULT_BOARD_ID=8070
+# Board Configuration (one of these required)
+export BOT_BOARD_ID=9297                          # Direct board ID (skips lookup)
+export BOT_BOARD_NAME="Platform Experience UI"    # Lookup board by name via Jira
 ```
 
 ## Authentication
@@ -62,9 +62,10 @@ Memory server operations use direct HTTP (POST /tasks).
 
 ## Board Resolution
 
-Determines board based on ticket labels:
-- `platform-experience-ui` label → Board 9297 (Platform Experience UI)
-- Otherwise → Board 8070 (default)
+Resolves board from environment variables (same as new-work skill):
+- `BOT_BOARD_ID` set → use directly (fast path, no API call)
+- `BOT_BOARD_NAME` set → lookup via `jira_get_agile_boards`
+- Neither set → fail with error
 
 ## Error Handling
 

--- a/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
+++ b/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
@@ -29,12 +29,7 @@ import httpx
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 from jira_mcp import jira_call
 
-from .constants import (
-    DEFAULT_BOARD_ID,
-    LABEL_PLATFORM_UI,
-    PLATFORM_UI_BOARD_ID,
-    TRANSITION_IN_PROGRESS,
-)
+from .constants import TRANSITION_IN_PROGRESS
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -77,8 +72,6 @@ class ClaimTicketOperations:
     def __init__(
         self,
         memory_url: str,
-        platform_ui_board_id: int = PLATFORM_UI_BOARD_ID,
-        default_board_id: int = DEFAULT_BOARD_ID,
         dry_run: bool = False,
     ):
         """
@@ -86,19 +79,15 @@ class ClaimTicketOperations:
 
         Args:
             memory_url: Memory server base URL
-            platform_ui_board_id: Board ID for platform-experience-ui tickets
-            default_board_id: Default board ID
             dry_run: If True, log actions without executing them
         """
         self.memory_url = memory_url.rstrip("/")
-        self.platform_ui_board_id = platform_ui_board_id
-        self.default_board_id = default_board_id
         self.dry_run = dry_run
 
         # Workflow state
         self.bot_account_id: Optional[str] = None
         self.transition_id: Optional[str] = None
-        self.board_id: Optional[int] = None
+        self.board_id: Optional[str] = None
         self.sprint_id: Optional[int] = None
 
     def get_bot_account_id(self) -> OperationResult:
@@ -370,22 +359,21 @@ class ClaimTicketOperations:
 
     def resolve_board(self, jira_key: str) -> OperationResult:
         """
-        Resolve correct board based on ticket labels via jira_get_issue.
-
-        Logic:
-        - If ticket has 'platform-experience-ui' label: use platform_ui_board_id (9297)
-        - Otherwise: use default_board_id (8070)
+        Resolve board from BOT_BOARD_ID or BOT_BOARD_NAME environment variables.
 
         Args:
-            jira_key: JIRA ticket key (e.g., RHCLOUD-12345)
+            jira_key: JIRA ticket key (used for logging only)
 
         Returns:
             OperationResult with board ID
         """
         logger.info(f"Resolving board for {jira_key}...")
 
+        bot_board_id = os.environ.get("BOT_BOARD_ID", "")
+        bot_board_name = os.environ.get("BOT_BOARD_NAME", "")
+
         if self.dry_run:
-            self.board_id = self.default_board_id
+            self.board_id = bot_board_id or "dry-run-board"
             logger.info(f"[DRY RUN] Would resolve board for {jira_key}")
             return OperationResult(
                 operation="resolve_board",
@@ -395,9 +383,32 @@ class ClaimTicketOperations:
             )
 
         try:
-            data = jira_call("jira_get_issue", {"issue_key": jira_key})
-            if not data:
-                error_msg = "jira_get_issue returned None"
+            if bot_board_id:
+                self.board_id = bot_board_id
+                logger.info(f"Using BOT_BOARD_ID: {self.board_id}")
+            elif bot_board_name:
+                data = jira_call("jira_get_agile_boards", {"board_name": bot_board_name, "limit": 1})
+                if not data:
+                    error_msg = f"No board found matching name '{bot_board_name}'"
+                    logger.error(error_msg)
+                    return OperationResult(
+                        operation="resolve_board",
+                        status=OperationStatus.FAILED,
+                        message=error_msg,
+                    )
+                boards = data if isinstance(data, list) else data.get("values", [])
+                if not boards:
+                    error_msg = f"No board found matching name '{bot_board_name}'"
+                    logger.error(error_msg)
+                    return OperationResult(
+                        operation="resolve_board",
+                        status=OperationStatus.FAILED,
+                        message=error_msg,
+                    )
+                self.board_id = str(boards[0]["id"])
+                logger.info(f"Resolved board '{bot_board_name}' → {self.board_id}")
+            else:
+                error_msg = "Neither BOT_BOARD_ID nor BOT_BOARD_NAME is set"
                 logger.error(error_msg)
                 return OperationResult(
                     operation="resolve_board",
@@ -405,21 +416,11 @@ class ClaimTicketOperations:
                     message=error_msg,
                 )
 
-            labels = data.get("fields", {}).get("labels", [])
-
-            # Check for platform-experience-ui label
-            if LABEL_PLATFORM_UI in labels:
-                self.board_id = self.platform_ui_board_id
-                logger.info(f"Found 'platform-experience-ui' label, using board {self.board_id}")
-            else:
-                self.board_id = self.default_board_id
-                logger.info(f"No 'platform-experience-ui' label, using default board {self.board_id}")
-
             return OperationResult(
                 operation="resolve_board",
                 status=OperationStatus.SUCCESS,
                 message=f"Resolved board ID: {self.board_id}",
-                details={"board_id": self.board_id, "labels": labels},
+                details={"board_id": self.board_id},
             )
         except Exception as e:
             error_msg = f"Failed to resolve board: {str(e)}"

--- a/.claude/skills/claim-ticket/scripts/constants.py
+++ b/.claude/skills/claim-ticket/scripts/constants.py
@@ -1,11 +1,4 @@
 """Constants for claim-ticket operations."""
 
-# Board IDs
-PLATFORM_UI_BOARD_ID = 9297
-DEFAULT_BOARD_ID = 8070
-
 # JIRA transition names
 TRANSITION_IN_PROGRESS = "In Progress"
-
-# Labels
-LABEL_PLATFORM_UI = "platform-experience-ui"

--- a/.claude/skills/claim-ticket/tests/conftest.py
+++ b/.claude/skills/claim-ticket/tests/conftest.py
@@ -11,6 +11,7 @@ TEST_MEMORY_URL = "https://test-memory.example.com"
 TEST_SPRINT_ID = 12345
 TEST_SPRINT_NAME = "Sprint 42"
 TEST_TRANSITION_ID = "21"
+TEST_BOARD_ID = "9297"
 
 
 @pytest.fixture
@@ -33,7 +34,7 @@ def successful_jira_responses():
         "jira_get_transitions": {"transitions": [{"id": TEST_TRANSITION_ID, "name": "In Progress"}]},
         "jira_update_issue": {},
         "jira_transition_issue": {},
-        "jira_get_issue": {"fields": {"labels": ["platform-experience-ui"]}},
+        "jira_get_agile_boards": {"values": [{"id": int(TEST_BOARD_ID), "name": "Test Board"}]},
         "jira_get_sprints_from_board": {"sprints": [{"id": TEST_SPRINT_ID, "name": TEST_SPRINT_NAME}]},
         "jira_add_issues_to_sprint": {},
     }

--- a/.claude/skills/claim-ticket/tests/test_integration.py
+++ b/.claude/skills/claim-ticket/tests/test_integration.py
@@ -2,13 +2,22 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from scripts.claim_ticket_operations import (
     ClaimTicketOperations,
     OperationStatus,
     execute_claim_ticket_workflow,
 )
 
-from .conftest import TEST_JIRA_KEY, TEST_MEMORY_URL
+from .conftest import TEST_BOARD_ID, TEST_JIRA_KEY, TEST_MEMORY_URL
+
+
+@pytest.fixture(autouse=True)
+def set_board_env(monkeypatch):
+    """Set BOT_BOARD_NAME for all integration tests."""
+    monkeypatch.setenv("BOT_BOARD_NAME", "Test Board")
+    monkeypatch.delenv("BOT_BOARD_ID", raising=False)
 
 
 class TestWorkflow:
@@ -31,10 +40,9 @@ class TestWorkflow:
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_workflow_fails_on_first_error(self, mock_jira_call):
         """Test workflow stops on first failure."""
-        # Clear cache to ensure get_bot_account_id runs
         ClaimTicketOperations._bot_account_id_cache = None
 
-        mock_jira_call.return_value = None  # Simulates MCP failure
+        mock_jira_call.return_value = None
 
         result = execute_claim_ticket_workflow(
             jira_key=TEST_JIRA_KEY,
@@ -42,7 +50,7 @@ class TestWorkflow:
         )
 
         assert result.success is False
-        assert len(result.operations) == 1  # Only first operation attempted
+        assert len(result.operations) == 1
         assert result.operations[0].status == OperationStatus.FAILED
 
     def test_workflow_missing_memory_url(self):
@@ -60,7 +68,7 @@ class TestWorkflow:
         """Test workflow with skipped operations."""
         jira_responses = {
             "jira_get_user_profile": {"account_id": "bot-123"},
-            "jira_get_issue": {"fields": {"labels": []}},
+            "jira_get_agile_boards": {"values": [{"id": int(TEST_BOARD_ID), "name": "Test Board"}]},
             "jira_get_sprints_from_board": {"sprints": [{"id": 12345}]},
         }
 
@@ -75,3 +83,52 @@ class TestWorkflow:
         assert result.success is True
         skipped = [op for op in result.operations if op.status == OperationStatus.SKIPPED]
         assert len(skipped) == 4
+
+    @patch("scripts.claim_ticket_operations.jira_call")
+    def test_workflow_with_board_id_env(self, mock_jira_call, mock_memory_server, monkeypatch):
+        """Test workflow uses BOT_BOARD_ID when set (skips name lookup)."""
+        monkeypatch.setenv("BOT_BOARD_ID", "8070")
+        monkeypatch.delenv("BOT_BOARD_NAME", raising=False)
+
+        jira_responses = {
+            "jira_get_user_profile": {"account_id": "bot-123"},
+            "jira_get_transitions": {"transitions": [{"id": "21", "name": "In Progress"}]},
+            "jira_update_issue": {},
+            "jira_transition_issue": {},
+            "jira_get_sprints_from_board": {"sprints": [{"id": 12345, "name": "Sprint 42"}]},
+            "jira_add_issues_to_sprint": {},
+        }
+        mock_jira_call.side_effect = lambda tool_name, args: jira_responses.get(tool_name)
+
+        result = execute_claim_ticket_workflow(
+            jira_key=TEST_JIRA_KEY,
+            memory_url=TEST_MEMORY_URL,
+        )
+
+        assert result.success is True
+        board_op = next(op for op in result.operations if op.operation == "resolve_board")
+        assert board_op.details["board_id"] == "8070"
+
+    @patch("scripts.claim_ticket_operations.jira_call")
+    def test_workflow_no_board_config(self, mock_jira_call, monkeypatch):
+        """Test workflow fails when no board env vars set."""
+        monkeypatch.delenv("BOT_BOARD_ID", raising=False)
+        monkeypatch.delenv("BOT_BOARD_NAME", raising=False)
+
+        jira_responses = {
+            "jira_get_user_profile": {"account_id": "bot-123"},
+            "jira_get_transitions": {"transitions": [{"id": "21", "name": "In Progress"}]},
+            "jira_update_issue": {},
+            "jira_transition_issue": {},
+        }
+        mock_jira_call.side_effect = lambda tool_name, args: jira_responses.get(tool_name, {})
+
+        result = execute_claim_ticket_workflow(
+            jira_key=TEST_JIRA_KEY,
+            memory_url=TEST_MEMORY_URL,
+        )
+
+        assert result.success is False
+        board_op = next(op for op in result.operations if op.operation == "resolve_board")
+        assert board_op.status == OperationStatus.FAILED
+        assert "Neither BOT_BOARD_ID nor BOT_BOARD_NAME" in board_op.message

--- a/.claude/skills/claim-ticket/tests/test_operations.py
+++ b/.claude/skills/claim-ticket/tests/test_operations.py
@@ -15,8 +15,6 @@ def operations():
     """Create ClaimTicketOperations instance for testing."""
     return ClaimTicketOperations(
         memory_url="https://test-memory.example.com",
-        platform_ui_board_id=9297,
-        default_board_id=8070,
         dry_run=False,
     )
 
@@ -171,24 +169,52 @@ class TestResolveBoard:
     """Test resolve_board operation."""
 
     @patch("scripts.claim_ticket_operations.jira_call")
-    def test_resolve_board_platform_ui_label(self, mock_jira_call, operations):
-        """Test board resolution with platform-experience-ui label."""
-        mock_jira_call.return_value = {"fields": {"labels": ["platform-experience-ui", "other-label"]}}
+    def test_resolve_board_from_env_id(self, mock_jira_call, operations, monkeypatch):
+        """Test board resolution from BOT_BOARD_ID env var."""
+        monkeypatch.setenv("BOT_BOARD_ID", "9297")
 
         result = operations.resolve_board("RHCLOUD-12345")
 
         assert result.status == OperationStatus.SUCCESS
-        assert operations.board_id == 9297
+        assert operations.board_id == "9297"
+        mock_jira_call.assert_not_called()
 
     @patch("scripts.claim_ticket_operations.jira_call")
-    def test_resolve_board_default(self, mock_jira_call, operations):
-        """Test board resolution without platform-experience-ui label."""
-        mock_jira_call.return_value = {"fields": {"labels": ["other-label"]}}
+    def test_resolve_board_from_env_name(self, mock_jira_call, operations, monkeypatch):
+        """Test board resolution from BOT_BOARD_NAME env var via Jira lookup."""
+        monkeypatch.delenv("BOT_BOARD_ID", raising=False)
+        monkeypatch.setenv("BOT_BOARD_NAME", "Platform Experience UI")
+        mock_jira_call.return_value = {"values": [{"id": 9297, "name": "Platform Experience UI"}]}
 
         result = operations.resolve_board("RHCLOUD-12345")
 
         assert result.status == OperationStatus.SUCCESS
-        assert operations.board_id == 8070
+        assert operations.board_id == "9297"
+        mock_jira_call.assert_called_once_with(
+            "jira_get_agile_boards", {"board_name": "Platform Experience UI", "limit": 1}
+        )
+
+    @patch("scripts.claim_ticket_operations.jira_call")
+    def test_resolve_board_name_not_found(self, mock_jira_call, operations, monkeypatch):
+        """Test board resolution when name lookup returns empty."""
+        monkeypatch.delenv("BOT_BOARD_ID", raising=False)
+        monkeypatch.setenv("BOT_BOARD_NAME", "Nonexistent Board")
+        mock_jira_call.return_value = {"values": []}
+
+        result = operations.resolve_board("RHCLOUD-12345")
+
+        assert result.status == OperationStatus.FAILED
+        assert "No board found" in result.message
+
+    def test_resolve_board_no_env_vars(self, operations, monkeypatch):
+        """Test board resolution when no env vars set."""
+        monkeypatch.delenv("BOT_BOARD_ID", raising=False)
+        monkeypatch.delenv("BOT_BOARD_NAME", raising=False)
+
+        result = operations.resolve_board("RHCLOUD-12345")
+
+        assert result.status == OperationStatus.FAILED
+        assert "Neither BOT_BOARD_ID nor BOT_BOARD_NAME" in result.message
 
 
 class TestGetActiveSprint:
@@ -197,19 +223,19 @@ class TestGetActiveSprint:
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_get_active_sprint_success(self, mock_jira_call, operations):
         """Test successful active sprint retrieval."""
-        operations.board_id = 9297
+        operations.board_id = "9297"
         mock_jira_call.return_value = {"sprints": [{"id": 12345, "name": "Sprint 42"}]}
 
         result = operations.get_active_sprint()
 
         assert result.status == OperationStatus.SUCCESS
         assert operations.sprint_id == 12345
-        mock_jira_call.assert_called_once_with("jira_get_sprints_from_board", {"board_id": 9297, "state": "active"})
+        mock_jira_call.assert_called_once_with("jira_get_sprints_from_board", {"board_id": "9297", "state": "active"})
 
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_get_active_sprint_no_active(self, mock_jira_call, operations):
         """Test when no active sprint found."""
-        operations.board_id = 9297
+        operations.board_id = "9297"
         mock_jira_call.return_value = {"sprints": []}
 
         result = operations.get_active_sprint()
@@ -243,7 +269,7 @@ class TestTaskAdd:
     def test_task_add_success(self, mock_client_class, operations):
         """Test successful task addition to memory server."""
         operations.bot_account_id = "bot-123"
-        operations.board_id = 9297
+        operations.board_id = "9297"
         operations.sprint_id = 12345
 
         mock_client = Mock()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Before starting work, `jira_get_issue` → check issue links:
 
 #### Implement
 
-1. **Claim**: `jira_get_user_profile` → `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress" → **Sprint**: `platform-experience-ui` label → board 9297, else → board 8070. `jira_get_sprints_from_board` state=active → `jira_add_issues_to_sprint`.
+1. **Claim**: `jira_get_user_profile` → `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress" → **Sprint**: board from `BOT_BOARD_ID` or `BOT_BOARD_NAME` env var → `jira_get_sprints_from_board` state=active → `jira_add_issues_to_sprint`.
 
 2. **Track**: `task_add` w/ `jira_key, repo, branch (bot/<KEY>), in_progress, title, summary, metadata`:
    ```json


### PR DESCRIPTION
## Summary

Replaces hardcoded board IDs (9297/8070) and label-based routing in `claim-ticket` skill with `BOT_BOARD_ID`/`BOT_BOARD_NAME` env var config — same pattern `new-work` already uses.

**RHCLOUD-47772**

## Changes

- **`constants.py`** — removed hardcoded `PLATFORM_UI_BOARD_ID`, `DEFAULT_BOARD_ID`, `LABEL_PLATFORM_UI`
- **`claim_ticket_operations.py`** — `resolve_board()` now reads `BOT_BOARD_ID` (direct) or `BOT_BOARD_NAME` (Jira lookup) from env instead of checking ticket labels
- **`CLAUDE.md`** — removed hardcoded board ID reference
- **Tests** — updated to cover env var paths (ID, name lookup, missing config)
- **Docs** — SKILL.md and README.md updated

## Test plan

- [x] All 24 tests pass (`uv run python -m pytest -v`)
- [x] New tests: `test_resolve_board_from_env_id`, `test_resolve_board_from_env_name`, `test_resolve_board_name_not_found`, `test_resolve_board_no_env_vars`
- [x] Integration test: `test_workflow_with_board_id_env`, `test_workflow_no_board_config`