### PR TITLE
feat: support org/repo prefix in repo: labels

### DIFF
--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -77,19 +77,31 @@ def get_active_sprint():
     return sprints[0] if sprints else None
 
 
-def get_known_repos():
+def load_project_repos():
     try:
-        return set(json.loads(PROJECT_REPOS.read_text()).keys())
+        return json.loads(PROJECT_REPOS.read_text())
     except Exception as e:
         print(f"ERR reading {PROJECT_REPOS}: {e}", file=sys.stderr)
-        return set()
+        return {}
 
 
-def match_repo_labels(labels, known_repos):
+def build_repo_lookup(repos_dict):
+    lookup = {}
+    for key, cfg in repos_dict.items():
+        lookup[key] = key
+        upstream = cfg.get("upstream", "")
+        parts = upstream.rstrip("/").removesuffix(".git").split("/")
+        if len(parts) >= 2:
+            org_repo = f"{parts[-2]}/{parts[-1]}"
+            lookup[org_repo] = key
+    return lookup
+
+
+def match_repo_labels(labels, repo_lookup):
     repo_labels = [l.replace("repo:", "") for l in labels if l.startswith("repo:")]
     if not repo_labels:
         return []
-    matched = [r for r in repo_labels if r in known_repos]
+    matched = [repo_lookup[r] for r in repo_labels if r in repo_lookup]
     return matched if len(matched) == len(repo_labels) else []
 
 
@@ -97,7 +109,8 @@ def get_candidates():
     if not BOT_LABEL:
         print("ERR: BOT_LABEL not set", file=sys.stderr)
         return []
-    known = get_known_repos()
+    repos_dict = load_project_repos()
+    repo_lookup = build_repo_lookup(repos_dict)
     status_list = ", ".join(f'"{s}"' for s in NOT_STARTED_STATUSES)
     candidates = []
 
@@ -129,7 +142,7 @@ def get_candidates():
     for issue in candidates:
         fields = issue.get("fields", {})
         labels = fields.get("labels", [])
-        repos = match_repo_labels(labels, known)
+        repos = match_repo_labels(labels, repo_lookup)
         comments = (fields.get("comment", {}).get("comments") or [])[-5:]
 
         results.append({

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ Before starting work, `jira_get_issue` → check issue links:
    - By tags: `css`, `testing`, `patternfly`, `ci`, `dependency-upgrade`
    - Apply ALL insights. Avoid past reviewer corrections. Follow learned conventions.
 
-5. **Prepare repos**: `repo:` labels → match `project-repos.json`. Fork workflow default:
+5. **Prepare repos**: `repo:` labels → match `project-repos.json`. Bare (`repo:insights-chrome`) or org-prefixed (`repo:RedHatInsights/insights-chrome`) — org/repo resolved via upstream URLs. Fork workflow default:
    - `url` = bot's fork, `upstream` = original repo (PR target), `host` = "gitlab" if GL, `readonly` = read only
 
    Dir = `./repos/<repo-name>/` (from upstream URL basename, no `.git`).

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -233,7 +233,7 @@ Or manually ensure the ticket has:
 
 Required labels:
 - **Primary label** — matches the bot instance: `hcc-ai-framework` or `hcc-ai-platform-accessmanagement`
-- **`repo:<name>`** — must match a key in the remote config's `project-repos.json` (e.g. `repo:insights-rbac`, `repo:notifications-frontend`)
+- **`repo:<name>`** or **`repo:<org>/<name>`** — must match a key in `project-repos.json` either by bare name (e.g. `repo:insights-rbac`) or org-prefixed name resolved via upstream URL (e.g. `repo:RedHatInsights/insights-rbac`)
 
 Optional:
 - `needs-investigation` — bot investigates and reports findings instead of implementing

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Tickets must be explicitly groomed. The bot never picks random backlog items.
 ### Required labels
 
 - **Primary label** (e.g. `hcc-ai-framework`, `hcc-ai-platform-accessmanagement`) — marks the ticket as bot-eligible for a specific team. The bot only picks up tickets with its configured label.
-- **`repo:<name>`** — identifies the target repo (must match a key in the remote config's `project-repos.json`). A ticket can have multiple `repo:` labels for cross-repo work.
+- **`repo:<name>`** or **`repo:<org>/<name>`** — identifies the target repo. Bare names (e.g. `repo:insights-chrome`) match keys in `project-repos.json` directly. Org-prefixed names (e.g. `repo:RedHatInsights/insights-chrome`) are resolved via the upstream URL. A ticket can have multiple `repo:` labels for cross-repo work.
 
 ### Optional labels
 
@@ -158,7 +158,7 @@ All repos use forks by default. The bot pushes to the fork and opens PRs/MRs tar
    }
    ```
    For GitLab repos, add `"host": "gitlab"`.
-3. Add a `repo:my-repo` label to the Jira ticket.
+3. Add a `repo:my-repo` label to the Jira ticket. You can also use the full `repo:OrgName/my-repo` format.
 
 The bot clones repos automatically when it picks up a ticket. It fetches from `upstream`, creates branches based on the latest upstream code, pushes to `origin` (the fork), and opens PRs/MRs targeting the upstream repo.
 

--- a/tests/test_new_work.py
+++ b/tests/test_new_work.py
@@ -1,0 +1,103 @@
+"""Tests for new_work.py repo label matching with org/repo support."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".claude" / "skills" / "new-work"))
+
+from new_work import build_repo_lookup, match_repo_labels
+
+
+SAMPLE_REPOS = {
+    "insights-chrome": {
+        "url": "https://github.com/platex-rehor-bot/insights-chrome.git",
+        "upstream": "https://github.com/RedHatInsights/insights-chrome.git",
+    },
+    "notifications-frontend": {
+        "url": "https://github.com/platex-rehor-bot/notifications-frontend.git",
+        "upstream": "https://github.com/RedHatInsights/notifications-frontend.git",
+    },
+    "app-interface": {
+        "url": "https://gitlab.cee.redhat.com/platform-experience-services-bot/app-interface.git",
+        "upstream": "https://gitlab.cee.redhat.com/service/app-interface.git",
+        "host": "gitlab",
+    },
+    "other-org-repo": {
+        "url": "https://github.com/platex-rehor-bot/other-org-repo.git",
+        "upstream": "https://github.com/some-other-org/other-org-repo.git",
+    },
+}
+
+
+class TestBuildRepoLookup:
+    def test_bare_keys(self):
+        lookup = build_repo_lookup(SAMPLE_REPOS)
+        assert lookup["insights-chrome"] == "insights-chrome"
+        assert lookup["notifications-frontend"] == "notifications-frontend"
+        assert lookup["app-interface"] == "app-interface"
+
+    def test_github_org_repo(self):
+        lookup = build_repo_lookup(SAMPLE_REPOS)
+        assert lookup["RedHatInsights/insights-chrome"] == "insights-chrome"
+        assert lookup["RedHatInsights/notifications-frontend"] == "notifications-frontend"
+
+    def test_gitlab_org_repo(self):
+        lookup = build_repo_lookup(SAMPLE_REPOS)
+        assert lookup["service/app-interface"] == "app-interface"
+
+    def test_other_org(self):
+        lookup = build_repo_lookup(SAMPLE_REPOS)
+        assert lookup["some-other-org/other-org-repo"] == "other-org-repo"
+
+    def test_empty_dict(self):
+        assert build_repo_lookup({}) == {}
+
+    def test_missing_upstream(self):
+        lookup = build_repo_lookup({"my-repo": {"url": "https://x.com/my-repo.git"}})
+        assert lookup["my-repo"] == "my-repo"
+        assert len(lookup) == 1
+
+
+class TestMatchRepoLabels:
+    def setup_method(self):
+        self.lookup = build_repo_lookup(SAMPLE_REPOS)
+
+    def test_bare_label(self):
+        labels = ["hcc-ai-bot", "repo:insights-chrome"]
+        assert match_repo_labels(labels, self.lookup) == ["insights-chrome"]
+
+    def test_org_label(self):
+        labels = ["hcc-ai-bot", "repo:RedHatInsights/insights-chrome"]
+        assert match_repo_labels(labels, self.lookup) == ["insights-chrome"]
+
+    def test_other_org_label(self):
+        labels = ["repo:some-other-org/other-org-repo"]
+        assert match_repo_labels(labels, self.lookup) == ["other-org-repo"]
+
+    def test_gitlab_org_label(self):
+        labels = ["repo:service/app-interface"]
+        assert match_repo_labels(labels, self.lookup) == ["app-interface"]
+
+    def test_multi_repo_labels(self):
+        labels = ["repo:insights-chrome", "repo:RedHatInsights/notifications-frontend"]
+        result = match_repo_labels(labels, self.lookup)
+        assert result == ["insights-chrome", "notifications-frontend"]
+
+    def test_no_repo_labels(self):
+        labels = ["hcc-ai-bot", "needs-investigation"]
+        assert match_repo_labels(labels, self.lookup) == []
+
+    def test_empty_labels(self):
+        assert match_repo_labels([], self.lookup) == []
+
+    def test_unmatched_returns_empty(self):
+        labels = ["repo:nonexistent-repo"]
+        assert match_repo_labels(labels, self.lookup) == []
+
+    def test_partial_match_returns_empty(self):
+        labels = ["repo:insights-chrome", "repo:nonexistent"]
+        assert match_repo_labels(labels, self.lookup) == []
+
+    def test_unmatched_org_returns_empty(self):
+        labels = ["repo:WrongOrg/insights-chrome"]
+        assert match_repo_labels(labels, self.lookup) == []


### PR DESCRIPTION
## Summary
- Adds support for `repo:org/name` format in Jira labels (e.g. `repo:RedHatInsights/insights-chrome`)
- Bare `repo:name` labels continue to work unchanged (backwards compatible)
- Org-prefixed labels are resolved by matching against upstream URLs in `project-repos.json`

## Changes
- **`new_work.py`** — replaced `get_known_repos()` with `load_project_repos()` + `build_repo_lookup()` that maps both bare keys and `org/repo` (from upstream URLs) to project-repos.json keys
- **`tests/test_new_work.py`** — 16 tests covering bare, org-prefixed, GitLab, multi-repo, unmatched, and edge cases
- **CLAUDE.md, README.md, OPERATIONS.md** — documented the new label format

## Test plan
- [x] All 45 tests pass (`uv run python -m pytest tests/ -v`)
- [x] Bare labels resolve correctly (backwards compat)
- [x] `repo:RedHatInsights/insights-chrome` resolves to key `insights-chrome`
- [x] `repo:service/app-interface` resolves to key `app-interface` (GitLab)
- [x] `repo:WrongOrg/insights-chrome` correctly returns no match
- [x] Partial matches (some labels valid, some not) return empty (all-or-nothing preserved)

RHCLOUD-47869