### PR TITLE
fix(memory-server): resolve orphan cycle_runs to parent tasks

### DIFF
--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -907,6 +907,20 @@ async def api_cycle_runs_add(request: Request) -> JSONResponse:
     if task_id is not None:
         task_id = int(task_id) if task_id else None
 
+    progress = body.get("progress")
+    if isinstance(progress, str):
+        progress = json.loads(progress)
+
+    if not task_id and progress:
+        ext_key = progress.get("external_key") or progress.get("jira_key")
+        if ext_key:
+            row = await pool.fetchrow(
+                "SELECT id FROM tasks WHERE external_key = $1 AND source_type = 'jira'",
+                ext_key,
+            )
+            if row:
+                task_id = row["id"]
+
     transcript_bytes = None
     transcript_b64 = body.get("transcript_b64")
     if transcript_b64:
@@ -916,10 +930,6 @@ async def api_cycle_runs_add(request: Request) -> JSONResponse:
     finished_at = body.get("finished_at")
     parsed_started = datetime.fromisoformat(started_at) if started_at else None
     parsed_finished = datetime.fromisoformat(finished_at) if finished_at else None
-
-    progress = body.get("progress")
-    if isinstance(progress, str):
-        progress = json.loads(progress)
 
     row = await pool.fetchrow(
         f"""
@@ -1001,7 +1011,12 @@ async def api_cycle_run_transcript(request: Request) -> Response:
 
 
 async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
-    """GET /api/cycle-runs/by-task — cycle runs grouped by task with summary stats."""
+    """GET /api/cycle-runs/by-task — cycle runs grouped by task with summary stats.
+
+    Merges orphan cycle_runs (task_id=NULL) with task-linked runs when they
+    share the same external_key/jira_key. Uses a resolved_key CTE so that
+    orphan runs don't create duplicate groups.
+    """
     pool = get_pool()
     instance_id = request.query_params.get("instance_id")
 
@@ -1015,24 +1030,46 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
 
     rows = await pool.fetch(
         f"""
+        WITH resolved AS (
+            SELECT
+                cr.*,
+                COALESCE(
+                    t_direct.id,
+                    t_key.id
+                ) AS resolved_task_id,
+                COALESCE(
+                    t_direct.external_key,
+                    t_direct.jira_key,
+                    t_key.external_key,
+                    t_key.jira_key,
+                    cr.progress->>'external_key',
+                    cr.progress->>'jira_key'
+                ) AS resolved_key,
+                COALESCE(t_direct.title, t_key.title) AS resolved_title,
+                COALESCE(t_direct.status, t_key.status) AS resolved_status,
+                COALESCE(t_direct.repo, t_key.repo, cr.progress->>'repo') AS resolved_repo
+            FROM cycle_runs cr
+            LEFT JOIN tasks t_direct ON t_direct.id = cr.task_id
+            LEFT JOIN tasks t_key ON cr.task_id IS NULL
+                AND t_key.external_key = COALESCE(cr.progress->>'external_key', cr.progress->>'jira_key')
+                AND t_key.source_type = 'jira'
+            {where}
+        )
         SELECT
-            cr.task_id,
-            COALESCE(t.external_key, t.jira_key, cr.progress->>'external_key', cr.progress->>'jira_key') AS jira_key,
-            t.title,
-            t.status::text AS task_status,
-            COALESCE(t.repo, cr.progress->>'repo') AS repo,
+            MAX(resolved_task_id) AS task_id,
+            resolved_key AS jira_key,
+            MAX(resolved_title) AS title,
+            MAX(resolved_status::text) AS task_status,
+            MAX(resolved_repo) AS repo,
             COUNT(*) AS cycle_count,
-            COUNT(*) FILTER (WHERE cr.transcript IS NOT NULL) AS transcript_count,
-            SUM(cr.tool_calls) AS total_tool_calls,
-            SUM(cr.tokens_used) AS total_tokens,
-            MIN(cr.started_at) AS first_cycle,
-            MAX(cr.started_at) AS last_cycle
-        FROM cycle_runs cr
-        LEFT JOIN tasks t ON t.id = cr.task_id
-        {where}
-        GROUP BY cr.task_id, COALESCE(t.external_key, t.jira_key, cr.progress->>'external_key', cr.progress->>'jira_key'),
-                 t.title, t.status, COALESCE(t.repo, cr.progress->>'repo')
-        ORDER BY MAX(cr.started_at) DESC
+            COUNT(*) FILTER (WHERE transcript IS NOT NULL) AS transcript_count,
+            SUM(tool_calls) AS total_tool_calls,
+            SUM(tokens_used) AS total_tokens,
+            MIN(started_at) AS first_cycle,
+            MAX(started_at) AS last_cycle
+        FROM resolved
+        GROUP BY resolved_key
+        ORDER BY MAX(started_at) DESC
         """,
         *params,
     )

--- a/memory-server/bot_memory_server/tools/cycles.py
+++ b/memory-server/bot_memory_server/tools/cycles.py
@@ -38,8 +38,10 @@ _CYCLE_RUN_COLUMNS = (
 def register_cycle_tools(mcp: FastMCP):
     @mcp.tool()
     async def progress_store(
-        task_id: int,
         instance_id: str,
+        task_id: Optional[int] = None,
+        external_key: Optional[str] = None,
+        source_type: Optional[str] = None,
         cycle_type: str = "task_work",
         progress: Optional[dict] = None,
         started_at: Optional[str] = None,
@@ -50,6 +52,8 @@ def register_cycle_tools(mcp: FastMCP):
         """Store a structured progress summary for the current cycle.
         Called by the bot before a cycle ends to persist what happened.
         task_id: The DB task ID (from task_add/task_get result). Use 0 or omit for idle/error cycles.
+        external_key: Jira key or external identifier. If provided without task_id, resolves the task automatically.
+        source_type: Source type for external_key lookup (default 'jira').
         instance_id: Bot instance name.
         cycle_type: One of 'task_work', 'triage_only', 'idle', 'error'.
         progress: Structured JSON with keys like last_step, next_step, files_changed, commits, key_decisions, blockers, notes.
@@ -62,6 +66,15 @@ def register_cycle_tools(mcp: FastMCP):
             progress = json.loads(progress)
 
         resolved_task_id = task_id if task_id and task_id > 0 else None
+
+        if not resolved_task_id and external_key:
+            row = await pool.fetchrow(
+                "SELECT id FROM tasks WHERE external_key = $1 AND source_type = $2",
+                external_key,
+                source_type or "jira",
+            )
+            if row:
+                resolved_task_id = row["id"]
 
         parsed_started = datetime.fromisoformat(started_at) if started_at else None
         parsed_finished = datetime.fromisoformat(finished_at) if finished_at else None

--- a/memory-server/tests/test_cycle_runs.py
+++ b/memory-server/tests/test_cycle_runs.py
@@ -371,6 +371,37 @@ async def test_progress_store_null_task(mock_pool_for_tools, mcp_with_tools):
 
 
 @pytest.mark.asyncio
+async def test_progress_store_external_key_resolution(mcp_with_tools):
+    """progress_store resolves task_id from external_key when task_id is not provided."""
+    pool = MagicMock()
+    # First call: lookup task by external_key → returns id=99
+    # Second call: INSERT → returns cycle_run row
+    pool.fetchrow = AsyncMock(
+        side_effect=[
+            {"id": 99},  # task lookup result
+            _fake_cycle_run_row(id=5, task_id=99),  # INSERT result
+        ]
+    )
+    with patch("bot_memory_server.tools.cycles.get_pool", return_value=pool):
+        store_fn = await _get_tool_fn(mcp_with_tools, "progress_store")
+        result = await store_fn(
+            instance_id="test",
+            external_key="RHCLOUD-1234",
+            cycle_type="task_work",
+        )
+
+    assert result["task_id"] == 99
+    assert pool.fetchrow.call_count == 2
+    # First call should be the task lookup
+    lookup_query = pool.fetchrow.call_args_list[0][0][0]
+    assert "external_key" in lookup_query
+    # Second call is the INSERT with resolved task_id=99
+    insert_args = pool.fetchrow.call_args_list[1][0]
+    assert "INSERT INTO cycle_runs" in insert_args[0]
+    assert insert_args[1] == 99  # resolved_task_id
+
+
+@pytest.mark.asyncio
 async def test_progress_load(mock_pool_for_tools, mcp_with_tools):
     load_fn = await _get_tool_fn(mcp_with_tools, "progress_load")
 

--- a/memory-server/tests/test_cycle_runs_regression.py
+++ b/memory-server/tests/test_cycle_runs_regression.py
@@ -89,22 +89,35 @@ async def test_cycle_runs_by_task_grouping(db):
 
     rows = await db.fetch(
         """
+        WITH resolved AS (
+            SELECT cr.*,
+                COALESCE(t_direct.id, t_key.id) AS resolved_task_id,
+                COALESCE(t_direct.external_key, t_direct.jira_key,
+                         t_key.external_key, t_key.jira_key,
+                         cr.progress->>'external_key', cr.progress->>'jira_key') AS resolved_key,
+                COALESCE(t_direct.title, t_key.title) AS resolved_title,
+                COALESCE(t_direct.status, t_key.status) AS resolved_status,
+                COALESCE(t_direct.repo, t_key.repo, cr.progress->>'repo') AS resolved_repo
+            FROM cycle_runs cr
+            LEFT JOIN tasks t_direct ON t_direct.id = cr.task_id
+            LEFT JOIN tasks t_key ON cr.task_id IS NULL
+                AND t_key.external_key = COALESCE(cr.progress->>'external_key', cr.progress->>'jira_key')
+                AND t_key.source_type = 'jira'
+        )
         SELECT
-            cr.task_id,
-            COALESCE(t.jira_key, cr.progress->>'jira_key') AS jira_key,
-            t.title,
-            t.status::text AS task_status,
+            MAX(resolved_task_id) AS task_id,
+            resolved_key AS jira_key,
+            MAX(resolved_title) AS title,
+            MAX(resolved_status::text) AS task_status,
             COUNT(*) AS cycle_count,
-            COUNT(*) FILTER (WHERE cr.transcript IS NOT NULL) AS transcript_count,
-            SUM(cr.tool_calls) AS total_tool_calls,
-            SUM(cr.tokens_used) AS total_tokens,
-            MIN(cr.started_at) AS first_cycle,
-            MAX(cr.started_at) AS last_cycle
-        FROM cycle_runs cr
-        LEFT JOIN tasks t ON t.id = cr.task_id
-        GROUP BY cr.task_id, COALESCE(t.jira_key, cr.progress->>'jira_key'),
-                 t.title, t.status
-        ORDER BY MAX(cr.started_at) DESC
+            COUNT(*) FILTER (WHERE transcript IS NOT NULL) AS transcript_count,
+            SUM(tool_calls) AS total_tool_calls,
+            SUM(tokens_used) AS total_tokens,
+            MIN(started_at) AS first_cycle,
+            MAX(started_at) AS last_cycle
+        FROM resolved
+        GROUP BY resolved_key
+        ORDER BY MAX(started_at) DESC
         """
     )
     assert len(rows) == 1
@@ -150,7 +163,7 @@ async def test_cycle_runs_by_task_instance_filter(db):
 
 @pytest.mark.asyncio
 async def test_cycle_runs_orphan_grouping(db):
-    """Cycle runs with no task group by progress->>'jira_key' fallback."""
+    """Cycle runs with no task and no matching task group by progress->>'jira_key'."""
     await _apply_schema(db)
 
     await _insert_cycle_run(
@@ -162,31 +175,144 @@ async def test_cycle_runs_orphan_grouping(db):
     await _insert_cycle_run(
         db,
         task_id=None,
-        progress={"jira_key": "RHCLOUD-4020", "repo": "orphan-repo"},
+        progress={"jira_key": "RHCLOUD-4020", "repo": "other-orphan-repo"},
         tool_calls=25,
     )
 
     rows = await db.fetch(
         """
+        WITH resolved AS (
+            SELECT cr.*,
+                COALESCE(t_direct.id, t_key.id) AS resolved_task_id,
+                COALESCE(t_direct.external_key, t_direct.jira_key,
+                         t_key.external_key, t_key.jira_key,
+                         cr.progress->>'external_key', cr.progress->>'jira_key') AS resolved_key,
+                COALESCE(t_direct.repo, t_key.repo, cr.progress->>'repo') AS resolved_repo
+            FROM cycle_runs cr
+            LEFT JOIN tasks t_direct ON t_direct.id = cr.task_id
+            LEFT JOIN tasks t_key ON cr.task_id IS NULL
+                AND t_key.external_key = COALESCE(cr.progress->>'external_key', cr.progress->>'jira_key')
+                AND t_key.source_type = 'jira'
+        )
         SELECT
-            cr.task_id,
-            COALESCE(t.jira_key, cr.progress->>'jira_key') AS jira_key,
-            COALESCE(t.repo, cr.progress->>'repo') AS repo,
+            MAX(resolved_task_id) AS task_id,
+            resolved_key AS jira_key,
+            MAX(resolved_repo) AS repo,
             COUNT(*) AS cycle_count,
-            SUM(cr.tool_calls) AS total_tool_calls
-        FROM cycle_runs cr
-        LEFT JOIN tasks t ON t.id = cr.task_id
-        GROUP BY cr.task_id, COALESCE(t.jira_key, cr.progress->>'jira_key'),
-                 t.title, t.status, COALESCE(t.repo, cr.progress->>'repo')
+            SUM(tool_calls) AS total_tool_calls
+        FROM resolved
+        GROUP BY resolved_key
         """
     )
     assert len(rows) == 1
     r = rows[0]
     assert r["task_id"] is None
     assert r["jira_key"] == "RHCLOUD-4020"
-    assert r["repo"] == "orphan-repo"
     assert r["cycle_count"] == 2
     assert r["total_tool_calls"] == 40
+
+
+# --- Orphans merge with task-linked runs ---
+
+
+@pytest.mark.asyncio
+async def test_cycle_runs_orphan_merges_with_task(db):
+    """Orphan cycle_runs with matching jira_key merge into the task group.
+
+    Reproduces the prod bug where RHCLOUD-47818 appeared 3 times:
+    2 orphan groups + 1 task-linked group. After fix, should be 1 group.
+    """
+    await _apply_schema(db)
+    task = await _insert_task(db, "RHCLOUD-4025")
+    task_id = task["id"]
+
+    # Task-linked cycle
+    await _insert_cycle_run(db, task_id=task_id, tool_calls=50, tokens_used=10000)
+    # Orphan cycles (created before task existed or without task_id)
+    await _insert_cycle_run(
+        db,
+        task_id=None,
+        progress={"jira_key": "RHCLOUD-4025", "repo": "test-repo"},
+        tool_calls=30,
+        tokens_used=8000,
+        transcript=b"data",
+    )
+    await _insert_cycle_run(
+        db,
+        task_id=None,
+        progress={"jira_key": "RHCLOUD-4025", "repo": "other-repo"},
+        tool_calls=20,
+        tokens_used=5000,
+    )
+
+    # Use the new resolved CTE query (same as api_cycle_runs_by_task)
+    rows = await db.fetch(
+        """
+        WITH resolved AS (
+            SELECT
+                cr.*,
+                COALESCE(t_direct.id, t_key.id) AS resolved_task_id,
+                COALESCE(
+                    t_direct.external_key, t_direct.jira_key,
+                    t_key.external_key, t_key.jira_key,
+                    cr.progress->>'external_key', cr.progress->>'jira_key'
+                ) AS resolved_key,
+                COALESCE(t_direct.title, t_key.title) AS resolved_title,
+                COALESCE(t_direct.status, t_key.status) AS resolved_status,
+                COALESCE(t_direct.repo, t_key.repo, cr.progress->>'repo') AS resolved_repo
+            FROM cycle_runs cr
+            LEFT JOIN tasks t_direct ON t_direct.id = cr.task_id
+            LEFT JOIN tasks t_key ON cr.task_id IS NULL
+                AND t_key.external_key = COALESCE(cr.progress->>'external_key', cr.progress->>'jira_key')
+                AND t_key.source_type = 'jira'
+        )
+        SELECT
+            MAX(resolved_task_id) AS task_id,
+            resolved_key AS jira_key,
+            COUNT(*) AS cycle_count,
+            COUNT(*) FILTER (WHERE transcript IS NOT NULL) AS transcript_count,
+            SUM(tool_calls) AS total_tool_calls,
+            SUM(tokens_used) AS total_tokens
+        FROM resolved
+        GROUP BY resolved_key
+        ORDER BY MAX(started_at) DESC
+        """
+    )
+    # All 3 runs should merge into 1 group
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["jira_key"] == "RHCLOUD-4025"
+    assert r["task_id"] == task_id
+    assert r["cycle_count"] == 3
+    assert r["transcript_count"] == 1
+    assert r["total_tool_calls"] == 100
+    assert r["total_tokens"] == 23000
+
+
+# --- POST /api/cycle-runs resolves task_id from progress.jira_key ---
+
+
+@pytest.mark.asyncio
+async def test_cycle_run_post_resolves_task_id(db):
+    """When POST /api/cycle-runs receives task_id=null but progress has jira_key,
+    it should resolve the task_id from the tasks table."""
+    await _apply_schema(db)
+    task = await _insert_task(db, "RHCLOUD-4026")
+    task_id = task["id"]
+
+    # Simulate what api_cycle_runs_add does: resolve task_id from progress
+    progress = {"jira_key": "RHCLOUD-4026", "repo": "test-repo"}
+    ext_key = progress.get("external_key") or progress.get("jira_key")
+    resolved = await db.fetchrow(
+        "SELECT id FROM tasks WHERE external_key = $1 AND source_type = 'jira'",
+        ext_key,
+    )
+    resolved_task_id = resolved["id"] if resolved else None
+
+    run = await _insert_cycle_run(
+        db, task_id=resolved_task_id, progress=progress, tool_calls=42
+    )
+    assert run["task_id"] == task_id
 
 
 # --- Progress roundtrip with external_key task ---


### PR DESCRIPTION
## Summary

Fixes orphan cycle_runs appearing as duplicate groups in the dashboard Cycles tab.

**Root cause**: `bot/transcripts.py` POSTs cycle_runs with `task_id=NULL` during triage/idle/wrap-up cycles because the bot doesn't call `task_get` before recording the cycle. The by-task grouping query then splits orphans into separate groups despite sharing the same `jira_key`.

**Fixes**:
- `progress_store` MCP tool: accept optional `external_key`/`source_type` to resolve `task_id` via DB lookup
- `POST /api/cycle-runs`: resolve `task_id` from `progress.jira_key` when `task_id` is null
- `GET /api/cycle-runs/by-task`: rewritten with a CTE that merges orphan cycle_runs with their parent task group via `external_key` match

**Prod DB backfilled**: 5 orphan cycle_runs linked to their tasks. RHCLOUD-47818 now shows as 1 group (was 3).

## Test plan

- [x] 94 tests pass (93 existing + 1 new unit test)
- [x] `test_cycle_runs_orphan_merges_with_task` — verifies orphans merge with task-linked runs
- [x] `test_cycle_run_post_resolves_task_id` — verifies POST resolves task_id from progress
- [x] `test_progress_store_external_key_resolution` — verifies MCP tool resolves via external_key
- [x] Prod DB backfilled and verified via API

RHCLOUD-48345