### PR TITLE
fix(dashboard): hide download button when no transcript, fix orphan grouping

### DIFF
--- a/bot/agent.py
+++ b/bot/agent.py
@@ -309,9 +309,22 @@ def _extract_context(block, ctx: CycleContext) -> None:
     elif name == "mcp__bot-memory__memory_delete":
         ctx.work_type = ctx.work_type or "memory_housekeeping"
 
+    # progress_store carries jira_key in progress dict
+    elif name == "mcp__bot-memory__progress_store":
+        progress = inp.get("progress") or {}
+        if isinstance(progress, dict):
+            if progress.get("jira_key"):
+                ctx.jira_key = ctx.jira_key or progress["jira_key"]
+            if progress.get("repo"):
+                ctx.repo = ctx.repo or progress["repo"]
+
 
 def _extract_task_id_from_result(block: ToolResultBlock, ctx: CycleContext) -> None:
-    """Extract task_id from MCP tool result content (task_add/task_get/task_update return task objects)."""
+    """Extract task_id from MCP tool result content.
+
+    Matches task objects (task_add/get/update → {id, jira_key, ...})
+    and cycle run objects (progress_store → {task_id, cycle_type, ...}).
+    """
     content = block.content
     if not content:
         return
@@ -326,11 +339,13 @@ def _extract_task_id_from_result(block: ToolResultBlock, ctx: CycleContext) -> N
         if not text:
             return
         data = json.loads(text)
-        if (
-            isinstance(data, dict)
-            and isinstance(data.get("id"), int)
-            and "jira_key" in data
-        ):
+        if not isinstance(data, dict):
+            return
+        # Task objects: {id: int, jira_key: ...}
+        if isinstance(data.get("id"), int) and "jira_key" in data:
             ctx.task_id = data["id"]
+        # Cycle run objects from progress_store: {task_id: int, cycle_type: ...}
+        elif isinstance(data.get("task_id"), int) and data["task_id"] > 0:
+            ctx.task_id = data["task_id"]
     except (json.JSONDecodeError, TypeError, IndexError, AttributeError):
         pass

--- a/dashboard/src/components/CycleRunCard.tsx
+++ b/dashboard/src/components/CycleRunCard.tsx
@@ -53,13 +53,15 @@ export default function CycleRunCard({ run, selected, onClick }: Props) {
         <span className="cycle-run-time" title={run.started_at}>
           {timeAgo(run.started_at)}
         </span>
-        <button
-          className="btn-download-cycle"
-          onClick={handleDownload}
-          title="Download transcript"
-        >
-          &#11015;
-        </button>
+        {run.has_transcript && (
+          <button
+            className="btn-download-cycle"
+            onClick={handleDownload}
+            title="Download transcript"
+          >
+            &#11015;
+          </button>
+        )}
       </div>
       <div className="cycle-run-meta">
         {duration != null && (

--- a/dashboard/src/pages/CycleRuns.tsx
+++ b/dashboard/src/pages/CycleRuns.tsx
@@ -355,10 +355,17 @@ function CycleRunDetail({
           </div>
         )}
 
-        <div className="detail-section">
-          <span className="detail-label">Transcript</span>
-          <TranscriptViewer runId={run.id} onRequestFullscreen={() => { if (!fullscreen) onToggleFullscreen(); }} />
-        </div>
+        {run.has_transcript ? (
+          <div className="detail-section">
+            <span className="detail-label">Transcript</span>
+            <TranscriptViewer runId={run.id} onRequestFullscreen={() => { if (!fullscreen) onToggleFullscreen(); }} />
+          </div>
+        ) : (
+          <div className="detail-section">
+            <span className="detail-label">Transcript</span>
+            <span className="transcript-unavailable">No transcript available for this cycle run.</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -129,6 +129,7 @@ export interface CycleRun {
   tokens_used: number | null;
   progress: Record<string, any>;
   created_at: string;
+  has_transcript?: boolean;
 }
 
 export interface WSEvent {

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -819,7 +819,8 @@ async def api_stats(request: Request) -> JSONResponse:
 
 _CYCLE_RUN_LIST_COLUMNS = (
     "id, task_id, cycle_type, instance_id, started_at, finished_at, "
-    "tool_calls, tokens_used, progress, created_at"
+    "tool_calls, tokens_used, progress, created_at, "
+    "(transcript IS NOT NULL) AS has_transcript"
 )
 
 
@@ -1000,10 +1001,10 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
         f"""
         SELECT
             cr.task_id,
-            t.jira_key,
+            COALESCE(t.jira_key, cr.progress->>'jira_key') AS jira_key,
             t.title,
             t.status::text AS task_status,
-            t.repo,
+            COALESCE(t.repo, cr.progress->>'repo') AS repo,
             COUNT(*) AS cycle_count,
             COUNT(*) FILTER (WHERE cr.transcript IS NOT NULL) AS transcript_count,
             SUM(cr.tool_calls) AS total_tool_calls,
@@ -1013,7 +1014,8 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
         FROM cycle_runs cr
         LEFT JOIN tasks t ON t.id = cr.task_id
         {where}
-        GROUP BY cr.task_id, t.jira_key, t.title, t.status, t.repo
+        GROUP BY cr.task_id, COALESCE(t.jira_key, cr.progress->>'jira_key'),
+                 t.title, t.status, COALESCE(t.repo, cr.progress->>'repo')
         ORDER BY MAX(cr.started_at) DESC
         """,
         *params,
@@ -1118,4 +1120,5 @@ def _cycle_run(row) -> dict:
         if isinstance(row["progress"], str)
         else (row["progress"] or {}),
         "created_at": row["created_at"].isoformat(),
+        "has_transcript": bool(row.get("has_transcript", False)),
     }


### PR DESCRIPTION
## Summary

Fixes two UX issues on the cycle runs dashboard page:

1. **Download button hidden when no transcript** — The download arrow now only appears on cycle runs that actually have a stored transcript, preventing silent 404 errors when users click it.

2. **Orphan grouping fix** — Cycle runs without a `task_id` but with a `jira_key` in their progress data are now grouped under their ticket instead of "Orphan cycles". Uses `COALESCE(t.jira_key, cr.progress->>'jira_key')` in the by-task grouping query.

3. **Bot agent extraction fix** — `_extract_task_id_from_result()` now also extracts `task_id` from `progress_store` cycle run results, preventing future orphan runs when the bot calls `progress_store` before transcript upload.

Closes [RHCLOUD-48541](https://issues.redhat.com/browse/RHCLOUD-48541)

## Changes

- `memory-server/bot_memory_server/api.py` — Add `has_transcript` boolean to list columns, COALESCE fallback in by-task grouping
- `dashboard/src/types.ts` — Add `has_transcript` to `CycleRun` interface
- `dashboard/src/components/CycleRunCard.tsx` — Conditionally render download button
- `dashboard/src/pages/CycleRuns.tsx` — Show "No transcript available" message in detail view
- `bot/agent.py` — Extract `task_id` from `progress_store` results, extract `jira_key` from progress dict

## Test plan

- [x] `python -m pytest tests/` — 26 tests pass
- [x] `npm run build` — dashboard builds cleanly
- [ ] Deploy to stage — verify download button hidden on transcript-less runs
- [ ] Verify orphan runs with `progress.jira_key` group under their ticket

[RHCLOUD-48541]: https://redhat.atlassian.net/browse/RHCLOUD-48541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ