### PR TITLE
fix(triage): add instance_id isolation to memory server calls

### DIFF
--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -18,6 +18,7 @@ from jira_mcp import jira_call
 from paths import SLEEP_FILE
 
 MEMORY_URL = os.environ.get("BOT_MEMORY_URL", "http://localhost:8080").rstrip("/mcp").rstrip("/")
+INSTANCE_ID = os.environ.get("BOT_INSTANCE_ID", "")
 PROJECT_REPOS = Path(__file__).resolve().parent.parent.parent.parent / "project-repos.json"
 
 
@@ -31,13 +32,19 @@ def http_get(url, headers=None, timeout=10):
         return None
 
 
+def _instance_param():
+    if INSTANCE_ID:
+        return f"&instance_id={urllib.parse.quote(INSTANCE_ID)}"
+    return ""
+
+
 def get_tasks():
-    data = http_get(f"{MEMORY_URL}/api/tasks?exclude_status=archived&limit=50")
+    data = http_get(f"{MEMORY_URL}/api/tasks?exclude_status=archived&limit=50{_instance_param()}")
     return data.get("items", []) if data else []
 
 
 def get_capacity():
-    data = http_get(f"{MEMORY_URL}/api/tasks?exclude_status=archived&exclude_status=done&exclude_status=paused&limit=50")
+    data = http_get(f"{MEMORY_URL}/api/tasks?exclude_status=archived&exclude_status=done&exclude_status=paused&limit=50{_instance_param()}")
     if data and "items" in data:
         n = len([t for t in data["items"] if t.get("status") in ("in_progress", "pr_open", "pr_changes")])
         return n, 10
@@ -324,6 +331,10 @@ def has_new_jira_feedback(e):
 
 
 def main():
+    if not INSTANCE_ID:
+        print("FATAL: BOT_INSTANCE_ID env var not set. Multi-instance isolation requires it.", file=sys.stderr)
+        sys.exit(1)
+
     tasks = get_tasks()
     active_n, max_n = get_capacity()
 

--- a/bot/run.py
+++ b/bot/run.py
@@ -257,6 +257,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if not args.instance_id:
+        parser.error("--instance-id is required (or set BOT_INSTANCE_ID env var)")
+
     setup_logging()
     logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- Triage script was fetching ALL tasks from memory server without `instance_id` filtering, causing cross-instance task visibility (UI bot seeing framework bot's tasks and vice versa)
- Now passes `BOT_INSTANCE_ID` as `?instance_id=` query param to both `get_tasks()` and `get_capacity()` API calls
- Makes `BOT_INSTANCE_ID` mandatory: `triage.py` exits with FATAL error and `run.py` refuses to start without it

## Test plan

- [x] Existing claim-ticket tests pass (20/20)
- [ ] Deploy to stage with both instances — verify each only sees its own tasks in triage output
- [ ] Verify `triage.py` exits with clear error when `BOT_INSTANCE_ID` is unset

Fixes: [RHCLOUD-47797](https://issues.redhat.com/browse/RHCLOUD-47797)

[RHCLOUD-47797]: https://redhat.atlassian.net/browse/RHCLOUD-47797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ