### PR TITLE
fix(skills): include closed-sprint tickets in backlog query

### DIFF
--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -125,7 +125,7 @@ def get_candidates():
             assignee_filter = "AND assignee is EMPTY "
         collect(
             f"labels = {BOT_LABEL} {assignee_filter}"
-            f"AND status IN ({status_list}) AND sprint is EMPTY "
+            f"AND status IN ({status_list}) AND (sprint is EMPTY OR sprint not in openSprints()) "
             f"ORDER BY priority DESC, created ASC",
             "backlog",
         )


### PR DESCRIPTION
## Summary

Fix new-work skill backlog query to include tickets with only closed sprints.

`sprint is EMPTY` only matches tickets **never** in any sprint. Tickets that bounced through closed sprints (e.g. RHCLOUD-41796 with 20 closed sprints) were silently excluded from the backlog tier.

Changed to `(sprint is EMPTY OR sprint not in openSprints())`.

## Context

[RHCLOUD-48370](https://redhat.atlassian.net/browse/RHCLOUD-48370)

## Test plan

- [x] Patched live on `devbot-fabric-access` pod — RHCLOUD-41796 now appears as candidate
- [x] `sprint/unassigned` and `sprint/bot-assigned` tiers unaffected (still use `openSprints()`)

[RHCLOUD-48370]: https://redhat.atlassian.net/browse/RHCLOUD-48370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ