### PR TITLE
feat(gitlab): add bot forks

### DIFF
--- a/rehor-config/agent/project-repos.json
+++ b/rehor-config/agent/project-repos.json
@@ -24,7 +24,7 @@
     "upstream": "https://github.com/RedHatInsights/frontend-operator.git"
   },
   "app-interface": {
-    "url": "https://gitlab.cee.redhat.com/mmarosi/app-interface.git",
+    "url": "https://gitlab.cee.redhat.com/platform-experience-services-bot/app-interface.git",
     "upstream": "https://gitlab.cee.redhat.com/service/app-interface.git",
     "host": "gitlab"
   },
@@ -109,7 +109,7 @@
     "upstream": "https://github.com/RedHatInsights/user-preferences-frontend.git"
   },
   "caddy-ubi": {
-    "url": "https://gitlab.cee.redhat.com/mmarosi/caddy-ubi.git",
+    "url": "https://gitlab.cee.redhat.com/platform-experience-services-bot/caddy-ubi.git",
     "upstream": "https://gitlab.cee.redhat.com/insights-platform/caddy-ubi.git",
     "host": "gitlab"
   },


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->

Change gitlab forks to the bot one.

---

### Checklist
- [x] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images pinned to specific tags, not `latest`

