### PR TITLE
feat(ci): add Postgres sidecar for migration tests

### DIFF
--- a/.tekton/platform-frontend-ai-dev-memory-server-pull-request.yaml
+++ b/.tekton/platform-frontend-ai-dev-memory-server-pull-request.yaml
@@ -31,6 +31,16 @@ spec:
     value: memory-server/Dockerfile
   - name: path-context
     value: .
+  - name: PGSQL_USER
+    value: devbot_test
+  - name: PGSQL_PASSWORD
+    value: devbot_test
+  - name: PGSQL_HOSTNAME
+    value: localhost
+  - name: PGSQL_PORT
+    value: '5432'
+  - name: PGSQL_DATABASE
+    value: devbot_migration_test
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -112,6 +122,16 @@ spec:
       type: string
       default: .
       description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+    - name: PGSQL_USER
+      type: string
+    - name: PGSQL_PASSWORD
+      type: string
+    - name: PGSQL_HOSTNAME
+      type: string
+    - name: PGSQL_PORT
+      type: string
+    - name: PGSQL_DATABASE
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -161,6 +181,109 @@ spec:
         workspace: workspace
       - name: basic-auth
         workspace: git-auth
+    - name: clone-repository-oci-ta
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: run-migration-tests
+      params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository-oci-ta.results.SOURCE_ARTIFACT)
+      - name: PGSQL_USER
+        value: $(params.PGSQL_USER)
+      - name: PGSQL_PASSWORD
+        value: $(params.PGSQL_PASSWORD)
+      - name: PGSQL_HOSTNAME
+        value: $(params.PGSQL_HOSTNAME)
+      - name: PGSQL_PORT
+        value: $(params.PGSQL_PORT)
+      - name: PGSQL_DATABASE
+        value: $(params.PGSQL_DATABASE)
+      runAfter:
+      - clone-repository-oci-ta
+      taskSpec:
+        sidecars:
+        - name: postgresql
+          image: docker.io/pgvector/pgvector:pg15
+          env:
+          - name: POSTGRES_DB
+            value: $(params.PGSQL_DATABASE)
+          - name: POSTGRES_USER
+            value: $(params.PGSQL_USER)
+          - name: POSTGRES_PASSWORD
+            value: $(params.PGSQL_PASSWORD)
+          computeResources: {}
+        params:
+        - name: SOURCE_ARTIFACT
+          type: string
+        - name: PGSQL_USER
+          type: string
+        - name: PGSQL_PASSWORD
+          type: string
+        - name: PGSQL_HOSTNAME
+          type: string
+        - name: PGSQL_PORT
+          type: string
+        - name: PGSQL_DATABASE
+          type: string
+        volumes:
+        - name: workdir
+          emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+          - mountPath: /var/workdir
+            name: workdir
+            readOnly: false
+        steps:
+        - name: use-trusted-artifact
+          image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+          args:
+          - use
+          - $(params.SOURCE_ARTIFACT)=/var/workdir
+        - name: run-tests
+          image: registry.access.redhat.com/ubi9/python-312:latest
+          workingDir: /var/workdir/memory-server
+          securityContext:
+            runAsUser: 0
+          script: |
+            #!/bin/bash
+            set -ex
+
+            echo "Waiting for PostgreSQL..."
+            for i in $(seq 1 30); do
+              if bash -c "echo > /dev/tcp/$(params.PGSQL_HOSTNAME)/$(params.PGSQL_PORT)" 2>/dev/null; then
+                echo "PostgreSQL is ready"
+                break
+              fi
+              echo "Attempt $i/30 — waiting..."
+              sleep 2
+            done
+
+            pip install --quiet asyncpg pytest pytest-asyncio
+            PGSQL_HOSTNAME=$(params.PGSQL_HOSTNAME) \
+            PGSQL_PORT=$(params.PGSQL_PORT) \
+            PGSQL_USER=$(params.PGSQL_USER) \
+            PGSQL_PASSWORD=$(params.PGSQL_PASSWORD) \
+            PGSQL_DATABASE=$(params.PGSQL_DATABASE) \
+            python -m pytest tests/test_db_migration.py -v -p no:cacheprovider
     - name: prefetch-dependencies
       params:
       - name: input

--- a/memory-server/tests/conftest.py
+++ b/memory-server/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+import asyncpg
+import pytest_asyncio
+
+DB_CONFIG = {
+    "host": os.getenv("PGSQL_HOSTNAME", "localhost"),
+    "port": int(os.getenv("PGSQL_PORT", "5432")),
+    "user": os.getenv("PGSQL_USER", "devbot_test"),
+    "password": os.getenv("PGSQL_PASSWORD", "devbot_test"),
+    "database": os.getenv("PGSQL_DATABASE", "devbot_migration_test"),
+}
+
+SCHEMA_PATH = Path(__file__).parent.parent / "src" / "schema.sql"
+
+
+@pytest_asyncio.fixture
+async def db():
+    conn = await asyncpg.connect(**DB_CONFIG)
+    tables = await conn.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+    )
+    for t in tables:
+        await conn.execute(f"DROP TABLE IF EXISTS {t['tablename']} CASCADE")
+    await conn.execute("DROP EXTENSION IF EXISTS vector CASCADE")
+    yield conn
+    await conn.close()

--- a/memory-server/tests/test_db_migration.py
+++ b/memory-server/tests/test_db_migration.py
@@ -1,0 +1,135 @@
+"""Schema validation tests against real PostgreSQL with pgvector.
+
+These run in CI via the Tekton pipeline's Postgres sidecar.
+Future migration stages add tests here for ALTER TABLE + backfill scripts.
+"""
+
+import asyncpg
+import pytest
+
+from conftest import SCHEMA_PATH
+
+
+@pytest.mark.asyncio
+async def test_db_connection(db):
+    result = await db.fetchval("SELECT 1")
+    assert result == 1
+
+
+@pytest.mark.asyncio
+async def test_schema_applies(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+
+    tables = await db.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+    )
+    table_names = {t["tablename"] for t in tables}
+
+    expected = {
+        "tasks",
+        "memories",
+        "bot_status",
+        "cycles",
+        "cycle_runs",
+        "slack_notifications",
+        "bot_instances",
+    }
+    missing = expected - table_names
+    assert not missing, f"Missing tables: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_schema_idempotent(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+    await db.execute(schema)
+    count = await db.fetchval("SELECT COUNT(*) FROM tasks")
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_task_insert_read(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+
+    await db.execute(
+        """
+        INSERT INTO tasks (jira_key, status, repo, branch)
+        VALUES ($1, $2, $3, $4)
+        """,
+        "TEST-1",
+        "in_progress",
+        "test-repo",
+        "bot/TEST-1",
+    )
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "TEST-1")
+    assert task is not None
+    assert task["status"] == "in_progress"
+    assert task["repo"] == "test-repo"
+    assert task["branch"] == "bot/TEST-1"
+    assert task["pr_number"] is None
+    assert task["pr_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_task_unique_constraint(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch) VALUES ($1, $2, $3, $4)",
+        "DUP-1",
+        "in_progress",
+        "repo",
+        "bot/DUP-1",
+    )
+
+    with pytest.raises(asyncpg.UniqueViolationError):
+        await db.execute(
+            "INSERT INTO tasks (jira_key, status, repo, branch) VALUES ($1, $2, $3, $4)",
+            "DUP-1",
+            "pr_open",
+            "repo2",
+            "bot/DUP-1-2",
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_keys(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch) VALUES ($1, $2, $3, $4)",
+        "FK-1",
+        "in_progress",
+        "repo",
+        "bot/FK-1",
+    )
+    task_id = await db.fetchval("SELECT id FROM tasks WHERE jira_key = $1", "FK-1")
+
+    await db.execute(
+        """
+        INSERT INTO cycle_runs (task_id, cycle_type, instance_id)
+        VALUES ($1, $2, $3)
+        """,
+        task_id,
+        "task_work",
+        "test-instance",
+    )
+    cycle = await db.fetchrow("SELECT * FROM cycle_runs WHERE task_id = $1", task_id)
+    assert cycle is not None
+    assert cycle["cycle_type"] == "task_work"
+
+    with pytest.raises(asyncpg.ForeignKeyViolationError):
+        await db.execute(
+            """
+            INSERT INTO cycle_runs (task_id, cycle_type, instance_id)
+            VALUES ($1, $2, $3)
+            """,
+            99999,
+            "task_work",
+            "test-instance",
+        )


### PR DESCRIPTION
## Summary

- Add pgvector/pgvector:pg15 sidecar + OCI-TA clone to memory-server PR pipeline
- Create pytest fixtures (conftest.py) and 6 schema validation tests
- Tests run parallel with build — no extra wall-clock time

**RHCLOUD-48384** — Stage 0 prerequisite for the generic task system migration (RHCLOUD-48375).

## What this does

Adds a `run-migration-tests` inline task to the memory-server PR pipeline that:
1. Clones source via OCI trusted artifacts (`git-clone-oci-ta`)
2. Starts a PostgreSQL 15 sidecar with pgvector extension
3. Waits for DB readiness (health check loop)
4. Runs pytest against the sidecar — validates schema applies, is idempotent, FK constraints work

Future migration stages (Stages 1-5) will add their migration scripts and tests to this same infrastructure.

## Test plan

- [x] Tekton pipeline triggers on this PR
- [x] `clone-repository-oci-ta` task completes successfully
- [x] `run-migration-tests` task: sidecar starts, health check passes, all 6 tests pass
- [ ] Build pipeline completes normally (unchanged)