### PR TITLE
fix(deploy): add ingress NetworkPolicies for proxy and memory-server

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -535,3 +535,62 @@ objects:
         protocol: UDP
       - port: 5353
         protocol: TCP
+
+# --- NetworkPolicy: Proxy accepts ingress from bot pods ---
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: ${PROXY_NAME}-ingress
+    labels:
+      app.kubernetes.io/part-of: devbot
+  spec:
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${PROXY_NAME}
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/part-of: devbot
+      ports:
+      - port: 3128
+        protocol: TCP
+      - port: 9090
+        protocol: TCP
+      - port: 8443
+        protocol: TCP
+      - port: 8444
+        protocol: TCP
+      - port: 8446
+        protocol: TCP
+
+# --- NetworkPolicy: Memory server accepts ingress from bot pods + OpenShift router ---
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: devbot-memory-server-ingress
+    labels:
+      app.kubernetes.io/part-of: devbot
+  spec:
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: memory-server
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/part-of: devbot
+      ports:
+      - port: 8080
+        protocol: TCP
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+      ports:
+      - port: 8080
+        protocol: TCP


### PR DESCRIPTION
### Description

  The namespace-level `networkPoliciesAllow` for openshift-customer-monitoring created a default-deny ingress policy on all pods in the namespace. This broke two things:

  1. **Bot → proxy**: bot pods could no longer reach the proxy (all ports timed out)
  2. **Router → memory-server**: the OpenShift router could not reach the memory-server, making the dashboard inaccessible

  Root cause: `networkPoliciesAllow` creates a NetworkPolicy with `podSelector: {}` and `policyTypes: ["Ingress"]`, which isolates every pod for ingress. We only had egress policies defined — no ingress policies
  existed.

  Fix: add explicit ingress NetworkPolicies:
  - **proxy**: accept from any pod with `app.kubernetes.io/part-of: devbot` on ports 3128, 9090, 8443, 8444, 8446
  - **memory-server**: accept from devbot pods + OpenShift router namespace (`network.openshift.io/policy-group: ingress`) on port 8080

  [RHCLOUD-48147](https://issues.redhat.com/browse/RHCLOUD-48147)

  ---
  
  ### Blast radius

  - All bot instances in `platform-frontend-ai-dev-stage` (framework, obsint, ui)
  - Memory server dashboard (external route)
  - No downstream repos affected — this is infrastructure-only

  Validated by applying the policies directly in OpenShift and confirming connectivity from the bot pod to all proxy ports and the memory-server.

  ---
  
  ### Rollback plan

  `git revert` is sufficient. Removing the ingress policies returns to the current (broken) state. The monitoring ingress policy from app-interface would continue to block intra-namespace traffic.

  ---
  
  ### Checklist
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not `latest`

  ### AI disclosure
  Assisted by: Claude Code (Claude Opus 4.6)

[RHCLOUD-48147]: https://redhat.atlassian.net/browse/RHCLOUD-48147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ