### PR TITLE
fix(wrap-up): pass webhook_url to slack_notify

### DIFF
--- a/.claude/skills/wrap-up/wrap_up.py
+++ b/.claude/skills/wrap-up/wrap_up.py
@@ -141,6 +141,9 @@ def archive_task(jira_key, summary):
 
 
 def slack_notify(jira_key, pr_info):
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
+    if not webhook_url:
+        return False, "SLACK_WEBHOOK_URL not set"
     pr_links = []
     for p in pr_info:
         pr_url = p.get("url", "")
@@ -164,6 +167,7 @@ def slack_notify(jira_key, pr_info):
                     "jira_key": jira_key,
                     "event_type": "release_pending",
                     "message": msg,
+                    "webhook_url": webhook_url,
                 },
             },
         },


### PR DESCRIPTION
## Summary
- `wrap_up.py` calls `slack_notify` via raw MCP HTTP to the memory server, bypassing the bot's MCP client
- The `webhook_url` param was missing, so the memory server had no webhook and silently failed
- Now reads `SLACK_WEBHOOK_URL` from the bot's env and passes it to the MCP tool call

## Test plan
- [x] Deploy and trigger a wrap-up — Slack notification should arrive
- [x] Verify wrap-up still works when `SLACK_WEBHOOK_URL` is unset (returns early with clear message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)