### PR TITLE
fix(deploy): bump memory-server memory to 2Gi/4Gi

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -150,10 +150,10 @@ objects:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 2Gi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 4Gi
 
 # --- Memory Server Service ---
 - apiVersion: v1


### PR DESCRIPTION
## Summary
- Bumps memory-server container memory request from 256Mi → 2Gi and limit from 512Mi → 4Gi
- Fixes OOMKill (exit code 137) during embedding computation — bundled embedding model exceeds 512Mi

## Related
[RHCLOUD-47850](https://issues.redhat.com/browse/RHCLOUD-47850)

## Test plan
- [ ] Verify pod stability under sustained embedding load (bulk memory upload of 200+ items)
- [ ] Confirm no OOMKills after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-47850]: https://redhat.atlassian.net/browse/RHCLOUD-47850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ