### PR TITLE
feat(skills): add slack-notify skill

### DIFF
--- a/.claude/skills/memory_mcp.py
+++ b/.claude/skills/memory_mcp.py
@@ -1,0 +1,101 @@
+"""Shared bot-memory MCP client for skill scripts.
+
+Uses the MCP Python SDK for proper session handling over streamable HTTP.
+
+Usage:
+    from memory_mcp import memory_call
+
+    data = memory_call("slack_notify", {"jira_key": "X", ...})
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+MEMORY_MCP_URL = os.environ.get("BOT_MEMORY_URL", "").rstrip("/")
+
+_session = None
+_read = None
+_write = None
+_cm_transport = None
+_cm_session = None
+
+
+async def _ensure_session():
+    global _session, _read, _write, _cm_transport, _cm_session
+    if _session is not None:
+        return _session
+
+    if not MEMORY_MCP_URL:
+        raise RuntimeError("BOT_MEMORY_URL not set")
+
+    from mcp.client.streamable_http import streamablehttp_client
+    from mcp import ClientSession
+
+    _cm_transport = streamablehttp_client(MEMORY_MCP_URL)
+    _read, _write, _ = await _cm_transport.__aenter__()
+    _cm_session = ClientSession(_read, _write)
+    _session = await _cm_session.__aenter__()
+    await _session.initialize()
+    return _session
+
+
+async def _call(tool_name, arguments, timeout=30):
+    session = await _ensure_session()
+    result = await asyncio.wait_for(
+        session.call_tool(tool_name, arguments),
+        timeout=timeout,
+    )
+    if result.isError:
+        text = result.content[0].text if result.content else "unknown error"
+        print(f"  ERR MCP {tool_name}: {text[:200]}", file=sys.stderr)
+        return None
+    text = result.content[0].text
+    return json.loads(text)
+
+
+async def _cleanup():
+    global _session, _cm_session, _cm_transport
+    if _cm_session:
+        try:
+            await _cm_session.__aexit__(None, None, None)
+        except Exception:
+            pass
+    if _cm_transport:
+        try:
+            await _cm_transport.__aexit__(None, None, None)
+        except Exception:
+            pass
+    _session = _cm_session = _cm_transport = None
+
+
+def memory_call(tool_name, arguments, timeout=30):
+    """Synchronous wrapper for MCP tool calls."""
+    if not MEMORY_MCP_URL:
+        print("WARN: BOT_MEMORY_URL not set", file=sys.stderr)
+        return None
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            raise RuntimeError("nested event loop")
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(_call(tool_name, arguments, timeout))
+    except Exception as e:
+        print(f"  ERR MCP {tool_name}: {e}", file=sys.stderr)
+        return None
+
+
+def memory_cleanup():
+    """Close MCP session."""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return
+    try:
+        loop.run_until_complete(_cleanup())
+    except Exception:
+        pass

--- a/.claude/skills/slack-notify/SKILL.md
+++ b/.claude/skills/slack-notify/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: slack-notify
+description: >
+  Send Slack notification. Reads SLACK_WEBHOOK_URL from env, calls memory-server
+  MCP slack_notify w/ webhook_url. No-ops if webhook not configured.
+when_to_use: >
+  Any Slack notification. Replaces direct slack_notify MCP calls.
+user-invocable: true
+allowed-tools:
+  - "Bash(python3 .claude/skills/slack-notify/slack_notify.py *)"
+---
+
+```bash
+python3 .claude/skills/slack-notify/slack_notify.py <JIRA_KEY> <EVENT_TYPE> "<MESSAGE>" 2>&1
+```
+
+Events: `pr_created`, `release_pending`, `needs_help`, `infra_error`, `review_reminder`.
+
+Msg = normal human language (NOT caveman). 1-2 sentences + links.
+
+Output: `{"sent": true/false, "reason": "..."}`. No webhook → silent no-op. 48h cooldown/ticket automatic.

--- a/.claude/skills/slack-notify/slack_notify.py
+++ b/.claude/skills/slack-notify/slack_notify.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Send Slack notification via memory-server MCP. Reads SLACK_WEBHOOK_URL from env.
+
+Usage:
+    python3 .claude/skills/slack-notify/slack_notify.py <jira_key> <event_type> <message>
+
+Event types: pr_created, release_pending, needs_help, infra_error, review_reminder
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from memory_mcp import memory_call, memory_cleanup
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(
+            "Usage: slack_notify.py <jira_key> <event_type> <message>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    jira_key = sys.argv[1]
+    event_type = sys.argv[2]
+    message = sys.argv[3]
+
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
+    if not webhook_url:
+        print(json.dumps({"sent": False, "reason": "SLACK_WEBHOOK_URL not set"}))
+        return
+
+    result = memory_call(
+        "slack_notify",
+        {
+            "jira_key": jira_key,
+            "event_type": event_type,
+            "message": message,
+            "webhook_url": webhook_url,
+        },
+    )
+    memory_cleanup()
+
+    if result:
+        print(json.dumps(result))
+    else:
+        print(json.dumps({"sent": False, "reason": "MCP call failed"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/wrap-up/wrap_up.py
+++ b/.claude/skills/wrap-up/wrap_up.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from jira_mcp import jira_call
+from memory_mcp import memory_call
 
 MEMORY_URL = (
     os.environ.get("BOT_MEMORY_URL", "http://localhost:8080").rstrip("/mcp").rstrip("/")
@@ -154,26 +155,17 @@ def slack_notify(jira_key, pr_info):
         else:
             pr_links.append(f"{repo}#{num}")
     msg = f"{jira_key} merged → Release Pending. PR: {', '.join(pr_links) if pr_links else '(unknown)'}"
-    result = http_request(
-        f"{MEMORY_URL}/mcp",
-        method="POST",
-        body={
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "slack_notify",
-                "arguments": {
-                    "jira_key": jira_key,
-                    "event_type": "release_pending",
-                    "message": msg,
-                    "webhook_url": webhook_url,
-                },
-            },
+    result = memory_call(
+        "slack_notify",
+        {
+            "jira_key": jira_key,
+            "event_type": "release_pending",
+            "message": msg,
+            "webhook_url": webhook_url,
         },
     )
-    if result and "result" in result:
-        return True, result["result"]
+    if result and result.get("sent"):
+        return True, result
     return False, str(result)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,13 @@ Tags: `bug-fix`, `cve`, `css`, `patternfly`, `dependency-upgrade`, `ci`, `ui-cha
 
 ### Slack Notifications
 
-| Tool | Purpose |
-|------|---------|
-| `slack_notify` | Post to team Slack. Params: `jira_key, event_type, message, webhook_url`. **Always pass `webhook_url` from `$SLACK_WEBHOOK_URL` env var.** 48h cooldown per jira_key (any event type). |
+Use `/slack-notify` skill (NOT direct `slack_notify` MCP tool):
+
+```bash
+python3 .claude/skills/slack-notify/slack_notify.py <JIRA_KEY> <EVENT_TYPE> "<MESSAGE>" 2>&1
+```
+
+Script reads `$SLACK_WEBHOOK_URL` from env. No webhook → silent no-op. 48h cooldown per jira_key (automatic).
 
 **Event types**: `pr_created`, `release_pending`, `needs_help`, `infra_error`, `review_reminder`.
 
@@ -145,7 +149,7 @@ Tags: `bug-fix`, `cve`, `css`, `patternfly`, `dependency-upgrade`, `ci`, `ui-cha
 - `infra_error` — infrastructure issue preventing work (sandbox broken, auth failed, etc.).
 - `review_reminder` — PR awaiting human review. Send on first PR triage if no notification sent yet. Bot reviews don't count. Include ticket key, PR link, repo.
 
-**Rules**: Cooldown is automatic (48h per jira_key, any event type — one notification per ticket per 48h). Don't check manually. Message = normal human language (NOT caveman). Keep concise: 1-2 sentences + links. Don't notify for routine operations (task updates, memory stores, etc.).
+**Rules**: Cooldown automatic. Msg = normal human language (NOT caveman). Concise: 1-2 sentences + links. Don't notify for routine ops.
 
 ## Workflow Loop
 
@@ -194,7 +198,7 @@ PR statuses are in the triage output. For each `pr_open`/`pr_changes` task:
 0. **Reload persona**: Read `personas/<name>/prompt.md` for repo tech stack (same logic as step 6). Has CI fix patterns + sequencing rules.
 1. `cd` repo dir. `git fetch origin`. Fork? Also `git fetch upstream`.
 2. Check `host` in `project-repos.json` → `gh` (GitHub) or `glab` (GitLab). **ALL `glab` commands MUST include `--hostname gitlab.cee.redhat.com`** — without it, glab defaults to `gitlab.com` which is blocked. Fork repos: `glab mr` needs `--repo <upstream-project-path>`.
-3. **Review reminder**: If no Slack notification sent yet for this task → ALWAYS send `slack_notify` `review_reminder` (first notification, regardless of PR age). After first notification, cooldown handles repeat reminders automatically every 48h. **Bot reviews don't count for reminders** — only human reviews satisfy the "reviewed" condition. PR with only bot reviews = still needs human review → send reminder. **However, bot review feedback IS actionable** — address suggestions from coderabbitai, sourcery-ai, etc. as real code review feedback. Fix valid issues, dismiss false positives with a reply.
+3. **Review reminder**: No Slack notification sent yet → ALWAYS invoke `/slack-notify` w/ `review_reminder` (first notification, regardless of PR age). After first, cooldown handles repeats every 48h. **Bot reviews don't count** — only human reviews satisfy "reviewed". PR w/ only bot reviews = still needs human review → send reminder. **However, bot review feedback IS actionable** — address coderabbitai/sourcery-ai suggestions as real feedback. Fix valid issues, dismiss false positives w/ reply.
 
 4. Handle in order:
 
@@ -225,7 +229,7 @@ PR statuses are in the triage output. For each `pr_open`/`pr_changes` task:
 - **Update linked issues**: duplicates → comment fix merged. Related → link PR. Blocked → blocker resolved.
 - **Store learnings**: `memory_store` as `learning` + `codebase_pattern`. Set `repo` + `tags`.
 
-**Unresolvable**: Jira comment explaining blocker. `task_update` `paused_reason`. `slack_notify` `needs_help`: "{KEY} blocked — {reason}". Task stays tracked.
+**Unresolvable**: Jira comment explaining blocker. `task_update` `paused_reason`. Invoke `/slack-notify` w/ `needs_help`: "{KEY} blocked — {reason}". Task stays tracked.
 
 Handle one PR issue → stop. Next cycle picks up next.
 
@@ -382,7 +386,7 @@ Before starting work, `jira_get_issue` → check issue links:
 
 12. **Report on Jira**: `jira_transition_issue` → "Code Review". `jira_add_comment`: what done, PR links, concerns. Update linked issues w/ PR links (one comment per, only on PR open or completion).
 
-13. **Notify Slack**: `slack_notify` `pr_created`: "{KEY}: {title} — PR: {url}". Also notify `needs_help` if investigation or blocked.
+13. **Notify Slack**: Invoke `/slack-notify` w/ `pr_created`: "{KEY}: {title} — PR: {url}". Also `needs_help` if investigation or blocked.
 
 ## Progress Tracking
 


### PR DESCRIPTION
## Summary

- Add `/slack-notify` skill that reads `SLACK_WEBHOOK_URL` from env and calls the memory-server MCP tool deterministically — fixes unreliable prompt compliance where the agent would intermittently omit the `webhook_url` parameter
- Add shared `memory_mcp.py` client (mirrors existing `jira_mcp.py` pattern) for proper MCP session handling
- Update `wrap-up` to use the shared client (was broken — POSTing raw JSON-RPC to SSE endpoint)
- Update CLAUDE.md: all Slack notification references now point to the skill

Tested on `devbot-framework` pod — `{"sent": true, "reason": "ok"}`.

RHCLOUD-48206

## Test plan

- [x] Copy skill to running bot pod, invoke manually — notification delivered
- [ ] Merge and verify bot uses skill in next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)