### PR TITLE
fix(claim-ticket): inline constant to fix relative import

### DIFF
--- a/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
+++ b/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
@@ -29,7 +29,7 @@ import httpx
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 from jira_mcp import jira_call
 
-from .constants import TRANSITION_IN_PROGRESS
+TRANSITION_IN_PROGRESS = "In Progress"
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/.claude/skills/claim-ticket/scripts/constants.py
+++ b/.claude/skills/claim-ticket/scripts/constants.py
@@ -1,4 +1,0 @@
-"""Constants for claim-ticket operations."""
-
-# JIRA transition names
-TRANSITION_IN_PROGRESS = "In Progress"


### PR DESCRIPTION
## Summary
- Fixes relative import error in `claim_ticket_operations.py` that caused the bot to waste ~4 tool calls per cycle
- `from .constants import TRANSITION_IN_PROGRESS` fails when script is run directly with `python3` (not as package)
- Inlined the constant and deleted the now-unused `constants.py` module
- All 25 tests pass

RHCLOUD-47778