### PR TITLE
feat(memory-server): create temporary memory upload endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ report.md
 .chrome-profile/
 __pycache__/
 *.pyc
+*.egg-info/
+.pytest_cache/
 .venv/
 .python-version
 dashboard/node_modules/

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -58,6 +58,7 @@ objects:
 #      jira-token            — Jira API token
 #      e2e-username          — SSO username for UI verification
 #      e2e-password          — SSO password for UI verification
+#      upload-memory-password — (temporary) shared secret for bulk memory upload
 #
 # Networking (Routes, NetworkPolicies) is managed via app-interface.
 #
@@ -124,6 +125,12 @@ objects:
                 key: db.name
           - name: PGSQL_SSLMODE
             value: require
+          - name: UPLOAD_MEMORY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: upload-memory-password
+                optional: true
           startupProbe:
             httpGet:
               path: /health

--- a/memory-server/pyproject.toml
+++ b/memory-server/pyproject.toml
@@ -12,3 +12,10 @@ dependencies = [
     "uvicorn>=0.30",
     "websockets>=13.0",
 ]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "httpx>=0.27",
+]

--- a/memory-server/src/api.py
+++ b/memory-server/src/api.py
@@ -1,5 +1,7 @@
 """REST API endpoints for the web dashboard."""
 import json
+import logging
+import os
 from datetime import date as date_type
 
 from starlette.requests import Request
@@ -8,6 +10,8 @@ from starlette.responses import JSONResponse
 from .db import get_pool
 from .embeddings import embed
 from .events import Event, bus
+
+logger = logging.getLogger(__name__)
 
 
 async def api_tasks(request: Request) -> JSONResponse:
@@ -279,6 +283,66 @@ async def api_memory_delete(request: Request) -> JSONResponse:
         return JSONResponse({"error": f"Memory {memory_id} not found"}, status_code=404)
     await bus.publish(Event("memory_deleted", {"id": int(memory_id)}))
     return JSONResponse({"deleted": True, "id": int(memory_id)})
+
+
+async def api_memory_upload(request: Request) -> JSONResponse:
+    """POST /api/memories/upload — bulk upload memories with a shared secret."""
+    secret = os.environ.get("UPLOAD_MEMORY_PASSWORD")
+    if not secret:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    auth = request.headers.get("authorization", "")
+    if not auth.startswith("Bearer ") or auth[7:] != secret:
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    body = await request.json()
+    memories = body.get("memories", [])
+    if not memories:
+        return JSONResponse({"uploaded": 0, "errors": []})
+
+    pool = get_pool()
+    uploaded = 0
+    errors = []
+
+    for i, m in enumerate(memories):
+        try:
+            title = m["title"]
+            category = m["category"]
+            content = m["content"]
+            repo = m.get("repo")
+            jira_key = m.get("jira_key")
+            tags = m.get("tags", [])
+            metadata = m.get("metadata", {})
+
+            existing = await pool.fetchval(
+                "SELECT id FROM memories WHERE title = $1 AND category = $2 AND repo IS NOT DISTINCT FROM $3",
+                title, category, repo,
+            )
+            if existing:
+                errors.append({"index": i, "title": title, "reason": "duplicate"})
+                continue
+
+            vector = embed(f"{title}\n{content}")
+            row = await pool.fetchrow(
+                """
+                INSERT INTO memories (category, repo, jira_key, title, content, tags, embedding, metadata)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                RETURNING *
+                """,
+                category, repo, jira_key, title, content,
+                tags or [],
+                vector,
+                json.dumps(metadata or {}),
+            )
+            await bus.publish(Event("memory_stored", {"id": row["id"], "title": title, "category": category}))
+            uploaded += 1
+        except KeyError as e:
+            errors.append({"index": i, "reason": f"missing field: {e}"})
+        except Exception as e:
+            errors.append({"index": i, "title": m.get("title", "?"), "reason": str(e)})
+
+    logger.info("Memory upload: %d uploaded, %d errors/skipped", uploaded, len(errors))
+    return JSONResponse({"uploaded": uploaded, "errors": errors})
 
 
 async def api_bot_status(request: Request) -> JSONResponse:

--- a/memory-server/src/server.py
+++ b/memory-server/src/server.py
@@ -75,13 +75,14 @@ async def asset_files(request: Request) -> FileResponse:
 
 
 # REST API for the dashboard
-from .api import api_tasks, api_task_delete, api_task_unarchive, api_memories, api_memory_get, api_memory_search, api_memory_embeddings, api_memory_delete, api_tags, api_stats, api_bot_status, api_instances, api_costs, api_analytics
+from .api import api_tasks, api_task_delete, api_task_unarchive, api_memories, api_memory_get, api_memory_search, api_memory_embeddings, api_memory_delete, api_memory_upload, api_tags, api_stats, api_bot_status, api_instances, api_costs, api_analytics
 
 mcp.custom_route("/api/tasks", methods=["GET"])(api_tasks)
 mcp.custom_route("/api/tasks/{jira_key:path}", methods=["DELETE"])(api_task_delete)
 mcp.custom_route("/api/tasks/{jira_key:path}/unarchive", methods=["POST"])(api_task_unarchive)
 mcp.custom_route("/api/memories", methods=["GET"])(api_memories)
 mcp.custom_route("/api/memories/search", methods=["GET"])(api_memory_search)
+mcp.custom_route("/api/memories/upload", methods=["POST"])(api_memory_upload)
 mcp.custom_route("/api/memories/embeddings", methods=["GET"])(api_memory_embeddings)
 mcp.custom_route("/api/memories/{id}", methods=["GET"])(api_memory_get)
 mcp.custom_route("/api/memories/{id}", methods=["DELETE"])(api_memory_delete)

--- a/memory-server/tests/test_memory_upload.py
+++ b/memory-server/tests/test_memory_upload.py
@@ -1,0 +1,170 @@
+"""Tests for the POST /api/memories/upload endpoint."""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from src.api import api_memory_upload
+
+app = Starlette(routes=[Route("/api/memories/upload", api_memory_upload, methods=["POST"])])
+
+
+def _fake_row(id: int, title: str, category: str, **kwargs):
+    """Build a dict that looks like an asyncpg Record."""
+    return {
+        "id": id,
+        "title": title,
+        "category": category,
+        "content": kwargs.get("content", "test"),
+        "repo": kwargs.get("repo"),
+        "jira_key": kwargs.get("jira_key"),
+        "tags": kwargs.get("tags", []),
+        "created_at": datetime.now(timezone.utc),
+        "metadata": json.dumps(kwargs.get("metadata", {})),
+        "embedding": [0.0] * 384,
+    }
+
+
+@pytest.fixture
+def mock_pool():
+    pool = MagicMock()
+    pool.fetchval = AsyncMock(return_value=None)
+    pool.fetchrow = AsyncMock(side_effect=lambda q, *a: _fake_row(1, a[3], a[0]))
+    with patch("src.api.get_pool", return_value=pool):
+        yield pool
+
+
+@pytest.fixture
+def mock_embed():
+    with patch("src.api.embed", return_value=[0.0] * 384) as m:
+        yield m
+
+
+@pytest.mark.asyncio
+async def test_returns_404_when_disabled(monkeypatch):
+    monkeypatch.delenv("UPLOAD_MEMORY_PASSWORD", raising=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/memories/upload", json={"memories": []})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_returns_403_wrong_token(monkeypatch):
+    monkeypatch.setenv("UPLOAD_MEMORY_PASSWORD", "correct-password")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/memories/upload",
+            json={"memories": []},
+            headers={"Authorization": "Bearer wrong"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_returns_403_missing_header(monkeypatch):
+    monkeypatch.setenv("UPLOAD_MEMORY_PASSWORD", "correct-password")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/memories/upload", json={"memories": []})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_upload_empty_list(monkeypatch):
+    monkeypatch.setenv("UPLOAD_MEMORY_PASSWORD", "secret")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/memories/upload",
+            json={"memories": []},
+            headers={"Authorization": "Bearer secret"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"uploaded": 0, "errors": []}
+
+
+@pytest.mark.asyncio
+async def test_upload_single_memory(monkeypatch, mock_pool, mock_embed):
+    monkeypatch.setenv("UPLOAD_MEMORY_PASSWORD", "secret")
+    memories = [{"category": "learning", "title": "Test", "content": "Some content", "tags": ["ci"]}]
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/memories/upload",
+            json={"memories": memories},
+            headers={"Authorization": "Bearer secret"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["uploaded"] == 1
+    assert data["errors"] == []
+    mock_embed.assert_called_once_with("Test\nSome content")
+    mock_pool.fetchrow.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_skips_duplicates(monkeypatch, mock_pool, mock_embed):
+    monkeypatch.setenv("UPLOAD_MEMORY_PASSWORD", "secret")
+    mock_pool.fetchval = AsyncMock(return_value=42)
+
+    memories = [{"category": "learning", "title": "Existing", "content": "Already there"}]
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/memories/upload",
+            json={"memories": memories},
+            headers={"Authorization": "Bearer secret"},
+        )
+
+    data = resp.json()
+    assert data["uploaded"] == 0
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["reason"] == "duplicate"
+    mock_pool.fetchrow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reports_missing_fields(monkeypatch, mock_pool, mock_embed):
+    monkeypatch.setenv("UPLOAD_MEMORY_PASSWORD", "secret")
+    memories = [{"category": "learning"}]  # missing title and content
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/memories/upload",
+            json={"memories": memories},
+            headers={"Authorization": "Bearer secret"},
+        )
+
+    data = resp.json()
+    assert data["uploaded"] == 0
+    assert len(data["errors"]) == 1
+    assert "missing field" in data["errors"][0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_upload_ignores_extra_fields(monkeypatch, mock_pool, mock_embed):
+    """Memories exported from GET /api/memories include id and created_at — these should be ignored."""
+    monkeypatch.setenv("UPLOAD_MEMORY_PASSWORD", "secret")
+    memories = [{
+        "id": 999,
+        "category": "learning",
+        "title": "From export",
+        "content": "Exported content",
+        "created_at": "2026-01-01T00:00:00Z",
+        "tags": [],
+    }]
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/memories/upload",
+            json={"memories": memories},
+            headers={"Authorization": "Bearer secret"},
+        )
+
+    data = resp.json()
+    assert data["uploaded"] == 1
+    assert data["errors"] == []


### PR DESCRIPTION
## Summary
  
  Adds a temporary `POST /api/memories/upload` endpoint to the memory server for bulk-uploading memories from a local instance to the cluster.

  - Gated by `UPLOAD_MEMORY_PASSWORD` env var (sourced from `devbot-secrets` Vault secret)
  - No env var set = endpoint returns 404 (disabled by default)
  - Wrong/missing `Authorization: Bearer <password>` = 403
  - Accepts `{"memories": [...]}` matching the shape of `GET /api/memories` output — no transformation needed
  - Skips duplicates by `(title, category, repo)` match
  - Returns `{"uploaded": N, "errors": [...]}`
  - `optional: true` on the secretKeyRef so the pod starts fine without the key in Vault

  ### Usage
  
  ```bash
  # Export from local instance
  curl -s http://localhost:8080/api/memories?limit=9999 | jq '.items' > memories.json

  # Upload to cluster (no port needed — route handles TLS on 443, forwards to 8080 internally)
  curl -X POST https://<route-hostname>/api/memories/upload \
    -H 'Content-Type: application/json' \
    -H 'Authorization: Bearer <password-string>' \
    -d "{\"memories\": $(cat memories.json)}"
```

###   Cleanup

  Remove upload-memory-password from Vault and redeploy. The endpoint auto-disables when the env var is absent.

###   Test plan
  
  - 404 when UPLOAD_MEMORY_PASSWORD is unset
  - 403 with wrong bearer token
  - 403 with missing auth header
  - Empty list returns {"uploaded": 0, "errors": []}
  - Single memory inserts correctly and calls embed() with expected input
  - Duplicates skipped by (title, category, repo) match
  - Missing required fields reported in errors array
  - Extra fields from export (id, created_at) silently ignored
  - Add upload-memory-password key to Vault, deploy, verify endpoint works on cluster