### PR TITLE
feat(memory-server): add generic task system columns and migration

### DIFF
--- a/.tekton/platform-frontend-ai-dev-memory-server-pull-request.yaml
+++ b/.tekton/platform-frontend-ai-dev-memory-server-pull-request.yaml
@@ -278,12 +278,13 @@ spec:
             done
 
             pip install --quiet asyncpg pytest pytest-asyncio
+            JIRA_URL=https://redhat.atlassian.net \
             PGSQL_HOSTNAME=$(params.PGSQL_HOSTNAME) \
             PGSQL_PORT=$(params.PGSQL_PORT) \
             PGSQL_USER=$(params.PGSQL_USER) \
             PGSQL_PASSWORD=$(params.PGSQL_PASSWORD) \
             PGSQL_DATABASE=$(params.PGSQL_DATABASE) \
-            python -m pytest tests/test_db_migration.py -v -p no:cacheprovider
+            python -m pytest tests/ -v -p no:cacheprovider --ignore=tests/test_cycle_runs.py --ignore=tests/test_memory_upload.py
     - name: prefetch-dependencies
       params:
       - name: input

--- a/memory-server/src/migrations/m001_generic_tasks.py
+++ b/memory-server/src/migrations/m001_generic_tasks.py
@@ -1,0 +1,131 @@
+"""Migration 001: Add generic task system columns and backfill from jira_key.
+
+Additive only — no columns removed, no constraints changed.
+Idempotent — safe to run multiple times (skips rows where external_key is already set).
+
+Usage:
+    python -m memory_server.migrations.m001_generic_tasks
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+
+SCHEMA_PATH = Path(__file__).parent.parent / "schema.sql"
+
+JIRA_BASE_URL = os.environ["JIRA_URL"].rstrip("/") + "/browse"
+
+SIMPLE_TABLES = [
+    "bot_status",
+    "bot_instances",
+    "cycles",
+    "slack_notifications",
+    "memories",
+]
+
+
+def _build_dsn() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if url:
+        return url
+    host = os.environ.get("PGSQL_HOSTNAME", "localhost")
+    port = os.environ.get("PGSQL_PORT", "5432")
+    user = os.environ.get("PGSQL_USER", "devbot_test")
+    password = os.environ.get("PGSQL_PASSWORD", "devbot_test")
+    database = os.environ.get("PGSQL_DATABASE", "devbot_migration_test")
+    return f"postgresql://{user}:{password}@{host}:{port}/{database}"
+
+
+def _build_artifacts(pr_number, pr_url, metadata) -> list[dict]:
+    artifacts = []
+    seen_urls: set[str] = set()
+
+    if pr_number and pr_url:
+        artifacts.append(
+            {"name": f"PR #{pr_number}", "url": pr_url, "type": "pull_request"}
+        )
+        seen_urls.add(pr_url)
+
+    meta = metadata if isinstance(metadata, dict) else {}
+    for pr in meta.get("prs", []):
+        url = pr.get("url", "")
+        if not url or url in seen_urls:
+            continue
+        seen_urls.add(url)
+        number = pr.get("number", "?")
+        pr_type = "merge_request" if pr.get("host") == "gitlab" else "pull_request"
+        prefix = "MR" if pr_type == "merge_request" else "PR"
+        artifacts.append({"name": f"{prefix} #{number}", "url": url, "type": pr_type})
+
+    return artifacts
+
+
+async def run_migration(conn: asyncpg.Connection) -> dict:
+    schema = SCHEMA_PATH.read_text()
+    await conn.execute(schema)
+
+    stats = {"tasks": 0}
+
+    rows = await conn.fetch(
+        "SELECT id, jira_key, pr_number, pr_url, metadata "
+        "FROM tasks WHERE external_key IS NULL AND jira_key IS NOT NULL"
+    )
+    for row in rows:
+        meta = row["metadata"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+        artifacts = _build_artifacts(row["pr_number"], row["pr_url"], meta)
+        source_url = f"{JIRA_BASE_URL}/{row['jira_key']}" if row["jira_key"] else None
+
+        await conn.execute(
+            "UPDATE tasks SET external_key = $1, source_type = $2, "
+            "source_url = $3, artifacts = $4 WHERE id = $5",
+            row["jira_key"],
+            "jira",
+            source_url,
+            json.dumps(artifacts),
+            row["id"],
+        )
+        stats["tasks"] += 1
+
+    for table in SIMPLE_TABLES:
+        has_jira_key = await conn.fetchval(
+            "SELECT EXISTS ("
+            "  SELECT 1 FROM information_schema.columns "
+            "  WHERE table_name = $1 AND column_name = 'jira_key'"
+            ")",
+            table,
+        )
+        if not has_jira_key:
+            stats[table] = 0
+            continue
+
+        result = await conn.execute(
+            f"UPDATE {table} SET external_key = jira_key, source_type = 'jira' "  # noqa: S608
+            f"WHERE external_key IS NULL AND jira_key IS NOT NULL"
+        )
+        count = int(result.split()[-1]) if result else 0
+        stats[table] = count
+
+    return stats
+
+
+async def main():
+    dsn = _build_dsn()
+    conn = await asyncpg.connect(dsn)
+    try:
+        stats = await run_migration(conn)
+        print("Migration 001 complete:")
+        for table, count in stats.items():
+            print(f"  {table}: {count} rows backfilled")
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/memory-server/src/schema.sql
+++ b/memory-server/src/schema.sql
@@ -166,6 +166,38 @@ CREATE TABLE IF NOT EXISTS cycle_runs (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Stage 1: Generic task system columns (RHCLOUD-48376)
+-- Additive only — all nullable, no constraints yet. Backfilled by migration 001.
+DO $$ BEGIN
+    -- tasks: core generic columns + artifacts
+    ALTER TABLE tasks ADD COLUMN IF NOT EXISTS external_key TEXT;
+    ALTER TABLE tasks ADD COLUMN IF NOT EXISTS source_type TEXT;
+    ALTER TABLE tasks ADD COLUMN IF NOT EXISTS source_url TEXT;
+    ALTER TABLE tasks ADD COLUMN IF NOT EXISTS artifacts JSONB DEFAULT '[]';
+
+    -- bot_status
+    ALTER TABLE bot_status ADD COLUMN IF NOT EXISTS external_key TEXT;
+    ALTER TABLE bot_status ADD COLUMN IF NOT EXISTS source_type TEXT;
+
+    -- bot_instances
+    ALTER TABLE bot_instances ADD COLUMN IF NOT EXISTS external_key TEXT;
+    ALTER TABLE bot_instances ADD COLUMN IF NOT EXISTS source_type TEXT;
+
+    -- cycles
+    ALTER TABLE cycles ADD COLUMN IF NOT EXISTS external_key TEXT;
+    ALTER TABLE cycles ADD COLUMN IF NOT EXISTS source_type TEXT;
+
+    -- slack_notifications
+    ALTER TABLE slack_notifications ADD COLUMN IF NOT EXISTS external_key TEXT;
+    ALTER TABLE slack_notifications ADD COLUMN IF NOT EXISTS source_type TEXT;
+
+    -- memories
+    ALTER TABLE memories ADD COLUMN IF NOT EXISTS external_key TEXT;
+    ALTER TABLE memories ADD COLUMN IF NOT EXISTS source_type TEXT;
+EXCEPTION
+    WHEN duplicate_column THEN NULL;
+END $$;
+
 -- Only create index if table has enough rows (ivfflat needs data)
 -- On first startup with empty table, queries fall back to sequential scan
 -- Re-run this after seeding data:

--- a/memory-server/tests/test_migration_001.py
+++ b/memory-server/tests/test_migration_001.py
@@ -1,0 +1,334 @@
+"""Migration 001 integrity tests — generic task system columns + backfill.
+
+Tests run against real Postgres via the CI sidecar (or local instance).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from conftest import SCHEMA_PATH
+
+os.environ.setdefault("JIRA_URL", "https://redhat.atlassian.net")
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from migrations.m001_generic_tasks import _build_artifacts, run_migration  # noqa: E402
+
+
+TABLES_WITH_GENERIC_COLS = [
+    "tasks",
+    "bot_status",
+    "bot_instances",
+    "cycles",
+    "slack_notifications",
+    "memories",
+]
+
+
+async def _apply_schema(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+
+
+@pytest.mark.asyncio
+async def test_migration_adds_columns(db):
+    await _apply_schema(db)
+
+    for table in TABLES_WITH_GENERIC_COLS:
+        cols = await db.fetch(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = $1 AND column_name IN ('external_key', 'source_type')",
+            table,
+        )
+        col_names = {c["column_name"] for c in cols}
+        assert "external_key" in col_names, f"{table} missing external_key"
+        assert "source_type" in col_names, f"{table} missing source_type"
+
+    task_cols = await db.fetch(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = 'tasks' AND column_name IN ('source_url', 'artifacts')",
+    )
+    task_col_names = {c["column_name"] for c in task_cols}
+    assert "source_url" in task_col_names
+    assert "artifacts" in task_col_names
+
+
+@pytest.mark.asyncio
+async def test_backfill_simple_task(db):
+    await _apply_schema(db)
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch) VALUES ($1, $2, $3, $4)",
+        "RHCLOUD-100",
+        "in_progress",
+        "test-repo",
+        "bot/RHCLOUD-100",
+    )
+
+    stats = await run_migration(db)
+    assert stats["tasks"] == 1
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "RHCLOUD-100")
+    assert task["external_key"] == "RHCLOUD-100"
+    assert task["source_type"] == "jira"
+    assert task["source_url"] == "https://redhat.atlassian.net/browse/RHCLOUD-100"
+    assert json.loads(task["artifacts"]) == []
+
+
+@pytest.mark.asyncio
+async def test_backfill_single_pr(db):
+    await _apply_schema(db)
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch, pr_number, pr_url) "
+        "VALUES ($1, $2, $3, $4, $5, $6)",
+        "RHCLOUD-200",
+        "pr_open",
+        "insights-chrome",
+        "bot/RHCLOUD-200",
+        42,
+        "https://github.com/RedHatInsights/insights-chrome/pull/42",
+    )
+
+    await run_migration(db)
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "RHCLOUD-200")
+    artifacts = json.loads(task["artifacts"])
+    assert len(artifacts) == 1
+    assert artifacts[0]["name"] == "PR #42"
+    assert (
+        artifacts[0]["url"]
+        == "https://github.com/RedHatInsights/insights-chrome/pull/42"
+    )
+    assert artifacts[0]["type"] == "pull_request"
+
+
+@pytest.mark.asyncio
+async def test_backfill_multi_repo_prs(db):
+    await _apply_schema(db)
+
+    metadata = {
+        "prs": [
+            {
+                "repo": "insights-chrome",
+                "number": 10,
+                "url": "https://github.com/RedHatInsights/insights-chrome/pull/10",
+                "host": "github",
+            },
+            {
+                "repo": "insights-rbac",
+                "number": 20,
+                "url": "https://github.com/RedHatInsights/insights-rbac/pull/20",
+                "host": "github",
+            },
+        ]
+    }
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch, metadata) "
+        "VALUES ($1, $2, $3, $4, $5)",
+        "RHCLOUD-300",
+        "pr_open",
+        "insights-chrome",
+        "bot/RHCLOUD-300",
+        json.dumps(metadata),
+    )
+
+    await run_migration(db)
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "RHCLOUD-300")
+    artifacts = json.loads(task["artifacts"])
+    assert len(artifacts) == 2
+    urls = {a["url"] for a in artifacts}
+    assert "https://github.com/RedHatInsights/insights-chrome/pull/10" in urls
+    assert "https://github.com/RedHatInsights/insights-rbac/pull/20" in urls
+
+
+@pytest.mark.asyncio
+async def test_backfill_overlap_dedup(db):
+    await _apply_schema(db)
+
+    pr_url = "https://github.com/RedHatInsights/insights-chrome/pull/42"
+    metadata = {
+        "prs": [
+            {"repo": "insights-chrome", "number": 42, "url": pr_url, "host": "github"},
+        ]
+    }
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch, pr_number, pr_url, metadata) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        "RHCLOUD-400",
+        "pr_open",
+        "insights-chrome",
+        "bot/RHCLOUD-400",
+        42,
+        pr_url,
+        json.dumps(metadata),
+    )
+
+    await run_migration(db)
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "RHCLOUD-400")
+    artifacts = json.loads(task["artifacts"])
+    assert len(artifacts) == 1, f"Expected 1 artifact (deduped), got {len(artifacts)}"
+
+
+@pytest.mark.asyncio
+async def test_backfill_gitlab_type(db):
+    await _apply_schema(db)
+
+    metadata = {
+        "prs": [
+            {
+                "repo": "some-gl-repo",
+                "number": 5,
+                "url": "https://gitlab.cee.redhat.com/some/repo/-/merge_requests/5",
+                "host": "gitlab",
+            },
+        ]
+    }
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch, metadata) "
+        "VALUES ($1, $2, $3, $4, $5)",
+        "RHCLOUD-500",
+        "pr_open",
+        "some-gl-repo",
+        "bot/RHCLOUD-500",
+        json.dumps(metadata),
+    )
+
+    await run_migration(db)
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "RHCLOUD-500")
+    artifacts = json.loads(task["artifacts"])
+    assert len(artifacts) == 1
+    assert artifacts[0]["type"] == "merge_request"
+    assert artifacts[0]["name"] == "MR #5"
+
+
+@pytest.mark.asyncio
+async def test_backfill_other_tables(db):
+    await _apply_schema(db)
+
+    await db.execute(
+        "UPDATE bot_status SET jira_key = $1 WHERE id = 1",
+        "RHCLOUD-600",
+    )
+
+    await db.execute(
+        "INSERT INTO cycles (label, jira_key) VALUES ($1, $2)",
+        "test-label",
+        "RHCLOUD-601",
+    )
+
+    await db.execute(
+        "INSERT INTO slack_notifications (jira_key, event_type, message) "
+        "VALUES ($1, $2, $3)",
+        "RHCLOUD-602",
+        "pr_created",
+        "test message",
+    )
+
+    await db.execute(
+        "INSERT INTO memories (category, jira_key, title, content, embedding) "
+        "VALUES ($1, $2, $3, $4, $5)",
+        "learning",
+        "RHCLOUD-603",
+        "test memory",
+        "test content",
+        "[" + ",".join(["0"] * 384) + "]",
+    )
+
+    stats = await run_migration(db)
+
+    bs = await db.fetchrow("SELECT * FROM bot_status WHERE id = 1")
+    assert bs["external_key"] == "RHCLOUD-600"
+    assert bs["source_type"] == "jira"
+
+    cycle = await db.fetchrow("SELECT * FROM cycles WHERE jira_key = $1", "RHCLOUD-601")
+    assert cycle["external_key"] == "RHCLOUD-601"
+    assert cycle["source_type"] == "jira"
+
+    slack = await db.fetchrow(
+        "SELECT * FROM slack_notifications WHERE jira_key = $1", "RHCLOUD-602"
+    )
+    assert slack["external_key"] == "RHCLOUD-602"
+    assert slack["source_type"] == "jira"
+
+    mem = await db.fetchrow("SELECT * FROM memories WHERE jira_key = $1", "RHCLOUD-603")
+    assert mem["external_key"] == "RHCLOUD-603"
+    assert mem["source_type"] == "jira"
+
+
+@pytest.mark.asyncio
+async def test_backfill_idempotent(db):
+    await _apply_schema(db)
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch, pr_number, pr_url) "
+        "VALUES ($1, $2, $3, $4, $5, $6)",
+        "RHCLOUD-700",
+        "pr_open",
+        "test-repo",
+        "bot/RHCLOUD-700",
+        99,
+        "https://github.com/org/repo/pull/99",
+    )
+
+    stats1 = await run_migration(db)
+    assert stats1["tasks"] == 1
+
+    stats2 = await run_migration(db)
+    assert stats2["tasks"] == 0
+
+    count = await db.fetchval("SELECT COUNT(*) FROM tasks")
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_old_columns_untouched(db):
+    await _apply_schema(db)
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch, pr_number, pr_url) "
+        "VALUES ($1, $2, $3, $4, $5, $6)",
+        "RHCLOUD-800",
+        "pr_open",
+        "my-repo",
+        "bot/RHCLOUD-800",
+        77,
+        "https://github.com/org/repo/pull/77",
+    )
+
+    await run_migration(db)
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "RHCLOUD-800")
+    assert task["jira_key"] == "RHCLOUD-800"
+    assert task["pr_number"] == 77
+    assert task["pr_url"] == "https://github.com/org/repo/pull/77"
+    assert task["repo"] == "my-repo"
+    assert task["branch"] == "bot/RHCLOUD-800"
+    assert task["status"] == "pr_open"
+
+
+@pytest.mark.asyncio
+async def test_source_url_format(db):
+    await _apply_schema(db)
+
+    await db.execute(
+        "INSERT INTO tasks (jira_key, status, repo, branch) VALUES ($1, $2, $3, $4)",
+        "RHCLOUD-12345",
+        "in_progress",
+        "test-repo",
+        "bot/RHCLOUD-12345",
+    )
+
+    await run_migration(db)
+
+    task = await db.fetchrow("SELECT * FROM tasks WHERE jira_key = $1", "RHCLOUD-12345")
+    assert task["source_url"] == "https://redhat.atlassian.net/browse/RHCLOUD-12345"


### PR DESCRIPTION
## Summary

Stage 1 of the generic task system migration ([RHCLOUD-48376](https://redhat.atlassian.net/browse/RHCLOUD-48376), parent epic [RHCLOUD-48375](https://redhat.atlassian.net/browse/RHCLOUD-48375)).

**Additive only** — no columns removed, no behavior changed, no API changes. The bot keeps working on old columns unaware of the new ones.

### What's in this PR

- **Schema**: Adds `external_key`, `source_type`, `source_url`, `artifacts` columns to 6 tables (tasks, bot_status, bot_instances, cycles, slack_notifications, memories). All nullable, no constraints yet.
- **Migration script** (`m001_generic_tasks.py`): Idempotent backfill that copies `jira_key` → `external_key`, sets `source_type = 'jira'`, constructs `source_url`, and builds `artifacts` JSONB array from `pr_number`/`pr_url` + `metadata.prs[]` with URL deduplication.
- **10 migration tests** covering: column existence, simple task, single PR, multi-repo PRs, overlap dedup, GitLab MR type, other tables backfill, idempotency, old columns untouched, source URL format.

### What this does NOT change

- No API changes (Stage 2)
- No tool signature changes (Stage 2)
- No model changes (Stage 2)
- No CLAUDE.md instruction changes (Stage 4)
- No column drops (Stage 5)

## Test plan

- [ ] CI pipeline: all 16 migration tests pass (6 existing + 10 new) against Postgres sidecar
- [ ] Existing tests unaffected (schema changes are additive with `ADD COLUMN IF NOT EXISTS`)
- [ ] Migration is idempotent (running twice produces same result)
- [ ] Old columns untouched after backfill

[RHCLOUD-48376]: https://redhat.atlassian.net/browse/RHCLOUD-48376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-48375]: https://redhat.atlassian.net/browse/RHCLOUD-48375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ