### PR TITLE
fix(claim-ticket): guard against sprint overwrite

### DIFF
--- a/.claude/skills/claim-ticket/README.md
+++ b/.claude/skills/claim-ticket/README.md
@@ -99,9 +99,11 @@ export JIRA_API_TOKEN=your_api_token_here
 # Memory Server (required)
 export BOT_MEMORY_URL=https://memory-server.example.com
 
-# Board Configuration (one of these required)
-export BOT_BOARD_ID=9297                          # Direct board ID (skips lookup)
-export BOT_BOARD_NAME="Platform Experience UI"    # Lookup board by name via Jira
+# Board Configuration (one of these required for sprint assignment)
+# WARNING: These are EXAMPLES — use your instance's actual board ID/name.
+# Using wrong board IDs overwrites the ticket's existing sprint.
+export BOT_BOARD_ID=<your-board-id>               # Direct board ID (skips lookup)
+export BOT_BOARD_NAME="<Your Board Name>"         # Lookup board by name via Jira
 ```
 
 **Note:** Uses JIRA Cloud API v3 with Basic authentication (email + API token).

--- a/.claude/skills/claim-ticket/SKILL.md
+++ b/.claude/skills/claim-ticket/SKILL.md
@@ -52,9 +52,11 @@ export BOT_JIRA_EMAIL=<your-bot-jira-email>
 # Memory Server (required)
 export BOT_MEMORY_URL=https://memory-server.example.com
 
-# Board Configuration (one of these required)
-export BOT_BOARD_ID=9297                          # Direct board ID (skips lookup)
-export BOT_BOARD_NAME="Platform Experience UI"    # Lookup board by name via Jira
+# Board Configuration (one of these required for sprint assignment)
+# WARNING: These are EXAMPLES — use your instance's actual board ID/name.
+# Using wrong board IDs overwrites the ticket's existing sprint.
+export BOT_BOARD_ID=<your-board-id>               # Direct board ID (skips lookup)
+export BOT_BOARD_NAME="<Your Board Name>"         # Lookup board by name via Jira
 ```
 
 ## Authentication

--- a/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
+++ b/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
@@ -461,9 +461,28 @@ class ClaimTicketOperations:
                 message=error_msg,
             )
 
+    def _check_existing_sprint(self, jira_key: str) -> Optional[str]:
+        """Return the name of the ticket's current active/future sprint, or None."""
+        try:
+            data = jira_call(
+                "jira_get_issue",
+                {"issue_key": jira_key, "fields": "customfield_10020"},
+            )
+            if not data:
+                return None
+            fields = data.get("fields", {}) if isinstance(data, dict) else {}
+            sprints = fields.get("customfield_10020") or []
+            for s in sprints:
+                if isinstance(s, dict) and s.get("state") in ("active", "future"):
+                    return s.get("name", "unknown")
+        except Exception as e:
+            logger.warning(f"Could not check existing sprint for {jira_key}: {e}")
+        return None
+
     def add_to_sprint(self, jira_key: str) -> OperationResult:
         """
         Add ticket to the active sprint via jira_add_issues_to_sprint.
+        Skips if the ticket already belongs to an active or future sprint.
 
         Args:
             jira_key: JIRA ticket key (e.g., RHCLOUD-12345)
@@ -478,6 +497,17 @@ class ClaimTicketOperations:
                 operation="add_to_sprint",
                 status=OperationStatus.FAILED,
                 message=error_msg,
+            )
+
+        existing = self._check_existing_sprint(jira_key)
+        if existing:
+            msg = f"{jira_key} already in sprint '{existing}' — skipping"
+            logger.info(msg)
+            return OperationResult(
+                operation="add_to_sprint",
+                status=OperationStatus.SUCCESS,
+                message=msg,
+                details={"skipped": True, "existing_sprint": existing},
             )
 
         logger.info(f"Adding {jira_key} to sprint {self.sprint_id}...")

--- a/.claude/skills/claim-ticket/tests/test_operations.py
+++ b/.claude/skills/claim-ticket/tests/test_operations.py
@@ -266,11 +266,7 @@ class TestAddToSprint:
         """Test sprint addition is skipped when ticket already has an active sprint."""
         operations.sprint_id = 12345
         mock_jira_call.return_value = {
-            "fields": {
-                "customfield_10020": [
-                    {"id": 99999, "name": "CCXDEV Sprint 169", "state": "active"}
-                ]
-            }
+            "fields": {"customfield_10020": [{"id": 99999, "name": "CCXDEV Sprint 169", "state": "active"}]}
         }
 
         result = operations.add_to_sprint("CCXDEV-16393")

--- a/.claude/skills/claim-ticket/tests/test_operations.py
+++ b/.claude/skills/claim-ticket/tests/test_operations.py
@@ -241,16 +241,47 @@ class TestAddToSprint:
 
     @patch("scripts.claim_ticket_operations.jira_call")
     def test_add_to_sprint_success(self, mock_jira_call, operations):
-        """Test successful sprint addition."""
+        """Test successful sprint addition when ticket has no sprint."""
         operations.sprint_id = 12345
-        mock_jira_call.return_value = {}
+        mock_jira_call.side_effect = [
+            {"fields": {"customfield_10020": []}},
+            {},
+        ]
 
         result = operations.add_to_sprint("RHCLOUD-12345")
 
         assert result.status == OperationStatus.SUCCESS
-        mock_jira_call.assert_called_once_with(
+        assert mock_jira_call.call_count == 2
+        mock_jira_call.assert_any_call(
+            "jira_get_issue",
+            {"issue_key": "RHCLOUD-12345", "fields": "customfield_10020"},
+        )
+        mock_jira_call.assert_any_call(
             "jira_add_issues_to_sprint",
             {"sprint_id": 12345, "issue_keys": ["RHCLOUD-12345"]},
+        )
+
+    @patch("scripts.claim_ticket_operations.jira_call")
+    def test_add_to_sprint_skips_existing(self, mock_jira_call, operations):
+        """Test sprint addition is skipped when ticket already has an active sprint."""
+        operations.sprint_id = 12345
+        mock_jira_call.return_value = {
+            "fields": {
+                "customfield_10020": [
+                    {"id": 99999, "name": "CCXDEV Sprint 169", "state": "active"}
+                ]
+            }
+        }
+
+        result = operations.add_to_sprint("CCXDEV-16393")
+
+        assert result.status == OperationStatus.SUCCESS
+        assert "already in sprint" in result.message
+        assert result.details["skipped"] is True
+        assert result.details["existing_sprint"] == "CCXDEV Sprint 169"
+        mock_jira_call.assert_called_once_with(
+            "jira_get_issue",
+            {"issue_key": "CCXDEV-16393", "fields": "customfield_10020"},
         )
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Before starting work, `jira_get_issue` → check issue links:
 
 #### Implement
 
-1. **Claim**: Use `$BOT_JIRA_EMAIL` env var for assignee (never `jira_get_user_profile`). `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress" → **Sprint**: board from `BOT_BOARD_ID` or `BOT_BOARD_NAME` env var → `jira_get_sprints_from_board` state=active → `jira_add_issues_to_sprint`.
+1. **Claim**: `$BOT_JIRA_EMAIL` for assignee (never `jira_get_user_profile`). `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress" → **Sprint**: `jira_get_issue` fields=`customfield_10020` first — active/future sprint exists → **SKIP** (Jira overwrites existing sprint on add). No sprint → `BOT_BOARD_ID`/`BOT_BOARD_NAME` env → `jira_get_sprints_from_board` active → `jira_add_issues_to_sprint`. Neither env set → skip. **NEVER hardcode board IDs or use doc examples.**
 
 2. **Track**: `task_add` w/ `jira_key, repo, branch (bot/<KEY>), in_progress, title, summary, metadata`:
    ```json


### PR DESCRIPTION
## Summary

Fixes a bug where `add_to_sprint()` blindly adds a ticket to the bot's active sprint without checking if it already has one. In Jira, adding to a new sprint **replaces** the existing sprint — this caused CCXDEV-16393 to have its sprint overwritten from "CCXDEV Sprint 169" to "HCC UI Sprint 62".

### Changes

- **`claim_ticket_operations.py`**: New `_check_existing_sprint()` method queries `customfield_10020` before adding. If ticket already has an active/future sprint, skips with success + details.
- **`CLAUDE.md`**: Updated fallback instructions — check existing sprint first, skip if present, never use hardcoded board IDs, skip sprint assignment entirely if no `BOT_BOARD_ID`/`BOT_BOARD_NAME` env var set.
- **`SKILL.md` / `README.md`**: Replaced hardcoded example board ID `9297` with `<your-board-id>` placeholder + warning about sprint overwrite risk.
- **Tests**: Updated existing test to mock the sprint check, added new test for the "already has sprint" skip path.

## Test plan

- [x] All 19 existing + new tests pass
- [ ] Verify with a ticket that already has a sprint — should log "already in sprint" and skip
- [ ] Verify with a ticket that has no sprint — should add normally

Fixes [RHCLOUD-48079](https://redhat.atlassian.net/browse/RHCLOUD-48079)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-48079]: https://redhat.atlassian.net/browse/RHCLOUD-48079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ