### PR TITLE
feat(bot): add transcript capture and progress instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,13 @@ Active: `in_progress`, `pr_open`, `pr_changes`. Terminal: `done`, `archived`, `p
 
 **Multi-repo**: One task per Jira ticket. Primary repo in `repo`, all in `metadata.repos`. PRs in `metadata.prs` as `[{"repo", "number", "url", "host"}]`.
 
+### Cycle Progress Tools
+
+| Tool | Purpose |
+|------|---------|
+| `progress_store` | Store structured cycle progress. Params: `task_id, instance_id, cycle_type, progress?, started_at?, finished_at?, tool_calls?, tokens_used?` |
+| `progress_load` | Load last N progress entries for a task. Params: `task_id, instance_id?, limit?` (default 5) |
+
 ### Memory Tools
 
 | Tool | Purpose |
@@ -395,7 +402,23 @@ Keep task record updated throughout (not just end). `task_update` w/ `summary` +
 - `last_step`: `branch_created`/`implemented`/`tests_passing`/`push_failed`/`pr_opened`/`review_addressed`/`investigation_posted`/`archived`
 - `files_changed`, `commits`, `next_step`, `notes`, `repos`, `prs`
 
-**On startup — interrupted work**: Triage output shows all `in_progress` tasks w/ `last_step`. Any w/ `last_step` set? → `memory_search` repo + problem → resume from `next_step`. Task metadata = specific work state. RAG memory = cross-ticket learnings.
+### Cycle Progress (progress_load / progress_store)
+
+Persists structured progress across cycles. Separate from `task_update` — creates **history**, not just current state.
+
+**On resume** (existing task, not new):
+1. `task_get(jira_key)` → note `id` field = `task_id`
+2. `progress_load(task_id=<id>)` → last 5 cycle summaries
+3. Use returned progress → understand prior decisions, files, blockers, where left off
+
+**Before cycle ends** (after work on task):
+1. `progress_store(task_id=<id>, instance_id=<instance>, cycle_type="task_work", progress={...})`
+2. Progress keys: `last_step`, `next_step`, `files_changed`, `commits`, `key_decisions`, `blockers`, `notes`
+3. In addition to `task_update` — call both
+
+Idle/error cycles: `run.py` handles automatically. No agent action.
+
+**On startup — interrupted work**: `in_progress` w/ `last_step` set? → `progress_load(task_id)` for cycle history + `memory_search` repo + problem → resume from `next_step`. Cycle progress = per-cycle history. Task metadata = current state. RAG memory = cross-ticket learnings.
 
 ## Rules
 

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -1,5 +1,6 @@
 """Core agent cycle — invokes Claude Agent SDK."""
 
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -12,6 +13,7 @@ from claude_agent_sdk import (
     ResultMessage,
     SystemMessage,
     TextBlock,
+    ToolResultBlock,
     query,
 )
 
@@ -35,6 +37,7 @@ class CycleContext:
     repo: str | None = None
     work_type: str | None = None
     summary: str | None = None
+    task_id: int | None = None
 
 
 async def _push_status(
@@ -208,10 +211,11 @@ async def run_cycle(
                                 logger.info("[agent] %s", text[:300])
                                 # Push to dashboard
                                 await _push_status(http, "working", text[:500])
+                        elif isinstance(block, ToolResultBlock):
+                            _extract_task_id_from_result(block, ctx)
                         elif hasattr(block, "name"):
                             desc = _describe_tool_use(block)
                             logger.info("[tool] %s", desc)
-                            # Extract work context from MCP tool calls
                             _extract_context(block, ctx)
 
                 elif isinstance(message, ResultMessage):
@@ -304,3 +308,29 @@ def _extract_context(block, ctx: CycleContext) -> None:
     # Memory housekeeping
     elif name == "mcp__bot-memory__memory_delete":
         ctx.work_type = ctx.work_type or "memory_housekeeping"
+
+
+def _extract_task_id_from_result(block: ToolResultBlock, ctx: CycleContext) -> None:
+    """Extract task_id from MCP tool result content (task_add/task_get/task_update return task objects)."""
+    content = block.content
+    if not content:
+        return
+    try:
+        text = (
+            content
+            if isinstance(content, str)
+            else content[0].get("text", "")
+            if isinstance(content, list)
+            else ""
+        )
+        if not text:
+            return
+        data = json.loads(text)
+        if (
+            isinstance(data, dict)
+            and isinstance(data.get("id"), int)
+            and "jira_key" in data
+        ):
+            ctx.task_id = data["id"]
+    except (json.JSONDecodeError, TypeError, IndexError, AttributeError):
+        pass

--- a/bot/run.py
+++ b/bot/run.py
@@ -20,6 +20,7 @@ from .agent import run_cycle
 from .config import ALLOWED_TOOLS, Config, load_config, load_mcp_servers, sanitize_env
 from .costs import record_cost
 from .merge import apply_merged_config
+from .transcripts import record_transcript
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = SCRIPT_DIR / "data"
@@ -341,6 +342,13 @@ def main() -> None:
                     label=args.label,
                     result=result,
                     ctx=ctx,
+                )
+                record_transcript(
+                    label=args.label,
+                    result=result,
+                    ctx=ctx,
+                    cwd=str(SCRIPT_DIR),
+                    instance_id=instance_id,
                 )
             else:
                 logger.warning("Cycle produced no result")

--- a/bot/transcripts.py
+++ b/bot/transcripts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -74,12 +74,10 @@ def record_transcript(
     is_error = getattr(result, "subtype", "") != "success"
     cycle_type = _resolve_cycle_type(ctx.work_type if ctx else None, is_error)
 
-    duration_ms = getattr(result, "duration_ms", 0)
+    duration_ms = getattr(result, "duration_ms", None) or 0
     now = datetime.now(timezone.utc)
     started_at = now
     if duration_ms:
-        from datetime import timedelta
-
         started_at = now - timedelta(milliseconds=duration_ms)
 
     body: dict = {
@@ -125,4 +123,4 @@ def record_transcript(
     try:
         httpx.post(CYCLE_RUNS_API, json=body, timeout=10.0)
     except Exception:
-        logger.debug("Failed to push cycle run to API (dashboard may be down)")
+        logger.warning("Failed to push cycle run to API", exc_info=True)

--- a/bot/transcripts.py
+++ b/bot/transcripts.py
@@ -1,0 +1,128 @@
+"""Transcript capture — compresses and stores cycle transcripts via the dashboard API."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from .agent import CycleContext
+
+logger = logging.getLogger(__name__)
+
+CYCLE_RUNS_API = os.environ.get(
+    "CYCLE_RUNS_API_URL", "http://localhost:8080/api/cycle-runs"
+)
+
+_WORK_TYPE_TO_CYCLE_TYPE = {
+    "new_ticket": "task_work",
+    "pr_review": "task_work",
+    "ci_fix": "task_work",
+    "idle": "idle",
+    "memory_housekeeping": "idle",
+    "error": "error",
+}
+
+
+def _resolve_cycle_type(work_type: str | None, is_error: bool) -> str:
+    if is_error:
+        return "error"
+    if work_type:
+        return _WORK_TYPE_TO_CYCLE_TYPE.get(work_type, "task_work")
+    return "triage_only"
+
+
+def _find_transcript(session_id: str, cwd: str) -> Path | None:
+    """Locate the Claude session transcript JSONL file."""
+    slug = cwd.replace("/", "-")
+    if not slug.startswith("-"):
+        slug = "-" + slug
+    home = Path.home()
+    path = home / ".claude" / "projects" / slug / f"{session_id}.jsonl"
+    if path.exists():
+        return path
+    # Fallback: scan project dirs for the session file
+    projects_dir = home / ".claude" / "projects"
+    if projects_dir.is_dir():
+        for candidate in projects_dir.iterdir():
+            f = candidate / f"{session_id}.jsonl"
+            if f.exists():
+                return f
+    return None
+
+
+def record_transcript(
+    label: str,
+    result,
+    ctx: CycleContext | None = None,
+    cwd: str = "",
+    instance_id: str | None = None,
+) -> None:
+    """Compress and store the cycle transcript + metadata to the dashboard API."""
+    session_id = getattr(result, "session_id", "")
+    if not session_id:
+        logger.debug("No session_id in result — skipping transcript capture")
+        return
+
+    usage = getattr(result, "usage", None) or {}
+    is_error = getattr(result, "subtype", "") != "success"
+    cycle_type = _resolve_cycle_type(ctx.work_type if ctx else None, is_error)
+
+    duration_ms = getattr(result, "duration_ms", 0)
+    now = datetime.now(timezone.utc)
+    started_at = now
+    if duration_ms:
+        from datetime import timedelta
+
+        started_at = now - timedelta(milliseconds=duration_ms)
+
+    body: dict = {
+        "task_id": ctx.task_id if ctx else None,
+        "cycle_type": cycle_type,
+        "instance_id": instance_id or label,
+        "started_at": started_at.isoformat(),
+        "finished_at": now.isoformat(),
+        "tool_calls": getattr(result, "num_turns", 0),
+        "tokens_used": usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
+        "progress": {
+            "jira_key": ctx.jira_key if ctx else None,
+            "repo": ctx.repo if ctx else None,
+            "work_type": ctx.work_type if ctx else None,
+            "summary": ctx.summary if ctx else None,
+        },
+    }
+
+    transcript_path = _find_transcript(session_id, cwd)
+    if transcript_path:
+        try:
+            import zstandard as zstd
+
+            raw = transcript_path.read_bytes()
+            compressor = zstd.ZstdCompressor(level=19)
+            compressed = compressor.compress(raw)
+            body["transcript_b64"] = base64.b64encode(compressed).decode()
+            logger.info(
+                "Transcript: %d bytes → %d compressed (%.0f%% savings)",
+                len(raw),
+                len(compressed),
+                (1 - len(compressed) / len(raw)) * 100 if raw else 0,
+            )
+        except ImportError:
+            logger.warning(
+                "zstandard not installed — storing cycle run without transcript"
+            )
+        except Exception:
+            logger.warning("Failed to read/compress transcript", exc_info=True)
+    else:
+        logger.debug("Transcript file not found for session %s", session_id)
+
+    try:
+        httpx.post(CYCLE_RUNS_API, json=body, timeout=10.0)
+    except Exception:
+        logger.debug("Failed to push cycle run to API (dashboard may be down)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "filelock",
     "httpx",
     "python-dotenv",
+    "zstandard>=0.23",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -4,11 +4,9 @@ import base64
 import json
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 # Mock claude_agent_sdk before importing bot modules
 _mock_sdk = ModuleType("claude_agent_sdk")

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1,0 +1,304 @@
+"""Tests for bot.transcripts and bot.agent task_id extraction."""
+
+import base64
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock claude_agent_sdk before importing bot modules
+_mock_sdk = ModuleType("claude_agent_sdk")
+for name in [
+    "AssistantMessage",
+    "ClaudeAgentOptions",
+    "HookMatcher",
+    "ResultMessage",
+    "SystemMessage",
+    "TextBlock",
+    "ToolResultBlock",
+    "query",
+]:
+    setattr(_mock_sdk, name, MagicMock)
+sys.modules["claude_agent_sdk"] = _mock_sdk
+
+from bot.agent import CycleContext, _extract_task_id_from_result  # noqa: E402
+from bot.transcripts import _find_transcript, _resolve_cycle_type, record_transcript  # noqa: E402
+
+
+# --- _extract_task_id_from_result ---
+
+
+@dataclass
+class FakeToolResultBlock:
+    tool_use_id: str = "tool_1"
+    content: str | list | None = None
+    is_error: bool | None = None
+
+
+class TestExtractTaskId:
+    def test_extracts_from_string_content(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(
+            content=json.dumps(
+                {"id": 42, "jira_key": "RHCLOUD-123", "status": "in_progress"}
+            )
+        )
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id == 42
+
+    def test_extracts_from_list_content(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(
+            content=[{"text": json.dumps({"id": 99, "jira_key": "OME-50"})}]
+        )
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id == 99
+
+    def test_ignores_non_task_result(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(
+            content=json.dumps({"active": 3, "max": 10, "has_capacity": True})
+        )
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id is None
+
+    def test_ignores_result_without_jira_key(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(
+            content=json.dumps({"id": 42, "name": "not a task"})
+        )
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id is None
+
+    def test_ignores_none_content(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(content=None)
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id is None
+
+    def test_ignores_empty_string(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(content="")
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id is None
+
+    def test_ignores_invalid_json(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(content="not json at all")
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id is None
+
+    def test_overwrites_with_latest_task(self):
+        ctx = CycleContext(task_id=10)
+        block = FakeToolResultBlock(
+            content=json.dumps({"id": 42, "jira_key": "RHCLOUD-999"})
+        )
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id == 42
+
+    def test_ignores_string_id(self):
+        ctx = CycleContext()
+        block = FakeToolResultBlock(
+            content=json.dumps({"id": "not-int", "jira_key": "RHCLOUD-1"})
+        )
+        _extract_task_id_from_result(block, ctx)
+        assert ctx.task_id is None
+
+
+# --- _resolve_cycle_type ---
+
+
+class TestResolveCycleType:
+    def test_error_takes_precedence(self):
+        assert _resolve_cycle_type("new_ticket", is_error=True) == "error"
+
+    def test_new_ticket(self):
+        assert _resolve_cycle_type("new_ticket", is_error=False) == "task_work"
+
+    def test_pr_review(self):
+        assert _resolve_cycle_type("pr_review", is_error=False) == "task_work"
+
+    def test_ci_fix(self):
+        assert _resolve_cycle_type("ci_fix", is_error=False) == "task_work"
+
+    def test_idle(self):
+        assert _resolve_cycle_type("idle", is_error=False) == "idle"
+
+    def test_memory_housekeeping(self):
+        assert _resolve_cycle_type("memory_housekeeping", is_error=False) == "idle"
+
+    def test_none_work_type(self):
+        assert _resolve_cycle_type(None, is_error=False) == "triage_only"
+
+    def test_unknown_maps_to_task_work(self):
+        assert _resolve_cycle_type("something_new", is_error=False) == "task_work"
+
+
+# --- _find_transcript ---
+
+
+class TestFindTranscript:
+    def test_finds_transcript_at_expected_path(self, tmp_path):
+        project_dir = tmp_path / ".claude" / "projects" / "-home-botuser-app"
+        project_dir.mkdir(parents=True)
+        transcript = project_dir / "abc-123.jsonl"
+        transcript.write_text('{"role": "assistant"}\n')
+
+        with patch("bot.transcripts.Path.home", return_value=tmp_path):
+            result = _find_transcript("abc-123", "/home/botuser/app")
+
+        assert result == transcript
+
+    def test_returns_none_when_missing(self, tmp_path):
+        with patch("bot.transcripts.Path.home", return_value=tmp_path):
+            result = _find_transcript("nonexistent", "/home/botuser/app")
+
+        assert result is None
+
+    def test_fallback_scan_finds_transcript(self, tmp_path):
+        other_dir = tmp_path / ".claude" / "projects" / "-some-other-path"
+        other_dir.mkdir(parents=True)
+        transcript = other_dir / "xyz-789.jsonl"
+        transcript.write_text('{"role": "user"}\n')
+
+        with patch("bot.transcripts.Path.home", return_value=tmp_path):
+            result = _find_transcript("xyz-789", "/wrong/path")
+
+        assert result == transcript
+
+
+# --- record_transcript ---
+
+
+@dataclass
+class FakeResult:
+    session_id: str = "test-session-id"
+    subtype: str = "success"
+    duration_ms: int = 5000
+    num_turns: int = 10
+    usage: dict | None = None
+
+    def __post_init__(self):
+        if self.usage is None:
+            self.usage = {"input_tokens": 50000, "output_tokens": 10000}
+
+
+class TestRecordTranscript:
+    def test_posts_cycle_run(self, tmp_path):
+        project_dir = tmp_path / ".claude" / "projects" / "-test-cwd"
+        project_dir.mkdir(parents=True)
+        transcript = project_dir / "test-session-id.jsonl"
+        transcript.write_text('{"role": "assistant", "content": "hello"}\n')
+
+        result = FakeResult()
+        ctx = CycleContext(jira_key="RHCLOUD-123", task_id=42, work_type="new_ticket")
+
+        with (
+            patch("bot.transcripts.Path.home", return_value=tmp_path),
+            patch("bot.transcripts.httpx.post") as mock_post,
+        ):
+            record_transcript(
+                label="test-label",
+                result=result,
+                ctx=ctx,
+                cwd="/test/cwd",
+                instance_id="test-instance",
+            )
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+
+        assert body["task_id"] == 42
+        assert body["cycle_type"] == "task_work"
+        assert body["instance_id"] == "test-instance"
+        assert body["tool_calls"] == 10
+        assert body["tokens_used"] == 60000
+        assert body["progress"]["jira_key"] == "RHCLOUD-123"
+        assert "transcript_b64" in body
+
+        # Verify transcript round-trips
+        import zstandard as zstd
+
+        compressed = base64.b64decode(body["transcript_b64"])
+        decompressor = zstd.ZstdDecompressor()
+        decompressed = decompressor.decompress(compressed)
+        assert b"hello" in decompressed
+
+    def test_posts_without_transcript_when_missing(self):
+        result = FakeResult()
+        ctx = CycleContext(work_type="idle")
+
+        with (
+            patch("bot.transcripts._find_transcript", return_value=None),
+            patch("bot.transcripts.httpx.post") as mock_post,
+        ):
+            record_transcript(
+                label="test-label",
+                result=result,
+                ctx=ctx,
+                cwd="/test/cwd",
+            )
+
+        mock_post.assert_called_once()
+        body = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get(
+            "json"
+        )
+        assert "transcript_b64" not in body
+        assert body["cycle_type"] == "idle"
+
+    def test_skips_when_no_session_id(self):
+        result = FakeResult(session_id="")
+
+        with patch("bot.transcripts.httpx.post") as mock_post:
+            record_transcript(label="test", result=result)
+
+        mock_post.assert_not_called()
+
+    def test_handles_api_failure_gracefully(self, tmp_path):
+        result = FakeResult()
+        ctx = CycleContext()
+
+        with (
+            patch("bot.transcripts._find_transcript", return_value=None),
+            patch(
+                "bot.transcripts.httpx.post",
+                side_effect=Exception("connection refused"),
+            ),
+        ):
+            record_transcript(label="test", result=result, ctx=ctx, cwd="/test")
+
+    def test_null_task_id_for_idle(self):
+        result = FakeResult()
+        ctx = CycleContext(work_type="idle", task_id=None)
+
+        with (
+            patch("bot.transcripts._find_transcript", return_value=None),
+            patch("bot.transcripts.httpx.post") as mock_post,
+        ):
+            record_transcript(label="test", result=result, ctx=ctx, cwd="/test")
+
+        body = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get(
+            "json"
+        )
+        assert body["task_id"] is None
+        assert body["cycle_type"] == "idle"
+
+    def test_error_cycle_type_on_failure(self):
+        result = FakeResult(subtype="error")
+        ctx = CycleContext(work_type="new_ticket")
+
+        with (
+            patch("bot.transcripts._find_transcript", return_value=None),
+            patch("bot.transcripts.httpx.post") as mock_post,
+        ):
+            record_transcript(label="test", result=result, ctx=ctx, cwd="/test")
+
+        body = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get(
+            "json"
+        )
+        assert body["cycle_type"] == "error"


### PR DESCRIPTION
## Summary

- Extends `CycleContext` with `task_id` field, extracted from `ToolResultBlock` content (task_add/task_get/task_update results)
- New `bot/transcripts.py`: after each cycle, reads the Claude session JSONL transcript, compresses with zstd, POSTs to `/api/cycle-runs`
- Wires `record_transcript()` into `run.py` main loop (after `record_cost()`)
- Adds `progress_load`/`progress_store` MCP tool documentation to CLAUDE.md
- Adds `zstandard>=0.23` to bot dependencies

## Context

[RHCLOUD-48344](https://redhat.atlassian.net/browse/RHCLOUD-48344) — depends on [RHCLOUD-48343](https://redhat.atlassian.net/browse/RHCLOUD-48343) (merged in #234)

## Test plan

- [x] Run a cycle — verify POST /api/cycle-runs is called with transcript
- [x] Verify transcript appears in GET /api/cycle-runs and is decompressible
- [x] Check task_id is extracted from tool results correctly
- [x] Verify record_cost flow unaffected

[RHCLOUD-48344]: https://redhat.atlassian.net/browse/RHCLOUD-48344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-48343]: https://redhat.atlassian.net/browse/RHCLOUD-48343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ