### PR TITLE
chore: allow python registry in network proxy

### DIFF
--- a/proxy/squid.conf
+++ b/proxy/squid.conf
@@ -23,6 +23,7 @@ acl allowed_domains dstdomain .npmjs.org
 acl allowed_domains dstdomain .nodejs.org
 acl allowed_domains dstdomain pypi.org
 acl allowed_domains dstdomain files.pythonhosted.org
+acl allowed_domains dstdomain pypi.python.org
 
 # Go toolchain and modules
 acl allowed_domains dstdomain go.dev


### PR DESCRIPTION
Require by access management instance