### PR TITLE
fix(memory-server): fix HuggingFace cache permissions for OpenShift

### DIFF
--- a/memory-server/Dockerfile
+++ b/memory-server/Dockerfile
@@ -28,7 +28,11 @@ RUN uv sync --frozen --no-dev
 
 # Pre-download the embedding model so startup doesn't need HuggingFace
 RUN uv run python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')" \
-    && rm -rf /opt/app-root/src/.cache/uv
+    && rm -rf /opt/app-root/src/.cache/uv \
+    && chmod -R a+rX /opt/app-root/src/.cache/huggingface
+
+# Offline mode — model is baked in, no network/cache writes needed at runtime
+ENV HF_HUB_OFFLINE=1
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary

- Fix `PermissionError` when memory-server loads the embedding model on OpenShift (arbitrary UIDs can't write to cache dirs created during build)
- `chmod -R a+rX` on baked-in HuggingFace cache so any UID can read it
- `HF_HUB_OFFLINE=1` prevents runtime network calls and cache write attempts

## Root cause

OpenShift runs containers with random UIDs. The HuggingFace cache written during `docker build` is owned by UID 0, but at runtime the container runs as a different UID. `sentence_transformers` tries to write lock files/metadata to the cache on model load → `PermissionError`.

## Test plan

- [x] Built and started container locally — model loads from cache, no download, no permission errors
- [ ] Deploy to OpenShift and verify memory-server starts cleanly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>