### PR TITLE
feat(memory-server): add cycle_runs table for progress and transcripts

### DIFF
--- a/memory-server/pyproject.toml
+++ b/memory-server/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic>=2.0",
     "uvicorn>=0.30",
     "websockets>=13.0",
+    "zstandard>=0.23",
 ]
 
 [project.optional-dependencies]

--- a/memory-server/src/api.py
+++ b/memory-server/src/api.py
@@ -888,9 +888,7 @@ async def api_cycle_runs_add(request: Request) -> JSONResponse:
     started_at = body.get("started_at")
     finished_at = body.get("finished_at")
     parsed_started = datetime.fromisoformat(started_at) if started_at else None
-    parsed_finished = (
-        datetime.fromisoformat(finished_at) if finished_at else None
-    )
+    parsed_finished = datetime.fromisoformat(finished_at) if finished_at else None
 
     progress = body.get("progress")
     if isinstance(progress, str):
@@ -940,9 +938,7 @@ async def api_cycle_run_transcript(request: Request) -> Response:
         "SELECT transcript FROM cycle_runs WHERE id = $1", int(run_id)
     )
     if not row:
-        return JSONResponse(
-            {"error": f"Cycle run {run_id} not found"}, status_code=404
-        )
+        return JSONResponse({"error": f"Cycle run {run_id} not found"}, status_code=404)
 
     transcript = row["transcript"]
     if transcript is None:

--- a/memory-server/src/api.py
+++ b/memory-server/src/api.py
@@ -1,12 +1,14 @@
 """REST API endpoints for the web dashboard."""
 
+import base64
 import json
 import logging
 import os
 from datetime import date as date_type
+from datetime import datetime
 
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 
 from .db import get_pool
 from .embeddings import embed
@@ -805,6 +807,176 @@ async def api_stats(request: Request) -> JSONResponse:
     )
 
 
+_CYCLE_RUN_LIST_COLUMNS = (
+    "id, task_id, cycle_type, instance_id, started_at, finished_at, "
+    "tool_calls, tokens_used, progress, created_at"
+)
+
+
+async def api_cycle_runs(request: Request) -> JSONResponse:
+    """GET /api/cycle-runs — list cycle runs, filterable.
+    POST /api/cycle-runs — store a new cycle run (with optional transcript)."""
+    if request.method == "POST":
+        return await api_cycle_runs_add(request)
+
+    pool = get_pool()
+    task_id = request.query_params.get("task_id")
+    instance_id = request.query_params.get("instance_id")
+    cycle_type = request.query_params.get("cycle_type")
+    limit = int(request.query_params.get("limit", "50"))
+    offset = int(request.query_params.get("offset", "0"))
+
+    conditions, params, idx = [], [], 0
+    if task_id:
+        idx += 1
+        conditions.append(f"task_id = ${idx}")
+        params.append(int(task_id))
+    if instance_id:
+        idx += 1
+        conditions.append(f"instance_id = ${idx}")
+        params.append(instance_id)
+    if cycle_type:
+        idx += 1
+        conditions.append(f"cycle_type = ${idx}")
+        params.append(cycle_type)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    total = await pool.fetchval(f"SELECT COUNT(*) FROM cycle_runs {where}", *params)
+
+    idx += 1
+    params.append(limit)
+    limit_idx = idx
+    idx += 1
+    params.append(offset)
+    offset_idx = idx
+
+    rows = await pool.fetch(
+        f"""
+        SELECT {_CYCLE_RUN_LIST_COLUMNS}
+        FROM cycle_runs {where}
+        ORDER BY created_at DESC
+        LIMIT ${limit_idx} OFFSET ${offset_idx}
+        """,
+        *params,
+    )
+
+    return JSONResponse(
+        {
+            "items": [_cycle_run(r) for r in rows],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+    )
+
+
+async def api_cycle_runs_add(request: Request) -> JSONResponse:
+    """POST /api/cycle-runs — store a cycle run with optional base64 transcript."""
+    pool = get_pool()
+    body = await request.json()
+
+    task_id = body.get("task_id")
+    if task_id is not None:
+        task_id = int(task_id) if task_id else None
+
+    transcript_bytes = None
+    transcript_b64 = body.get("transcript_b64")
+    if transcript_b64:
+        transcript_bytes = base64.b64decode(transcript_b64)
+
+    started_at = body.get("started_at")
+    finished_at = body.get("finished_at")
+    parsed_started = datetime.fromisoformat(started_at) if started_at else None
+    parsed_finished = (
+        datetime.fromisoformat(finished_at) if finished_at else None
+    )
+
+    progress = body.get("progress")
+    if isinstance(progress, str):
+        progress = json.loads(progress)
+
+    row = await pool.fetchrow(
+        f"""
+        INSERT INTO cycle_runs (task_id, cycle_type, instance_id, started_at, finished_at,
+                                tool_calls, tokens_used, progress, transcript)
+        VALUES ($1, $2, $3, COALESCE($4, NOW()), $5, $6, $7, $8, $9)
+        RETURNING {_CYCLE_RUN_LIST_COLUMNS}
+        """,
+        task_id,
+        body.get("cycle_type", "task_work"),
+        body.get("instance_id"),
+        parsed_started,
+        parsed_finished,
+        body.get("tool_calls"),
+        body.get("tokens_used"),
+        json.dumps(progress or {}),
+        transcript_bytes,
+    )
+    result = _cycle_run(row)
+    result["has_transcript"] = transcript_bytes is not None
+    await bus.publish(
+        Event(
+            "cycle_run_added",
+            {
+                "id": result["id"],
+                "task_id": result["task_id"],
+                "cycle_type": result["cycle_type"],
+                "instance_id": result["instance_id"],
+            },
+        )
+    )
+    return JSONResponse(result, status_code=201)
+
+
+async def api_cycle_run_transcript(request: Request) -> Response:
+    """GET /api/cycle-runs/{id}/transcript — return transcript, optionally decompressed."""
+    pool = get_pool()
+    run_id = request.path_params.get("id")
+    if not run_id:
+        return JSONResponse({"error": "missing cycle run id"}, status_code=400)
+
+    row = await pool.fetchrow(
+        "SELECT transcript FROM cycle_runs WHERE id = $1", int(run_id)
+    )
+    if not row:
+        return JSONResponse(
+            {"error": f"Cycle run {run_id} not found"}, status_code=404
+        )
+
+    transcript = row["transcript"]
+    if transcript is None:
+        return JSONResponse(
+            {"error": f"Cycle run {run_id} has no transcript"}, status_code=404
+        )
+
+    decompress = request.query_params.get("decompress", "").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+    if decompress:
+        try:
+            import zstandard as zstd
+
+            decompressor = zstd.ZstdDecompressor()
+            decompressed = decompressor.decompress(transcript)
+            return Response(
+                content=decompressed,
+                media_type="application/x-ndjson",
+            )
+        except Exception as e:
+            return JSONResponse(
+                {"error": f"Decompression failed: {e}"}, status_code=500
+            )
+
+    return Response(
+        content=bytes(transcript),
+        media_type="application/zstd",
+    )
+
+
 def _task(row, slack_notif=None) -> dict:
     result = {
         "id": row["id"],
@@ -865,4 +1037,21 @@ def _memory(row) -> dict:
         "metadata": json.loads(row["metadata"])
         if isinstance(row["metadata"], str)
         else (row["metadata"] or {}),
+    }
+
+
+def _cycle_run(row) -> dict:
+    return {
+        "id": row["id"],
+        "task_id": row["task_id"],
+        "cycle_type": row["cycle_type"],
+        "instance_id": row["instance_id"],
+        "started_at": row["started_at"].isoformat() if row["started_at"] else None,
+        "finished_at": row["finished_at"].isoformat() if row["finished_at"] else None,
+        "tool_calls": row["tool_calls"],
+        "tokens_used": row["tokens_used"],
+        "progress": json.loads(row["progress"])
+        if isinstance(row["progress"], str)
+        else (row["progress"] or {}),
+        "created_at": row["created_at"].isoformat(),
     }

--- a/memory-server/src/models.py
+++ b/memory-server/src/models.py
@@ -35,3 +35,16 @@ class Memory(BaseModel):
 
 class MemorySearchResult(Memory):
     similarity: float
+
+
+class CycleRun(BaseModel):
+    id: int
+    task_id: int | None = None
+    cycle_type: str
+    instance_id: str | None = None
+    started_at: datetime
+    finished_at: datetime | None = None
+    tool_calls: int | None = None
+    tokens_used: int | None = None
+    progress: dict[str, Any] | None = None
+    created_at: datetime

--- a/memory-server/src/schema.sql
+++ b/memory-server/src/schema.sql
@@ -151,6 +151,21 @@ EXCEPTION
     WHEN undefined_table THEN NULL;
 END $$;
 
+-- Cycle runs — progress history + compressed transcripts per bot cycle
+CREATE TABLE IF NOT EXISTS cycle_runs (
+    id              SERIAL PRIMARY KEY,
+    task_id         INTEGER REFERENCES tasks(id) ON DELETE SET NULL,
+    cycle_type      TEXT NOT NULL DEFAULT 'task_work',
+    instance_id     TEXT,
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at     TIMESTAMPTZ,
+    tool_calls      INTEGER,
+    tokens_used     INTEGER,
+    progress        JSONB,
+    transcript      BYTEA,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 -- Only create index if table has enough rows (ivfflat needs data)
 -- On first startup with empty table, queries fall back to sequential scan
 -- Re-run this after seeding data:

--- a/memory-server/src/server.py
+++ b/memory-server/src/server.py
@@ -40,11 +40,13 @@ from .tools.tasks import register_task_tools  # noqa: E402
 from .tools.rag import register_rag_tools  # noqa: E402
 from .tools.slack import register_slack_tools  # noqa: E402
 from .tools.org_members import register_org_member_tools  # noqa: E402
+from .tools.cycles import register_cycle_tools  # noqa: E402
 
 register_task_tools(mcp)
 register_rag_tools(mcp)
 register_slack_tools(mcp)
 register_org_member_tools(mcp)
+register_cycle_tools(mcp)
 
 
 # Health check
@@ -91,6 +93,8 @@ from .api import (  # noqa: E402
     api_instances,
     api_costs,
     api_analytics,
+    api_cycle_runs,
+    api_cycle_run_transcript,
 )
 
 mcp.custom_route("/api/tasks", methods=["GET"])(api_tasks)
@@ -110,6 +114,10 @@ mcp.custom_route("/api/costs", methods=["GET", "POST"])(api_costs)
 mcp.custom_route("/api/tags", methods=["GET"])(api_tags)
 mcp.custom_route("/api/stats", methods=["GET"])(api_stats)
 mcp.custom_route("/api/analytics", methods=["GET"])(api_analytics)
+mcp.custom_route("/api/cycle-runs", methods=["GET", "POST"])(api_cycle_runs)
+mcp.custom_route("/api/cycle-runs/{id}/transcript", methods=["GET"])(
+    api_cycle_run_transcript
+)
 
 
 # WebSocket for live updates

--- a/memory-server/src/tools/cycles.py
+++ b/memory-server/src/tools/cycles.py
@@ -63,12 +63,8 @@ def register_cycle_tools(mcp: FastMCP):
 
         resolved_task_id = task_id if task_id and task_id > 0 else None
 
-        parsed_started = (
-            datetime.fromisoformat(started_at) if started_at else None
-        )
-        parsed_finished = (
-            datetime.fromisoformat(finished_at) if finished_at else None
-        )
+        parsed_started = datetime.fromisoformat(started_at) if started_at else None
+        parsed_finished = datetime.fromisoformat(finished_at) if finished_at else None
 
         row = await pool.fetchrow(
             f"""

--- a/memory-server/src/tools/cycles.py
+++ b/memory-server/src/tools/cycles.py
@@ -1,0 +1,140 @@
+"""MCP tools for cycle progress storage and retrieval."""
+
+import json
+from datetime import datetime
+from typing import Optional
+
+from fastmcp import FastMCP
+
+from ..db import get_pool
+from ..events import Event, bus
+from ..models import CycleRun
+
+
+def _row_to_cycle_run(row) -> dict:
+    run = CycleRun(
+        id=row["id"],
+        task_id=row["task_id"],
+        cycle_type=row["cycle_type"],
+        instance_id=row["instance_id"],
+        started_at=row["started_at"],
+        finished_at=row["finished_at"],
+        tool_calls=row["tool_calls"],
+        tokens_used=row["tokens_used"],
+        progress=json.loads(row["progress"])
+        if isinstance(row["progress"], str)
+        else (row["progress"] or {}),
+        created_at=row["created_at"],
+    )
+    return run.model_dump(mode="json")
+
+
+_CYCLE_RUN_COLUMNS = (
+    "id, task_id, cycle_type, instance_id, started_at, finished_at, "
+    "tool_calls, tokens_used, progress, created_at"
+)
+
+
+def register_cycle_tools(mcp: FastMCP):
+    @mcp.tool()
+    async def progress_store(
+        task_id: int,
+        instance_id: str,
+        cycle_type: str = "task_work",
+        progress: Optional[dict] = None,
+        started_at: Optional[str] = None,
+        finished_at: Optional[str] = None,
+        tool_calls: Optional[int] = None,
+        tokens_used: Optional[int] = None,
+    ) -> dict:
+        """Store a structured progress summary for the current cycle.
+        Called by the bot before a cycle ends to persist what happened.
+        task_id: The DB task ID (from task_add/task_get result). Use 0 or omit for idle/error cycles.
+        instance_id: Bot instance name.
+        cycle_type: One of 'task_work', 'triage_only', 'idle', 'error'.
+        progress: Structured JSON with keys like last_step, next_step, files_changed, commits, key_decisions, blockers, notes.
+        started_at/finished_at: ISO timestamps. If omitted, started_at defaults to NOW().
+        tool_calls: Number of tool calls in this cycle.
+        tokens_used: Total tokens consumed."""
+        pool = get_pool()
+
+        if isinstance(progress, str):
+            progress = json.loads(progress)
+
+        resolved_task_id = task_id if task_id and task_id > 0 else None
+
+        parsed_started = (
+            datetime.fromisoformat(started_at) if started_at else None
+        )
+        parsed_finished = (
+            datetime.fromisoformat(finished_at) if finished_at else None
+        )
+
+        row = await pool.fetchrow(
+            f"""
+            INSERT INTO cycle_runs (task_id, cycle_type, instance_id, started_at, finished_at,
+                                    tool_calls, tokens_used, progress)
+            VALUES ($1, $2, $3, COALESCE($4, NOW()), $5, $6, $7, $8)
+            RETURNING {_CYCLE_RUN_COLUMNS}
+            """,
+            resolved_task_id,
+            cycle_type,
+            instance_id,
+            parsed_started,
+            parsed_finished,
+            tool_calls,
+            tokens_used,
+            json.dumps(progress or {}),
+        )
+        result = _row_to_cycle_run(row)
+        await bus.publish(
+            Event(
+                "cycle_run_added",
+                {
+                    "id": result["id"],
+                    "task_id": result["task_id"],
+                    "cycle_type": cycle_type,
+                    "instance_id": instance_id,
+                },
+            )
+        )
+        return result
+
+    @mcp.tool()
+    async def progress_load(
+        task_id: int,
+        instance_id: Optional[str] = None,
+        limit: int = 5,
+    ) -> list[dict]:
+        """Load recent progress entries for a task across cycles.
+        Returns the last N cycle progress summaries, most recent first.
+        Use this at cycle start to understand what happened in prior cycles.
+        task_id: The DB task ID.
+        instance_id: Optional filter to a specific bot instance.
+        limit: Max entries to return (default 5)."""
+        pool = get_pool()
+
+        conditions = ["task_id = $1"]
+        params: list = [task_id]
+        idx = 1
+
+        if instance_id:
+            idx += 1
+            conditions.append(f"instance_id = ${idx}")
+            params.append(instance_id)
+
+        idx += 1
+        params.append(min(limit, 50))
+
+        where = " AND ".join(conditions)
+        rows = await pool.fetch(
+            f"""
+            SELECT {_CYCLE_RUN_COLUMNS}
+            FROM cycle_runs
+            WHERE {where}
+            ORDER BY created_at DESC
+            LIMIT ${idx}
+            """,
+            *params,
+        )
+        return [_row_to_cycle_run(r) for r in rows]

--- a/memory-server/tests/test_cycle_runs.py
+++ b/memory-server/tests/test_cycle_runs.py
@@ -111,7 +111,9 @@ async def test_post_cycle_run_with_transcript(mock_pool):
 @pytest.mark.asyncio
 async def test_post_cycle_run_no_task(mock_pool):
     mock_pool.fetchrow = AsyncMock(
-        side_effect=lambda q, *a: _fake_cycle_run_row(id=2, task_id=None, cycle_type="idle")
+        side_effect=lambda q, *a: _fake_cycle_run_row(
+            id=2, task_id=None, cycle_type="idle"
+        )
     )
     body = {
         "cycle_type": "idle",
@@ -311,7 +313,9 @@ def mock_pool_for_tools():
     pool.fetch = AsyncMock(
         return_value=[
             _fake_cycle_run_row(id=1),
-            _fake_cycle_run_row(id=2, progress=json.dumps({"last_step": "tests_passing"})),
+            _fake_cycle_run_row(
+                id=2, progress=json.dumps({"last_step": "tests_passing"})
+            ),
         ]
     )
     with patch("src.tools.cycles.get_pool", return_value=pool):

--- a/memory-server/tests/test_cycle_runs.py
+++ b/memory-server/tests/test_cycle_runs.py
@@ -1,0 +1,401 @@
+"""Tests for cycle-runs REST API and MCP tools."""
+
+import asyncio
+import base64
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from src.api import api_cycle_runs, api_cycle_run_transcript
+
+
+app = Starlette(
+    routes=[
+        Route("/api/cycle-runs", api_cycle_runs, methods=["GET", "POST"]),
+        Route(
+            "/api/cycle-runs/{id}/transcript",
+            api_cycle_run_transcript,
+            methods=["GET"],
+        ),
+    ]
+)
+
+
+def _fake_cycle_run_row(id=1, task_id=42, **kwargs):
+    """Build a dict that looks like an asyncpg Record for cycle_runs."""
+    now = datetime.now(timezone.utc)
+    return {
+        "id": id,
+        "task_id": task_id,
+        "cycle_type": kwargs.get("cycle_type", "task_work"),
+        "instance_id": kwargs.get("instance_id", "test-instance"),
+        "started_at": kwargs.get("started_at", now),
+        "finished_at": kwargs.get("finished_at", now),
+        "tool_calls": kwargs.get("tool_calls", 50),
+        "tokens_used": kwargs.get("tokens_used", 100000),
+        "progress": kwargs.get("progress", json.dumps({"last_step": "implemented"})),
+        "created_at": kwargs.get("created_at", now),
+        "transcript": kwargs.get("transcript"),
+    }
+
+
+@pytest.fixture
+def mock_pool():
+    pool = MagicMock()
+    pool.fetchval = AsyncMock(return_value=1)
+    pool.fetchrow = AsyncMock(
+        side_effect=lambda q, *a: _fake_cycle_run_row(id=1, task_id=a[0])
+    )
+    pool.fetch = AsyncMock(return_value=[_fake_cycle_run_row()])
+    pool.execute = AsyncMock()
+    with patch("src.api.get_pool", return_value=pool):
+        yield pool
+
+
+# --- REST API: POST /api/cycle-runs ---
+
+
+@pytest.mark.asyncio
+async def test_post_cycle_run_basic(mock_pool):
+    body = {
+        "task_id": 42,
+        "cycle_type": "task_work",
+        "instance_id": "hcc-ai-framework",
+        "progress": {"last_step": "pr_opened", "files_changed": ["src/foo.py"]},
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/cycle-runs", json=body)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["id"] == 1
+    assert data["task_id"] == 42
+    assert data["cycle_type"] == "task_work"
+    mock_pool.fetchrow.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_post_cycle_run_with_transcript(mock_pool):
+    transcript_data = b'{"role": "assistant", "content": "hello"}\n'
+
+    import zstandard as zstd
+
+    compressor = zstd.ZstdCompressor(level=19)
+    compressed = compressor.compress(transcript_data)
+
+    body = {
+        "task_id": 42,
+        "cycle_type": "task_work",
+        "instance_id": "test",
+        "transcript_b64": base64.b64encode(compressed).decode(),
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/cycle-runs", json=body)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["has_transcript"] is True
+
+
+@pytest.mark.asyncio
+async def test_post_cycle_run_no_task(mock_pool):
+    mock_pool.fetchrow = AsyncMock(
+        side_effect=lambda q, *a: _fake_cycle_run_row(id=2, task_id=None, cycle_type="idle")
+    )
+    body = {
+        "cycle_type": "idle",
+        "instance_id": "test",
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/cycle-runs", json=body)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["task_id"] is None
+    assert data["cycle_type"] == "idle"
+
+
+@pytest.mark.asyncio
+async def test_post_cycle_run_with_timestamps(mock_pool):
+    body = {
+        "task_id": 42,
+        "cycle_type": "task_work",
+        "instance_id": "test",
+        "started_at": "2026-06-10T12:00:00+00:00",
+        "finished_at": "2026-06-10T12:05:00+00:00",
+        "tool_calls": 87,
+        "tokens_used": 150000,
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/cycle-runs", json=body)
+
+    assert resp.status_code == 201
+    call_args = mock_pool.fetchrow.call_args[0]
+    assert call_args[6] == 87  # tool_calls
+    assert call_args[7] == 150000  # tokens_used
+
+
+# --- REST API: GET /api/cycle-runs ---
+
+
+@pytest.mark.asyncio
+async def test_get_cycle_runs_list(mock_pool):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert "total" in data
+    assert len(data["items"]) == 1
+    assert data["items"][0]["cycle_type"] == "task_work"
+
+
+@pytest.mark.asyncio
+async def test_get_cycle_runs_filter_by_task(mock_pool):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs?task_id=42")
+
+    assert resp.status_code == 200
+    call_args = mock_pool.fetch.call_args
+    query = call_args[0][0]
+    assert "task_id = $1" in query
+
+
+@pytest.mark.asyncio
+async def test_get_cycle_runs_filter_by_instance(mock_pool):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs?instance_id=hcc-ai-framework")
+
+    assert resp.status_code == 200
+    call_args = mock_pool.fetch.call_args
+    query = call_args[0][0]
+    assert "instance_id = $" in query
+
+
+@pytest.mark.asyncio
+async def test_get_cycle_runs_filter_by_cycle_type(mock_pool):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs?cycle_type=idle")
+
+    assert resp.status_code == 200
+    call_args = mock_pool.fetch.call_args
+    query = call_args[0][0]
+    assert "cycle_type = $" in query
+
+
+@pytest.mark.asyncio
+async def test_get_cycle_runs_no_transcript_in_list(mock_pool):
+    """Listing should never include transcript data."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs")
+
+    data = resp.json()
+    for item in data["items"]:
+        assert "transcript" not in item
+        assert "transcript_b64" not in item
+
+
+# --- REST API: GET /api/cycle-runs/{id}/transcript ---
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_not_found(mock_pool):
+    mock_pool.fetchrow = AsyncMock(return_value=None)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs/999/transcript")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_no_transcript_stored(mock_pool):
+    mock_pool.fetchrow = AsyncMock(return_value={"transcript": None})
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs/1/transcript")
+
+    assert resp.status_code == 404
+    assert "no transcript" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_raw(mock_pool):
+    raw_bytes = b"compressed-data-here"
+    mock_pool.fetchrow = AsyncMock(return_value={"transcript": raw_bytes})
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(
+            "/api/cycle-runs/1/transcript",
+            headers={"accept": "application/octet-stream"},
+        )
+
+    assert resp.status_code == 200
+    assert "application/zstd" in resp.headers["content-type"]
+    assert resp.content == raw_bytes
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_decompressed(mock_pool):
+    transcript_text = b'{"role": "assistant"}\n{"role": "user"}\n'
+
+    import zstandard as zstd
+
+    compressor = zstd.ZstdCompressor()
+    compressed = compressor.compress(transcript_text)
+
+    mock_pool.fetchrow = AsyncMock(return_value={"transcript": compressed})
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cycle-runs/1/transcript?decompress=true")
+
+    assert resp.status_code == 200
+    assert resp.content == transcript_text
+    assert resp.headers["content-type"] == "application/x-ndjson"
+
+
+# --- MCP tools: progress_store / progress_load ---
+
+
+async def _get_tool_fn(mcp_instance, tool_name):
+    """Get the underlying function for an MCP tool by name."""
+    tools = await mcp_instance.list_tools()
+    for t in tools:
+        if t.name == tool_name:
+            return t.fn
+    raise KeyError(f"Tool {tool_name} not found")
+
+
+@pytest.fixture
+def mock_pool_for_tools():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        side_effect=lambda q, *a: _fake_cycle_run_row(id=1, task_id=a[0])
+    )
+    pool.fetch = AsyncMock(
+        return_value=[
+            _fake_cycle_run_row(id=1),
+            _fake_cycle_run_row(id=2, progress=json.dumps({"last_step": "tests_passing"})),
+        ]
+    )
+    with patch("src.tools.cycles.get_pool", return_value=pool):
+        yield pool
+
+
+@pytest.fixture
+def mcp_with_tools(mock_pool_for_tools):
+    from src.tools.cycles import register_cycle_tools
+    from fastmcp import FastMCP
+
+    mcp = FastMCP(name="test")
+    register_cycle_tools(mcp)
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_progress_store(mock_pool_for_tools, mcp_with_tools):
+    store_fn = await _get_tool_fn(mcp_with_tools, "progress_store")
+
+    result = await store_fn(
+        task_id=42,
+        instance_id="test-instance",
+        cycle_type="task_work",
+        progress={"last_step": "implemented", "files_changed": ["a.py"]},
+        tool_calls=50,
+        tokens_used=100000,
+    )
+
+    assert result["id"] == 1
+    assert result["task_id"] == 42
+    mock_pool_for_tools.fetchrow.assert_called_once()
+    query = mock_pool_for_tools.fetchrow.call_args[0][0]
+    assert "INSERT INTO cycle_runs" in query
+
+
+@pytest.mark.asyncio
+async def test_progress_store_null_task(mock_pool_for_tools, mcp_with_tools):
+    mock_pool_for_tools.fetchrow = AsyncMock(
+        side_effect=lambda q, *a: _fake_cycle_run_row(id=3, task_id=None)
+    )
+
+    store_fn = await _get_tool_fn(mcp_with_tools, "progress_store")
+
+    result = await store_fn(
+        task_id=0,
+        instance_id="test",
+        cycle_type="idle",
+    )
+
+    assert result["task_id"] is None
+    call_args = mock_pool_for_tools.fetchrow.call_args[0]
+    assert call_args[1] is None  # resolved_task_id
+
+
+@pytest.mark.asyncio
+async def test_progress_load(mock_pool_for_tools, mcp_with_tools):
+    load_fn = await _get_tool_fn(mcp_with_tools, "progress_load")
+
+    results = await load_fn(task_id=42, limit=5)
+
+    assert len(results) == 2
+    assert results[0]["id"] == 1
+    mock_pool_for_tools.fetch.assert_called_once()
+    query = mock_pool_for_tools.fetch.call_args[0][0]
+    assert "task_id = $1" in query
+    assert "ORDER BY created_at DESC" in query
+
+
+@pytest.mark.asyncio
+async def test_progress_load_with_instance_filter(mock_pool_for_tools, mcp_with_tools):
+    load_fn = await _get_tool_fn(mcp_with_tools, "progress_load")
+
+    await load_fn(task_id=42, instance_id="hcc-ai-framework", limit=3)
+
+    query = mock_pool_for_tools.fetch.call_args[0][0]
+    assert "instance_id = $2" in query
+
+
+@pytest.mark.asyncio
+async def test_progress_load_limit_capped(mock_pool_for_tools, mcp_with_tools):
+    load_fn = await _get_tool_fn(mcp_with_tools, "progress_load")
+
+    await load_fn(task_id=42, limit=999)
+
+    call_args = mock_pool_for_tools.fetch.call_args[0]
+    assert call_args[2] == 50  # capped at 50


### PR DESCRIPTION
## Summary

- Adds `cycle_runs` table to memory-server DB for storing per-cycle progress history (JSONB) and compressed transcripts (BYTEA, zstd)
- New REST API: `POST/GET /api/cycle-runs` for CRUD, `GET /api/cycle-runs/{id}/transcript` for on-demand decompression
- New MCP tools: `progress_store` and `progress_load` for bot agent to persist/retrieve structured progress across cycles
- 18 new tests covering all endpoints and MCP tools

## Context

[RHCLOUD-48343](https://redhat.atlassian.net/browse/RHCLOUD-48343)

The bot currently has no persistent record of what happened in each cycle beyond a single task state snapshot. This adds:
1. **Progress history** — structured JSONB summaries per cycle, loadable by the bot next cycle for continuity
2. **Transcript storage** — full zstd-compressed JSONL transcripts for human debugging and optimization

Both REST API and MCP tools accept `task_id` directly (DB integer PK) — no jira_key coupling. Null `task_id` for idle/error cycles.

## Test plan

- [x] `pytest tests/test_cycle_runs.py` — 18 tests passing
- [x] `pytest tests/` — all 26 tests passing (no regressions)
- [x] Live validation against running memory-server: POST, GET with filters, transcript round-trip (compress → store → decompress → verify match)

[RHCLOUD-48343]: https://redhat.atlassian.net/browse/RHCLOUD-48343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ