### PR TITLE
fix(ci): fix proxy Tekton pathChanged glob pattern

### DIFF
--- a/.tekton/platform-frontend-ai-dev-proxy-pull-request.yaml
+++ b/.tekton/platform-frontend-ai-dev-proxy-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master" && ( "./proxy/***".pathChanged() || ".tekton/platform-frontend-ai-dev-proxy-pull-request.yaml".pathChanged()
-      || "proxy/Dockerfile".pathChanged() )
+      == "master" && ( "proxy/**".pathChanged() || ".tekton/platform-frontend-ai-dev-proxy-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: platform-frontend-ai-dev

--- a/.tekton/platform-frontend-ai-dev-proxy-push.yaml
+++ b/.tekton/platform-frontend-ai-dev-proxy-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "master" && ( "./proxy/***".pathChanged() || ".tekton/platform-frontend-ai-dev-proxy-push.yaml".pathChanged()
-      || "proxy/Dockerfile".pathChanged() )
+      == "master" && ( "proxy/**".pathChanged() || ".tekton/platform-frontend-ai-dev-proxy-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: platform-frontend-ai-dev


### PR DESCRIPTION
## Summary

- Fix invalid `./proxy/***` glob in proxy Tekton pipeline CEL expressions — `***` is not a valid glob pattern, only `**` provides recursive matching
- Changed to `proxy/**` in both push and pull-request pipelines
- Removed redundant `proxy/Dockerfile` check (already covered by `proxy/**`)

## Problem

The proxy build pipeline was not triggering on pushes that changed files in `proxy/`. The bot and memory-server components build on every push (no path filter), but the proxy component uses `pathChanged()` with an invalid triple-star glob that silently fails to match.

Last successful proxy build was Jun 5 (PR #226, Konflux dep updates — triggered via the `.tekton/*.yaml` self-change rule). Subsequent proxy source changes (`proxy/squid.conf`, `proxy/start.sh`) did not trigger builds.

## Test plan

- [ ] Merge this PR — the `.tekton` file change itself will trigger a proxy build (self-referencing rule still works)
- [ ] Next push that changes `proxy/` files should also trigger the proxy build