### PR TITLE
fix(claim-ticket): use email for assignment instead of account ID lookup

### DIFF
--- a/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
+++ b/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
@@ -2,7 +2,7 @@
 Claim ticket workflow operations.
 
 Consolidates ticket claiming into a single script:
-1. get_bot_account_id - retrieve bot's JIRA account ID via MCP
+1. get_bot_email - retrieve bot's JIRA account ID via MCP
 2. get_transitions - get available transitions via MCP
 3. assign_ticket - assign ticket via MCP
 4. transition_to_in_progress - move to "In Progress" via MCP
@@ -90,83 +90,30 @@ class ClaimTicketOperations:
         self.board_id: Optional[str] = None
         self.sprint_id: Optional[int] = None
 
-    def get_bot_account_id(self) -> OperationResult:
+    def get_bot_email(self) -> OperationResult:
         """
-        Get bot's JIRA identity from BOT_JIRA_EMAIL env var, then resolve account ID via MCP.
+        Get bot's JIRA email from BOT_JIRA_EMAIL env var.
 
-        Returns:
-            OperationResult with account ID
+        No MCP call needed — jira_update_issue accepts email strings directly.
         """
-        if ClaimTicketOperations._bot_account_id_cache:
-            self.bot_account_id = ClaimTicketOperations._bot_account_id_cache
-            logger.info(f"Using cached bot account ID: {self.bot_account_id}")
-            return OperationResult(
-                operation="get_bot_account_id",
-                status=OperationStatus.SUCCESS,
-                message=f"Retrieved bot account ID from cache: {self.bot_account_id}",
-                details={"account_id": self.bot_account_id},
-            )
-
         bot_email = os.environ.get("BOT_JIRA_EMAIL")
         if not bot_email:
             error_msg = "BOT_JIRA_EMAIL env var not set"
             logger.error(error_msg)
             return OperationResult(
-                operation="get_bot_account_id",
+                operation="get_bot_email",
                 status=OperationStatus.FAILED,
                 message=error_msg,
             )
 
-        logger.info(f"Resolving JIRA account for {bot_email}...")
-
-        if self.dry_run:
-            self.bot_account_id = "dry-run-account-id"
-            logger.info(f"[DRY RUN] Would resolve account for {bot_email}")
-            return OperationResult(
-                operation="get_bot_account_id",
-                status=OperationStatus.SUCCESS,
-                message=f"Retrieved bot account ID (dry run): {self.bot_account_id}",
-                details={"account_id": self.bot_account_id},
-            )
-
-        try:
-            data = jira_call("jira_get_user_profile", {"user_identifier": bot_email})
-            if not data:
-                error_msg = f"jira_get_user_profile returned None for {bot_email}"
-                logger.error(error_msg)
-                return OperationResult(
-                    operation="get_bot_account_id",
-                    status=OperationStatus.FAILED,
-                    message=error_msg,
-                )
-
-            self.bot_account_id = data.get("account_id") or data.get("accountId")
-            if not self.bot_account_id:
-                error_msg = f"No account_id in jira_get_user_profile response: {data}"
-                logger.error(error_msg)
-                return OperationResult(
-                    operation="get_bot_account_id",
-                    status=OperationStatus.FAILED,
-                    message=error_msg,
-                )
-
-            ClaimTicketOperations._bot_account_id_cache = self.bot_account_id
-
-            logger.info(f"Retrieved bot account ID: {self.bot_account_id}")
-            return OperationResult(
-                operation="get_bot_account_id",
-                status=OperationStatus.SUCCESS,
-                message=f"Retrieved bot account ID: {self.bot_account_id}",
-                details={"account_id": self.bot_account_id},
-            )
-        except Exception as e:
-            error_msg = f"Failed to get bot account ID: {str(e)}"
-            logger.error(error_msg)
-            return OperationResult(
-                operation="get_bot_account_id",
-                status=OperationStatus.FAILED,
-                message=error_msg,
-            )
+        self.bot_account_id = bot_email
+        logger.info(f"Using bot email for assignment: {bot_email}")
+        return OperationResult(
+            operation="get_bot_email",
+            status=OperationStatus.SUCCESS,
+            message=f"Using bot email: {bot_email}",
+            details={"email": bot_email},
+        )
 
     def get_transitions(self, jira_key: str) -> OperationResult:
         """
@@ -201,7 +148,7 @@ class ClaimTicketOperations:
                     message=error_msg,
                 )
 
-            transitions = data.get("transitions", [])
+            transitions = data if isinstance(data, list) else data.get("transitions", [])
 
             # Find "In Progress" transition
             in_progress_transition = None
@@ -252,7 +199,7 @@ class ClaimTicketOperations:
             OperationResult with assignment details
         """
         if not self.bot_account_id:
-            error_msg = "Bot account ID not available. Run get_bot_account_id first."
+            error_msg = "Bot account ID not available. Run get_bot_email first."
             logger.error(error_msg)
             return OperationResult(
                 operation="assign_ticket",
@@ -275,7 +222,7 @@ class ClaimTicketOperations:
                 "jira_update_issue",
                 {
                     "issue_key": jira_key,
-                    "fields": {"assignee": {"accountId": self.bot_account_id}},
+                    "fields": json.dumps({"assignee": self.bot_account_id}),
                 },
             )
 
@@ -485,7 +432,7 @@ class ClaimTicketOperations:
                     message=error_msg,
                 )
 
-            sprints = data.get("sprints", [])
+            sprints = data if isinstance(data, list) else data.get("sprints", [])
 
             if not sprints:
                 error_msg = f"No active sprint found on board {self.board_id}"
@@ -684,15 +631,15 @@ def execute_claim_ticket_workflow(
     logger.info(f"Starting claim ticket workflow for {jira_key}...")
 
     # 1. Get bot account ID
-    if "get_bot_account_id" not in skip_operations:
-        result = operations.get_bot_account_id()
+    if "get_bot_email" not in skip_operations:
+        result = operations.get_bot_email()
         results.append(result)
         if result.status == OperationStatus.FAILED:
             return WorkflowResult(success=False, operations=results, jira_key=jira_key)
     else:
         results.append(
             OperationResult(
-                operation="get_bot_account_id",
+                operation="get_bot_email",
                 status=OperationStatus.SKIPPED,
                 message="Skipped by user request",
             )

--- a/.claude/skills/claim-ticket/tests/conftest.py
+++ b/.claude/skills/claim-ticket/tests/conftest.py
@@ -37,7 +37,6 @@ def mock_memory_server():
 def successful_jira_responses():
     """Standard JIRA responses for successful workflow."""
     return {
-        "jira_get_user_profile": {"account_id": TEST_BOT_ACCOUNT_ID},
         "jira_get_transitions": {"transitions": [{"id": TEST_TRANSITION_ID, "name": "In Progress"}]},
         "jira_update_issue": {},
         "jira_transition_issue": {},

--- a/.claude/skills/claim-ticket/tests/test_integration.py
+++ b/.claude/skills/claim-ticket/tests/test_integration.py
@@ -50,8 +50,11 @@ class TestWorkflow:
         )
 
         assert result.success is False
-        assert len(result.operations) == 1
-        assert result.operations[0].status == OperationStatus.FAILED
+        assert len(result.operations) == 2
+        assert result.operations[0].status == OperationStatus.SUCCESS
+        assert result.operations[0].operation == "get_bot_email"
+        assert result.operations[1].status == OperationStatus.FAILED
+        assert result.operations[1].operation == "get_transitions"
 
     def test_workflow_missing_memory_url(self):
         """Test workflow fails without memory URL."""

--- a/.claude/skills/claim-ticket/tests/test_operations.py
+++ b/.claude/skills/claim-ticket/tests/test_operations.py
@@ -27,65 +27,24 @@ def clear_bot_account_cache():
     ClaimTicketOperations._bot_account_id_cache = None
 
 
-class TestGetBotAccountId:
-    """Test get_bot_account_id operation."""
+class TestGetBotEmail:
+    """Test get_bot_email operation."""
 
-    @patch("scripts.claim_ticket_operations.jira_call")
-    def test_get_bot_account_id_success(self, mock_jira_call, operations):
-        """Test successful bot account ID retrieval via MCP."""
-        mock_jira_call.return_value = {"account_id": "bot-account-123"}
-
-        result = operations.get_bot_account_id()
+    def test_get_bot_email_success(self, operations):
+        """Test successful bot email retrieval from env var."""
+        result = operations.get_bot_email()
 
         assert result.status == OperationStatus.SUCCESS
-        assert result.operation == "get_bot_account_id"
-        assert "bot-account-123" in result.message
-        assert result.details["account_id"] == "bot-account-123"
-        assert operations.bot_account_id == "bot-account-123"
+        assert result.operation == "get_bot_email"
+        assert "bot@example.com" in result.message
+        assert result.details["email"] == "bot@example.com"
+        assert operations.bot_account_id == "bot@example.com"
 
-        mock_jira_call.assert_called_once_with("jira_get_user_profile", {"user_identifier": "bot@example.com"})
-
-    @patch("scripts.claim_ticket_operations.jira_call")
-    def test_get_bot_account_id_caching(self, mock_jira_call, operations):
-        """Test bot account ID is cached across instances."""
-        mock_jira_call.return_value = {"account_id": "bot-account-456"}
-
-        # First call - should hit MCP
-        result1 = operations.get_bot_account_id()
-        assert result1.status == OperationStatus.SUCCESS
-        assert mock_jira_call.call_count == 1
-
-        # Second call - should use cache
-        result2 = operations.get_bot_account_id()
-        assert result2.status == OperationStatus.SUCCESS
-        assert "cache" in result2.message.lower()
-        assert mock_jira_call.call_count == 1  # No additional MCP call
-
-    @patch("scripts.claim_ticket_operations.jira_call")
-    def test_get_bot_account_id_none_response(self, mock_jira_call, operations):
-        """Test handling when MCP returns None."""
-        mock_jira_call.return_value = None
-
-        result = operations.get_bot_account_id()
-
-        assert result.status == OperationStatus.FAILED
-        assert "returned None for bot@example.com" in result.message
-
-    @patch("scripts.claim_ticket_operations.jira_call")
-    def test_get_bot_account_id_dry_run(self, mock_jira_call):
-        """Test dry run mode."""
-        ops = ClaimTicketOperations(memory_url="https://test.example.com", dry_run=True)
-        result = ops.get_bot_account_id()
-
-        assert result.status == OperationStatus.SUCCESS
-        assert "dry run" in result.message.lower()
-        mock_jira_call.assert_not_called()
-
-    def test_get_bot_account_id_missing_env_var(self, monkeypatch):
+    def test_get_bot_email_missing_env_var(self, monkeypatch):
         """Test failure when BOT_JIRA_EMAIL is not set."""
         monkeypatch.delenv("BOT_JIRA_EMAIL", raising=False)
         ops = ClaimTicketOperations(memory_url="https://test.example.com")
-        result = ops.get_bot_account_id()
+        result = ops.get_bot_email()
 
         assert result.status == OperationStatus.FAILED
         assert "BOT_JIRA_EMAIL" in result.message
@@ -114,6 +73,19 @@ class TestGetTransitions:
         mock_jira_call.assert_called_once_with("jira_get_transitions", {"issue_key": "RHCLOUD-12345"})
 
     @patch("scripts.claim_ticket_operations.jira_call")
+    def test_get_transitions_flat_list(self, mock_jira_call, operations):
+        """Test transition retrieval when MCP returns flat list."""
+        mock_jira_call.return_value = [
+            {"id": "11", "name": "To Do"},
+            {"id": "21", "name": "In Progress"},
+        ]
+
+        result = operations.get_transitions("RHCLOUD-12345")
+
+        assert result.status == OperationStatus.SUCCESS
+        assert operations.transition_id == "21"
+
+    @patch("scripts.claim_ticket_operations.jira_call")
     def test_get_transitions_not_found(self, mock_jira_call, operations):
         """Test when In Progress transition not found."""
         mock_jira_call.return_value = {"transitions": [{"id": "11", "name": "To Do"}]}
@@ -129,8 +101,8 @@ class TestAssignTicket:
 
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_assign_ticket_success(self, mock_jira_call, operations):
-        """Test successful ticket assignment."""
-        operations.bot_account_id = "bot-123"
+        """Test successful ticket assignment using email string."""
+        operations.bot_account_id = "bot@example.com"
         mock_jira_call.return_value = {}
 
         result = operations.assign_ticket("RHCLOUD-12345")
@@ -138,7 +110,7 @@ class TestAssignTicket:
         assert result.status == OperationStatus.SUCCESS
         mock_jira_call.assert_called_once_with(
             "jira_update_issue",
-            {"issue_key": "RHCLOUD-12345", "fields": {"assignee": {"accountId": "bot-123"}}},
+            {"issue_key": "RHCLOUD-12345", "fields": '{"assignee": "bot@example.com"}'},
         )
 
     def test_assign_ticket_no_account_id(self, operations):
@@ -240,6 +212,17 @@ class TestGetActiveSprint:
         assert result.status == OperationStatus.SUCCESS
         assert operations.sprint_id == 12345
         mock_jira_call.assert_called_once_with("jira_get_sprints_from_board", {"board_id": "9297", "state": "active"})
+
+    @patch("scripts.claim_ticket_operations.jira_call")
+    def test_get_active_sprint_flat_list(self, mock_jira_call, operations):
+        """Test sprint retrieval when MCP returns flat list."""
+        operations.board_id = "9297"
+        mock_jira_call.return_value = [{"id": 12345, "name": "Sprint 42"}]
+
+        result = operations.get_active_sprint()
+
+        assert result.status == OperationStatus.SUCCESS
+        assert operations.sprint_id == 12345
 
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_get_active_sprint_no_active(self, mock_jira_call, operations):


### PR DESCRIPTION
## Summary

- Replace `get_bot_account_id()` with `get_bot_email()` — `jira_get_user_profile` returns no `account_id` field, so we use `BOT_JIRA_EMAIL` env var directly
- Fix `get_transitions` and `get_active_sprint` response parsing to handle both flat list and nested object formats from mcp-atlassian
- Update tests: new email-based assignment tests, flat response format coverage

## JIRA

[RHCLOUD-48013](https://redhat.atlassian.net/browse/RHCLOUD-48013)

## Test plan

- [x] All 18 unit tests pass (`uv run pytest tests/test_operations.py -v`)
- [ ] Deploy and verify claim-ticket workflow assigns tickets correctly using email

[RHCLOUD-48013]: https://redhat.atlassian.net/browse/RHCLOUD-48013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ