### PR TITLE
chore: add scalprum/scaffolding to project-repos

### DIFF
--- a/rehor-config/agent/project-repos.json
+++ b/rehor-config/agent/project-repos.json
@@ -172,5 +172,9 @@
   "cypress-e2e-image": {
     "url": "https://github.com/platex-rehor-bot/cypress-e2e-image.git",
     "upstream": "https://github.com/RedHatInsights/cypress-e2e-image.git"
+  },
+  "scalprum/scaffolding": {
+    "url": "https://github.com/platex-rehor-bot/scaffolding.git",
+    "upstream": "https://github.com/scalprum/scaffolding.git"
   }
 }


### PR DESCRIPTION
## Summary
- Fork created at `platex-rehor-bot/scaffolding` from `scalprum/scaffolding`
- Added to `rehor-config/agent/project-repos.json`
- Enables bot to pick up tickets with `repo:scalprum/scaffolding` label (e.g. RHCLOUD-47691)

## Test plan
- [x] Verified `repo:scalprum/scaffolding` label resolves to `scaffolding` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)