### PR TITLE
fix(new-work): drop assignee filter from active sprint query

### DIFF
--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -105,7 +105,7 @@ def get_candidates():
     if sprint:
         jql = (
             f"project = RHCLOUD AND labels = {BOT_LABEL} "
-            f"AND assignee is EMPTY AND status IN ({status_list}) "
+            f"AND status IN ({status_list}) "
             f"AND sprint = {sprint['id']} "
             f"ORDER BY priority DESC, created ASC"
         )

--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -23,6 +23,7 @@ BOT_BOARD_ID = os.environ.get("BOT_BOARD_ID", "")
 BOT_BOARD_NAME = os.environ.get("BOT_BOARD_NAME", "")
 BOT_INCLUDE_BACKLOG = os.environ.get("BOT_INCLUDE_BACKLOG", "").lower() in ("1", "true", "yes")
 BOT_JIRA_EMAIL = os.environ.get("BOT_JIRA_EMAIL", "")
+BOT_SPRINT_PREFIX = os.environ.get("BOT_SPRINT_PREFIX", "")
 NOT_STARTED_STATUSES = ("New", "Backlog", "Refinement", "To Do")
 
 
@@ -68,14 +69,25 @@ def get_active_sprint():
     data = jira_call("jira_get_sprints_from_board", {
         "board_id": board_id,
         "state": "active",
-        "limit": 1,
+        "limit": 10,
     })
     if not data:
         return None
     sprints = data if isinstance(data, list) else data.get("values", [])
-    if sprints:
-        print(f"Active sprint: {sprints[0].get('name', '?')} (id={sprints[0]['id']})", file=sys.stderr)
-    return sprints[0] if sprints else None
+    if not sprints:
+        return None
+    if BOT_SPRINT_PREFIX:
+        matched = [s for s in sprints if s.get("name", "").startswith(BOT_SPRINT_PREFIX)]
+        if matched:
+            sprint = matched[0]
+            print(f"Active sprint (prefix={BOT_SPRINT_PREFIX}): {sprint.get('name', '?')} (id={sprint['id']})", file=sys.stderr)
+            return sprint
+        names = [s.get("name", "?") for s in sprints]
+        print(f"WARN: no sprint matching prefix '{BOT_SPRINT_PREFIX}', available: {names}", file=sys.stderr)
+        return None
+    sprint = sprints[0]
+    print(f"Active sprint: {sprint.get('name', '?')} (id={sprint['id']})", file=sys.stderr)
+    return sprint
 
 
 def get_known_repos():

--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -22,6 +22,7 @@ BOT_LABEL = os.environ.get("BOT_LABEL", "")
 BOT_BOARD_ID = os.environ.get("BOT_BOARD_ID", "")
 BOT_BOARD_NAME = os.environ.get("BOT_BOARD_NAME", "")
 BOT_INCLUDE_BACKLOG = os.environ.get("BOT_INCLUDE_BACKLOG", "").lower() in ("1", "true", "yes")
+BOT_JIRA_EMAIL = os.environ.get("BOT_JIRA_EMAIL", "")
 NOT_STARTED_STATUSES = ("New", "Backlog", "Refinement", "To Do")
 
 
@@ -113,9 +114,13 @@ def get_candidates():
 
     if len(candidates) < 10 and BOT_INCLUDE_BACKLOG:
         existing_keys = {c["key"] for c in candidates}
+        if BOT_JIRA_EMAIL:
+            assignee_filter = f'AND (assignee is EMPTY OR assignee = "{BOT_JIRA_EMAIL}") '
+        else:
+            assignee_filter = "AND assignee is EMPTY "
         jql = (
             f"project = RHCLOUD AND labels = {BOT_LABEL} "
-            f"AND assignee is EMPTY AND status IN ({status_list}) "
+            f"{assignee_filter}AND status IN ({status_list}) "
             f"AND sprint is EMPTY "
             f"ORDER BY priority DESC, created ASC"
         )

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -23,6 +23,8 @@ parameters:
   value: "1"
 - name: BOT_BOARD_NAME
   value: ""
+- name: BOT_SPRINT_PREFIX
+  value: ""
 - name: BOT_INCLUDE_BACKLOG
   value: "false"
 - name: BOT_INSTANCE_ID
@@ -39,6 +41,8 @@ parameters:
   required: true
 - name: VERTEX_ALLOWED_MODELS
   required: true
+- name: SLACK_WEBHOOK_URL
+  value: ""
 objects:
 
 # ============================================================================
@@ -420,6 +424,8 @@ objects:
           # Bot config
           - name: BOT_BOARD_NAME
             value: ${BOT_BOARD_NAME}
+          - name: BOT_SPRINT_PREFIX
+            value: ${BOT_SPRINT_PREFIX}
           - name: BOT_INCLUDE_BACKLOG
             value: ${BOT_INCLUDE_BACKLOG}
           - name: BOT_INSTANCE_ID
@@ -432,6 +438,9 @@ objects:
             value: http://devbot-memory-server:8080/api/bot-status
           - name: COSTS_API_URL
             value: http://devbot-memory-server:8080/api/costs
+          # Slack notifications
+          - name: SLACK_WEBHOOK_URL
+            value: ${SLACK_WEBHOOK_URL}
           # Proxy — separate pod
           - name: PROXY_HOST
             value: devbot-proxy


### PR DESCRIPTION
## Summary
- Removes `assignee is EMPTY` filter from the active sprint JQL query
- Tickets in the active sprint are now found regardless of assignee — only status matters (must be in a not-started status like New, Backlog, Refinement, To Do)
- Backlog query (sprintless tickets) keeps the assignee filter — bot won't steal someone else's backlog work

## Context
RHCLOUD-47866 was not picked up because the sprint query required `assignee is EMPTY`. Tickets in the active sprint that are already assigned (e.g. by a human who forgot to transition status) should still be visible to the bot as candidates.

RHCLOUD-47866