### PR TITLE
fix(deploy): correct DNS egress and parameterize bot name

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -29,6 +29,8 @@ parameters:
   value: ""
 - name: BOT_CONFIG_REPO
   value: ""
+- name: BOT_NAME
+  value: devbot-bot
 - name: BOT_CONFIG_PATH
   value: "rehor-config"
 - name: GCP_PROJECT_ID
@@ -334,19 +336,21 @@ objects:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
-    name: devbot-bot
+    name: ${BOT_NAME}
     labels:
-      app.kubernetes.io/name: bot
+      app.kubernetes.io/name: ${BOT_NAME}
+      app.kubernetes.io/component: bot
       app.kubernetes.io/part-of: devbot
   spec:
     replicas: ${{BOT_REPLICAS}}
     selector:
       matchLabels:
-        app.kubernetes.io/name: bot
+        app.kubernetes.io/name: ${BOT_NAME}
     template:
       metadata:
         labels:
-          app.kubernetes.io/name: bot
+          app.kubernetes.io/name: ${BOT_NAME}
+          app.kubernetes.io/component: bot
           app.kubernetes.io/part-of: devbot
       spec:
         containers:
@@ -462,13 +466,13 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: devbot-bot-egress
+    name: ${BOT_NAME}-egress
     labels:
       app.kubernetes.io/part-of: devbot
   spec:
     podSelector:
       matchLabels:
-        app.kubernetes.io/name: bot
+        app.kubernetes.io/name: ${BOT_NAME}
     policyTypes:
     - Egress
     egress:
@@ -495,12 +499,11 @@ objects:
       - port: 8080
         protocol: TCP
     - to:
-      - namespaceSelector: {}
-        podSelector:
+      - namespaceSelector:
           matchLabels:
-            k8s-app: kube-dns
+            kubernetes.io/metadata.name: openshift-dns
       ports:
-      - port: 53
+      - port: 5353
         protocol: UDP
-      - port: 53
+      - port: 5353
         protocol: TCP


### PR DESCRIPTION
## Summary

- Fix DNS egress NetworkPolicy: OpenShift uses `openshift-dns` namespace on port 5353, not `k8s-app: kube-dns` on port 53. Bot pods were unable to resolve Service DNS names, causing them to hang on "Waiting for executor at devbot-proxy:9090..."
- Add `BOT_NAME` template parameter (default: `devbot-bot`) so each instance gets a distinct Deployment name, labels, selectors, and NetworkPolicy — enabling easy pod identification in OpenShift

## Jira

- [RHCLOUD-47779](https://redhat.atlassian.net/browse/RHCLOUD-47779) — DNS egress bug
- [RHCLOUD-47778](https://redhat.atlassian.net/browse/RHCLOUD-47778) — Parameterize Deployment name

## Test plan

- [ ] Deploy with `BOT_NAME: devbot-framework` in app-interface
- [ ] Verify pod name shows `devbot-framework-*`
- [ ] Verify DNS resolution works inside bot pod (`getent hosts devbot-proxy`)
- [ ] Verify bot connects to executor successfully

## App-interface change required

Set `BOT_NAME` parameter in deploy.yml for each instance:
- `platform-frontend-ai-dev`: `BOT_NAME: devbot-framework`
- `hcc-ui-agent-dev`: `BOT_NAME: devbot-ui`

[RHCLOUD-47779]: https://redhat.atlassian.net/browse/RHCLOUD-47779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-47778]: https://redhat.atlassian.net/browse/RHCLOUD-47778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ