### PR TITLE
fix(identity): use BOT_JIRA_EMAIL for ticket assignment

### DIFF
--- a/.claude/skills/claim-ticket/SKILL.md
+++ b/.claude/skills/claim-ticket/SKILL.md
@@ -46,6 +46,9 @@ Set these environment variables:
 # JIRA MCP Server (required)
 export JIRA_MCP_URL=http://proxy:8090
 
+# Bot JIRA identity (required) — email of the bot's Jira service account (from Vault)
+export BOT_JIRA_EMAIL=<your-bot-jira-email>
+
 # Memory Server (required)
 export BOT_MEMORY_URL=https://memory-server.example.com
 
@@ -56,7 +59,7 @@ export BOT_BOARD_NAME="Platform Experience UI"    # Lookup board by name via Jir
 
 ## Authentication
 
-JIRA operations use MCP via jira_call(). No API tokens needed - the mcp-atlassian server handles authentication.
+JIRA operations use MCP via jira_call(). No API tokens needed - the mcp-atlassian server handles authentication. Bot identity for ticket assignment comes from `BOT_JIRA_EMAIL`.
 
 Memory server operations use direct HTTP (POST /tasks).
 

--- a/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
+++ b/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
@@ -92,12 +92,11 @@ class ClaimTicketOperations:
 
     def get_bot_account_id(self) -> OperationResult:
         """
-        Get bot's JIRA account ID using jira_get_user_profile. Result is cached.
+        Get bot's JIRA identity from BOT_JIRA_EMAIL env var, then resolve account ID via MCP.
 
         Returns:
             OperationResult with account ID
         """
-        # Check class-level cache first
         if ClaimTicketOperations._bot_account_id_cache:
             self.bot_account_id = ClaimTicketOperations._bot_account_id_cache
             logger.info(f"Using cached bot account ID: {self.bot_account_id}")
@@ -108,11 +107,21 @@ class ClaimTicketOperations:
                 details={"account_id": self.bot_account_id},
             )
 
-        logger.info("Getting bot account ID via jira_get_user_profile...")
+        bot_email = os.environ.get("BOT_JIRA_EMAIL")
+        if not bot_email:
+            error_msg = "BOT_JIRA_EMAIL env var not set"
+            logger.error(error_msg)
+            return OperationResult(
+                operation="get_bot_account_id",
+                status=OperationStatus.FAILED,
+                message=error_msg,
+            )
+
+        logger.info(f"Resolving JIRA account for {bot_email}...")
 
         if self.dry_run:
             self.bot_account_id = "dry-run-account-id"
-            logger.info("[DRY RUN] Would call jira_get_user_profile")
+            logger.info(f"[DRY RUN] Would resolve account for {bot_email}")
             return OperationResult(
                 operation="get_bot_account_id",
                 status=OperationStatus.SUCCESS,
@@ -121,9 +130,9 @@ class ClaimTicketOperations:
             )
 
         try:
-            data = jira_call("jira_get_user_profile", {})
+            data = jira_call("jira_get_user_profile", {"user_identifier": bot_email})
             if not data:
-                error_msg = "jira_get_user_profile returned None"
+                error_msg = f"jira_get_user_profile returned None for {bot_email}"
                 logger.error(error_msg)
                 return OperationResult(
                     operation="get_bot_account_id",
@@ -141,7 +150,6 @@ class ClaimTicketOperations:
                     message=error_msg,
                 )
 
-            # Cache the account ID
             ClaimTicketOperations._bot_account_id_cache = self.bot_account_id
 
             logger.info(f"Retrieved bot account ID: {self.bot_account_id}")

--- a/.claude/skills/claim-ticket/tests/conftest.py
+++ b/.claude/skills/claim-ticket/tests/conftest.py
@@ -7,11 +7,18 @@ import pytest
 # Test constants
 TEST_JIRA_KEY = "RHCLOUD-12345"
 TEST_BOT_ACCOUNT_ID = "bot-123"
+TEST_BOT_EMAIL = "bot@example.com"
 TEST_MEMORY_URL = "https://test-memory.example.com"
 TEST_SPRINT_ID = 12345
 TEST_SPRINT_NAME = "Sprint 42"
 TEST_TRANSITION_ID = "21"
 TEST_BOARD_ID = "9297"
+
+
+@pytest.fixture(autouse=True)
+def set_bot_jira_email(monkeypatch):
+    """Set BOT_JIRA_EMAIL for all tests."""
+    monkeypatch.setenv("BOT_JIRA_EMAIL", TEST_BOT_EMAIL)
 
 
 @pytest.fixture

--- a/.claude/skills/claim-ticket/tests/test_operations.py
+++ b/.claude/skills/claim-ticket/tests/test_operations.py
@@ -43,7 +43,7 @@ class TestGetBotAccountId:
         assert result.details["account_id"] == "bot-account-123"
         assert operations.bot_account_id == "bot-account-123"
 
-        mock_jira_call.assert_called_once_with("jira_get_user_profile", {})
+        mock_jira_call.assert_called_once_with("jira_get_user_profile", {"user_identifier": "bot@example.com"})
 
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_get_bot_account_id_caching(self, mock_jira_call, operations):
@@ -69,7 +69,7 @@ class TestGetBotAccountId:
         result = operations.get_bot_account_id()
 
         assert result.status == OperationStatus.FAILED
-        assert "returned None" in result.message
+        assert "returned None for bot@example.com" in result.message
 
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_get_bot_account_id_dry_run(self, mock_jira_call):
@@ -80,6 +80,15 @@ class TestGetBotAccountId:
         assert result.status == OperationStatus.SUCCESS
         assert "dry run" in result.message.lower()
         mock_jira_call.assert_not_called()
+
+    def test_get_bot_account_id_missing_env_var(self, monkeypatch):
+        """Test failure when BOT_JIRA_EMAIL is not set."""
+        monkeypatch.delenv("BOT_JIRA_EMAIL", raising=False)
+        ops = ClaimTicketOperations(memory_url="https://test.example.com")
+        result = ops.get_bot_account_id()
+
+        assert result.status == OperationStatus.FAILED
+        assert "BOT_JIRA_EMAIL" in result.message
 
 
 class TestGetTransitions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Before starting work, `jira_get_issue` → check issue links:
 
 #### Implement
 
-1. **Claim**: `jira_get_user_profile` → `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress" → **Sprint**: board from `BOT_BOARD_ID` or `BOT_BOARD_NAME` env var → `jira_get_sprints_from_board` state=active → `jira_add_issues_to_sprint`.
+1. **Claim**: Use `$BOT_JIRA_EMAIL` env var for assignee (never `jira_get_user_profile`). `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress" → **Sprint**: board from `BOT_BOARD_ID` or `BOT_BOARD_NAME` env var → `jira_get_sprints_from_board` state=active → `jira_add_issues_to_sprint`.
 
 2. **Track**: `task_add` w/ `jira_key, repo, branch (bot/<KEY>), in_progress, title, summary, metadata`:
    ```json

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -412,6 +412,11 @@ objects:
               secretKeyRef:
                 name: devbot-secrets
                 key: bot-gl-email
+          - name: BOT_JIRA_EMAIL
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: jira-email
           # Bot config
           - name: BOT_BOARD_NAME
             value: ${BOT_BOARD_NAME}


### PR DESCRIPTION
## Summary
- Add `BOT_JIRA_EMAIL` env var (from Vault `jira-email` key) to deploy template
- Update `claim-ticket` skill to read `BOT_JIRA_EMAIL` instead of calling `jira_get_user_profile` with no params
- Update CLAUDE.md claim step to reference the env var

## Problem
Bot was assigning Jira tickets to the human operator (mmarosi) instead of itself. When the claim-ticket script failed at runtime, the bot fell back to manual MCP calls and grabbed the email from git config env vars (`GH_USER_EMAIL`), which pointed to the wrong user.

Observed on RHCLOUD-45919 — changelog confirmed the service account made the API call but assigned **to** Martin Marosi.

## Jira
[RHCLOUD-47782](https://redhat.atlassian.net/browse/RHCLOUD-47782)

## Test plan
- [ ] Verify vault secret version 13 has correct `jira-email` value
- [ ] Deploy and confirm bot assigns tickets to service account
- [ ] Verify claim-ticket skill reads `BOT_JIRA_EMAIL` correctly

[RHCLOUD-47782]: https://redhat.atlassian.net/browse/RHCLOUD-47782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ