### PR TITLE
feat(dashboard): genericize for multi-source tasks

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -155,6 +155,9 @@ function AppInner() {
         <BotBanner status={{
           state: currentInstance.state,
           message: currentInstance.message,
+          external_key: currentInstance.external_key,
+          source_type: currentInstance.source_type,
+          source_url: currentInstance.source_url,
           jira_key: currentInstance.jira_key,
           repo: currentInstance.repo,
           instance_id: currentInstance.instance_id,

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -22,12 +22,12 @@ export async function fetchTasks(params: { status?: string; exclude_status?: str
   return (await fetch('/api/tasks?' + qs)).json();
 }
 
-export async function deleteTask(jiraKey: string) {
-  return fetch('/api/tasks/' + encodeURIComponent(jiraKey), { method: 'DELETE' });
+export async function deleteTask(key: string) {
+  return fetch('/api/tasks/' + encodeURIComponent(key), { method: 'DELETE' });
 }
 
-export async function unarchiveTask(jiraKey: string) {
-  return fetch('/api/tasks/' + encodeURIComponent(jiraKey) + '/unarchive', { method: 'POST' });
+export async function unarchiveTask(key: string) {
+  return fetch('/api/tasks/' + encodeURIComponent(key) + '/unarchive', { method: 'POST' });
 }
 
 export async function fetchMemories(params: { category?: string; repo?: string; tag?: string; limit?: number; offset?: number }) {
@@ -73,7 +73,7 @@ export async function fetchCosts(days = 30, limit = 200, dateFrom?: string, date
   return (await fetch(`/api/costs?${qs}`)).json();
 }
 
-export async function fetchCycleRuns(params: { task_id?: number; instance_id?: string; cycle_type?: string; limit?: number; offset?: number }) {
+export async function fetchCycleRuns(params: { task_id?: number | 'none'; instance_id?: string; cycle_type?: string; limit?: number; offset?: number }) {
   const qs = new URLSearchParams();
   if (params.task_id != null) qs.set('task_id', String(params.task_id));
   if (params.instance_id) qs.set('instance_id', params.instance_id);

--- a/dashboard/src/components/BotBanner.tsx
+++ b/dashboard/src/components/BotBanner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { BotStatus } from '../types';
-import { timeAgo, JIRA_BASE } from '../utils';
+import { timeAgo, sourceUrl, displayKey } from '../utils';
 
 interface Props {
   status: BotStatus;
@@ -49,14 +49,14 @@ export default function BotBanner({ status }: Props) {
         </span>
       </div>
       <div className="banner-meta">
-        {status.jira_key && (
+        {displayKey(status) && (
           <a
-            href={JIRA_BASE + status.jira_key}
+            href={sourceUrl(status) || '#'}
             target="_blank"
             rel="noopener noreferrer"
             className="banner-jira"
           >
-            {status.jira_key}
+            {displayKey(status)}
           </a>
         )}
         {status.repo && <span className="banner-repo">{status.repo}</span>}

--- a/dashboard/src/components/CycleRunCard.tsx
+++ b/dashboard/src/components/CycleRunCard.tsx
@@ -1,5 +1,5 @@
 import type { CycleRun } from '../types';
-import { timeAgo, formatDuration, formatTokens, JIRA_BASE } from '../utils';
+import { timeAgo, formatDuration, formatTokens, sourceUrl } from '../utils';
 import { fetchCycleRunTranscript } from '../api';
 
 interface Props {
@@ -21,7 +21,8 @@ export default function CycleRunCard({ run, selected, onClick }: Props) {
     run.started_at && run.finished_at
       ? new Date(run.finished_at).getTime() - new Date(run.started_at).getTime()
       : null;
-  const jiraKey = progress.jira_key as string | undefined;
+  const extKey = (progress.external_key || progress.jira_key) as string | undefined;
+  const extUrl = sourceUrl({ external_key: extKey, source_type: progress.source_type as string });
 
   const handleDownload = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -74,15 +75,15 @@ export default function CycleRunCard({ run, selected, onClick }: Props) {
           <span className="cycle-run-tokens">{formatTokens(run.tokens_used)} tokens</span>
         )}
       </div>
-      {jiraKey && (
+      {extKey && (
         <a
-          href={JIRA_BASE + jiraKey}
+          href={extUrl || '#'}
           target="_blank"
           rel="noopener noreferrer"
           className="cycle-run-jira"
           onClick={(e) => e.stopPropagation()}
         >
-          {jiraKey}
+          {extKey}
         </a>
       )}
       {progress.summary && (

--- a/dashboard/src/components/DetailPanel.tsx
+++ b/dashboard/src/components/DetailPanel.tsx
@@ -1,5 +1,5 @@
 import type { Task, Memory } from '../types';
-import { timeAgo, JIRA_BASE } from '../utils';
+import { timeAgo, sourceUrl, displayKey } from '../utils';
 
 interface MemoryDetailProps {
   type: 'memory';
@@ -12,8 +12,8 @@ interface TaskDetailProps {
   type: 'task';
   task: Task;
   onClose: () => void;
-  onDelete?: (jiraKey: string) => void;
-  onUnarchive?: (jiraKey: string) => void;
+  onDelete?: (key: string) => void;
+  onUnarchive?: (key: string) => void;
 }
 
 type Props = MemoryDetailProps | TaskDetailProps;
@@ -57,11 +57,11 @@ function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, 'ty
               <span>{memory.repo}</span>
             </div>
           )}
-          {memory.jira_key && (
+          {displayKey(memory) && (
             <div className="detail-meta-item">
-              <span className="detail-label">Jira</span>
-              <a href={JIRA_BASE + memory.jira_key} target="_blank" rel="noopener noreferrer">
-                {memory.jira_key}
+              <span className="detail-label">Source</span>
+              <a href={sourceUrl(memory) || '#'} target="_blank" rel="noopener noreferrer">
+                {displayKey(memory)}
               </a>
             </div>
           )}
@@ -103,11 +103,14 @@ function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, 'ty
   );
 }
 
-function TaskDetail({ task, onClose, onDelete, onUnarchive }: Omit<TaskDetailProps, 'type'> & { onDelete?: (jiraKey: string) => void; onUnarchive?: (jiraKey: string) => void }) {
+function TaskDetail({ task, onClose, onDelete, onUnarchive }: Omit<TaskDetailProps, 'type'> & { onDelete?: (key: string) => void; onUnarchive?: (key: string) => void }) {
   const meta = task.metadata || {};
   const prs: Array<{ repo: string; number: number; url: string; host: string }> =
     meta.prs || [];
   const repos: string[] = meta.repos || [task.repo];
+  const key = displayKey(task);
+  const url = sourceUrl(task);
+  const artifacts = task.artifacts || [];
 
   const statusLabels: Record<string, string> = {
     in_progress: 'In Progress',
@@ -122,9 +125,11 @@ function TaskDetail({ task, onClose, onDelete, onUnarchive }: Omit<TaskDetailPro
     <div className="detail-panel">
       <div className="detail-header">
         <h3>
-          <a href={JIRA_BASE + task.jira_key} target="_blank" rel="noopener noreferrer">
-            {task.jira_key}
-          </a>
+          {url ? (
+            <a href={url} target="_blank" rel="noopener noreferrer">{key}</a>
+          ) : (
+            <span>{key}</span>
+          )}
           {task.title && <> &mdash; {task.title}</>}
         </h3>
         <button className="detail-close" onClick={onClose}>X</button>
@@ -146,7 +151,21 @@ function TaskDetail({ task, onClose, onDelete, onUnarchive }: Omit<TaskDetailPro
             <code className="mono">{task.branch}</code>
           </div>
 
-          {prs.length > 0 ? (
+          {artifacts.length > 0 ? (
+            <div className="detail-meta-item">
+              <span className="detail-label">Artifacts</span>
+              <div>
+                {artifacts.map((a, i) => (
+                  <div key={i}>
+                    <a href={a.url} target="_blank" rel="noopener noreferrer">
+                      {a.name}
+                    </a>
+                    {a.type && <span className="artifact-type"> ({a.type})</span>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : prs.length > 0 ? (
             <div className="detail-meta-item">
               <span className="detail-label">PRs</span>
               <div>
@@ -158,13 +177,6 @@ function TaskDetail({ task, onClose, onDelete, onUnarchive }: Omit<TaskDetailPro
                   </div>
                 ))}
               </div>
-            </div>
-          ) : task.pr_number ? (
-            <div className="detail-meta-item">
-              <span className="detail-label">PR</span>
-              <a href={task.pr_url || '#'} target="_blank" rel="noopener noreferrer">
-                #{task.pr_number}
-              </a>
             </div>
           ) : null}
 
@@ -229,12 +241,12 @@ function TaskDetail({ task, onClose, onDelete, onUnarchive }: Omit<TaskDetailPro
 
         <div className="detail-actions">
           {onUnarchive && (
-            <button className="btn-unarchive" onClick={() => onUnarchive(task.jira_key)}>
+            <button className="btn-unarchive" onClick={() => onUnarchive(key)}>
               Restore Task
             </button>
           )}
           {onDelete && (
-            <button className="btn-delete" onClick={() => onDelete(task.jira_key)}>
+            <button className="btn-delete" onClick={() => onDelete(key)}>
               Archive Task
             </button>
           )}

--- a/dashboard/src/components/MemoryCard.tsx
+++ b/dashboard/src/components/MemoryCard.tsx
@@ -1,5 +1,5 @@
 import type { Memory } from '../types';
-import { JIRA_BASE } from '../utils';
+import { sourceUrl, displayKey } from '../utils';
 
 interface Props {
   memory: Memory;
@@ -33,14 +33,14 @@ export default function MemoryCard({ memory, selected, showSimilarity, onClick }
           {memory.category.replace(/_/g, ' ')}
         </span>
         {memory.repo && <span className="memory-repo">{memory.repo}</span>}
-        {memory.jira_key && (
+        {displayKey(memory) && (
           <a
-            href={JIRA_BASE + memory.jira_key}
+            href={sourceUrl(memory) || '#'}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
           >
-            {memory.jira_key}
+            {displayKey(memory)}
           </a>
         )}
         {memory.tags.length > 0 && (

--- a/dashboard/src/components/TaskCard.tsx
+++ b/dashboard/src/components/TaskCard.tsx
@@ -1,5 +1,5 @@
 import type { Task } from '../types';
-import { timeAgo, JIRA_BASE } from '../utils';
+import { timeAgo, sourceUrl, displayKey } from '../utils';
 
 interface Props {
   task: Task;
@@ -16,8 +16,19 @@ const statusLabels: Record<string, string> = {
   archived: 'Archived',
 };
 
+const sourceTypeColors: Record<string, string> = {
+  jira: 'blue',
+  github: 'dark',
+  gitlab: 'orange',
+  scheduled: 'purple',
+  manual: 'dim',
+};
+
 export default function TaskCard({ task, selected, onClick }: Props) {
   const step = task.metadata?.last_step;
+  const url = sourceUrl(task);
+  const key = displayKey(task);
+  const firstArtifact = task.artifacts?.[0];
 
   return (
     <div
@@ -25,15 +36,24 @@ export default function TaskCard({ task, selected, onClick }: Props) {
       onClick={onClick}
     >
       <div className="task-card-header">
-        <a
-          href={JIRA_BASE + task.jira_key}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="task-jira-key"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {task.jira_key}
-        </a>
+        {url ? (
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="task-jira-key"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {key}
+          </a>
+        ) : (
+          <span className="task-jira-key">{key}</span>
+        )}
+        {task.source_type && task.source_type !== 'jira' && (
+          <span className={`source-type-badge ${sourceTypeColors[task.source_type] || 'dim'}`}>
+            {task.source_type}
+          </span>
+        )}
         <span className={`status-badge ${task.status}`}>
           {statusLabels[task.status] || task.status}
         </span>
@@ -41,15 +61,15 @@ export default function TaskCard({ task, selected, onClick }: Props) {
       {task.title && <div className="task-card-title">{task.title}</div>}
       <div className="task-card-meta">
         <span className="task-repo">{task.repo}</span>
-        {task.pr_number && (
+        {firstArtifact && (
           <a
-            href={task.pr_url || '#'}
+            href={firstArtifact.url}
             target="_blank"
             rel="noopener noreferrer"
             className="task-pr"
             onClick={(e) => e.stopPropagation()}
           >
-            PR #{task.pr_number}
+            {firstArtifact.name}
           </a>
         )}
         <span className="task-created" title={task.created_at}>

--- a/dashboard/src/components/Toasts.tsx
+++ b/dashboard/src/components/Toasts.tsx
@@ -43,7 +43,7 @@ export default function Toasts() {
 
       const data = event.data || {};
       const detail =
-        data.jira_key || data.title || (data.id ? `#${data.id}` : '');
+        data.external_key || data.jira_key || data.title || (data.id ? `#${data.id}` : '');
       const message =
         data.summary || data.status || data.category || '';
 

--- a/dashboard/src/pages/ArchivedTasks.tsx
+++ b/dashboard/src/pages/ArchivedTasks.tsx
@@ -34,8 +34,8 @@ export default function ArchivedTasks({ instanceId }: { instanceId?: string }) {
     });
   }, [onEvent, load]);
 
-  const handleUnarchive = async (jiraKey: string) => {
-    await unarchiveTask(jiraKey);
+  const handleUnarchive = async (key: string) => {
+    await unarchiveTask(key);
     setSelected(null);
     load();
   };

--- a/dashboard/src/pages/Costs.tsx
+++ b/dashboard/src/pages/Costs.tsx
@@ -16,7 +16,7 @@ import {
 } from 'recharts';
 import type { CycleEntry, DailyAggregate, AnalyticsData } from '../types';
 import { fetchCosts, fetchAnalytics } from '../api';
-import { formatDuration, formatTokens, JIRA_BASE } from '../utils';
+import { formatDuration, formatTokens, sourceUrl, displayKey } from '../utils';
 import { useWS } from '../hooks/useWebSocket';
 
 const DAYS_OPTIONS = [7, 14, 30, 90];
@@ -141,9 +141,9 @@ function CycleRow({ c }: { c: CycleEntry }) {
         {ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
       </div>
       <div className="cycle-work">
-        {c.jira_key ? (
-          <a href={`${JIRA_BASE}${c.jira_key}`} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
-            {c.jira_key}
+        {displayKey(c) ? (
+          <a href={sourceUrl(c) || '#'} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
+            {displayKey(c)}
           </a>
         ) : (
           <span style={{ color: 'var(--text-dim)' }}>—</span>
@@ -224,7 +224,7 @@ export default function Costs() {
       turns: c.num_turns,
       is_error: c.is_error,
       no_work: c.no_work,
-      jira_key: c.jira_key,
+      jira_key: displayKey(c),
       repo: c.repo,
       work_type: c.work_type,
       summary: c.summary,
@@ -261,8 +261,8 @@ export default function Costs() {
 
   // Ticket lifecycle stacked bar
   const ticketBarData = tickets.slice(0, 15).map(t => ({
-    key: t.jira_key,
-    title: t.title ? (t.title.length > 40 ? t.title.slice(0, 38) + '...' : t.title) : t.jira_key,
+    key: displayKey(t),
+    title: t.title ? (t.title.length > 40 ? t.title.slice(0, 38) + '...' : t.title) : displayKey(t),
     impl: t.impl_cycles,
     review: t.review_cycles,
     total_cost: t.total_cost,

--- a/dashboard/src/pages/CycleRuns.tsx
+++ b/dashboard/src/pages/CycleRuns.tsx
@@ -5,7 +5,7 @@ import type { CycleRun, TaskCycleGroup } from '../types';
 import { fetchCycleRuns, fetchCycleRunsByTask, fetchCycleRunTranscript } from '../api';
 import { useWS } from '../hooks/useWebSocket';
 import CycleRunCard from '../components/CycleRunCard';
-import { timeAgo, formatDuration, formatTokens, JIRA_BASE } from '../utils';
+import { timeAgo, formatDuration, formatTokens, sourceUrl, displayKey } from '../utils';
 
 import JSZip from 'jszip';
 
@@ -22,9 +22,10 @@ function downloadText(content: string, filename: string) {
   downloadBlob(new Blob([content], { type: 'application/x-ndjson' }), filename);
 }
 
-async function downloadAllTranscripts(taskId: number | null, jiraKey: string | null, instanceId?: string) {
-  const params: { task_id?: number; instance_id?: string; limit: number } = { limit: 100 };
+async function downloadAllTranscripts(taskId: number | null, key: string | null, instanceId?: string) {
+  const params: { task_id?: number | 'none'; instance_id?: string; limit: number } = { limit: 100 };
   if (taskId != null) params.task_id = taskId;
+  else if (!key) params.task_id = 'none';
   if (instanceId) params.instance_id = instanceId;
   const res = await fetchCycleRuns(params);
   const runs: CycleRun[] = res.items || [];
@@ -40,7 +41,7 @@ async function downloadAllTranscripts(taskId: number | null, jiraKey: string | n
     }
   }
 
-  const label = jiraKey || (taskId != null ? `task-${taskId}` : 'orphan');
+  const label = key || (taskId != null ? `task-${taskId}` : 'orphan');
   const blob = await zip.generateAsync({ type: 'blob' });
   downloadBlob(blob, `transcripts-${label}.zip`);
 }
@@ -337,7 +338,7 @@ function CycleRunDetail({
             <div className="progress-info">
               {progress.last_step && <div><strong>Last step:</strong> {progress.last_step}</div>}
               {progress.next_step && <div><strong>Next step:</strong> {progress.next_step}</div>}
-              {progress.jira_key && <div><strong>Jira:</strong> {progress.jira_key}</div>}
+              {(progress.external_key || progress.jira_key) && <div><strong>Source:</strong> {progress.external_key || progress.jira_key}</div>}
               {progress.summary && <div><strong>Summary:</strong> {progress.summary}</div>}
               {progress.files_changed && (
                 <div>
@@ -382,14 +383,16 @@ function TaskGroupCard({
   onClick: () => void;
   instanceId?: string;
 }) {
-  const label = group.jira_key || (group.task_id != null ? `Task #${group.task_id}` : 'Orphan cycles');
+  const key = displayKey(group);
+  const url = sourceUrl(group);
+  const label = key || (group.task_id != null ? `Task #${group.task_id}` : 'Orphan cycles');
   const [downloading, setDownloading] = useState(false);
 
   const handleDownload = async (e: React.MouseEvent) => {
     e.stopPropagation();
     setDownloading(true);
     try {
-      await downloadAllTranscripts(group.task_id, group.jira_key, instanceId);
+      await downloadAllTranscripts(group.task_id, key || null, instanceId);
     } finally {
       setDownloading(false);
     }
@@ -399,14 +402,14 @@ function TaskGroupCard({
     <div className={`task-group-card${expanded ? ' expanded' : ''}`} onClick={onClick}>
       <div className="task-group-header">
         <div className="task-group-title">
-          {group.jira_key ? (
+          {key ? (
             <a
-              href={JIRA_BASE + group.jira_key}
+              href={url || '#'}
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
             >
-              {group.jira_key}
+              {key}
             </a>
           ) : (
             <span>{label}</span>
@@ -442,7 +445,8 @@ function TaskGroupCard({
 
 function groupKey(g: TaskCycleGroup): string {
   if (g.task_id != null) return `t:${g.task_id}`;
-  if (g.jira_key) return `k:${g.jira_key}`;
+  const key = g.external_key || g.jira_key;
+  if (key) return `k:${key}`;
   return 'orphan';
 }
 
@@ -471,11 +475,12 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
     setGroups(data || []);
   }, [instanceId]);
 
-  const loadCyclesForTask = useCallback(async (taskId: number | null) => {
+  const loadCyclesForTask = useCallback(async (taskId: number | null, orphan = false) => {
     setLoadingRuns(true);
     try {
-      const params: { task_id?: number; instance_id?: string; limit: number } = { limit: 50 };
+      const params: { task_id?: number | 'none'; instance_id?: string; limit: number } = { limit: 50 };
       if (taskId != null) params.task_id = taskId;
+      else if (orphan) params.task_id = 'none';
       if (instanceId) params.instance_id = instanceId;
       const res = await fetchCycleRuns(params);
       setRuns(res.items || []);
@@ -497,7 +502,7 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
       const tid = taskParam ? parseInt(taskParam) : null;
       const match = groups.find((g) => g.task_id === tid);
       setExpandedGroupKey(match ? groupKey(match) : tid != null ? `t:${tid}` : 'orphan');
-      loadCyclesForTask(tid).then((items) => {
+      loadCyclesForTask(tid, tid == null).then((items) => {
         const found = items.find((r: CycleRun) => r.id === cycleId);
         if (found) setSelectedRun(found);
       });
@@ -524,7 +529,8 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
     setExpandedGroupKey(key);
     setSelectedRun(null);
     setFullscreen(false);
-    await loadCyclesForTask(g.task_id);
+    const isOrphan = g.task_id == null && !g.external_key && !g.jira_key;
+    await loadCyclesForTask(g.task_id, isOrphan);
   };
 
   const handleSelectRun = (run: CycleRun) => {

--- a/dashboard/src/pages/Instances.tsx
+++ b/dashboard/src/pages/Instances.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { BotInstance } from '../types';
 import { fetchInstances } from '../api';
 import { useWS } from '../hooks/useWebSocket';
-import { timeAgo, JIRA_BASE } from '../utils';
+import { timeAgo, sourceUrl, displayKey } from '../utils';
 
 export default function Instances() {
   const [instances, setInstances] = useState<BotInstance[]>([]);
@@ -73,15 +73,15 @@ export default function Instances() {
             </div>
 
             <div className="instance-card-meta">
-              {inst.jira_key && (
+              {displayKey(inst) && (
                 <a
-                  href={JIRA_BASE + inst.jira_key}
+                  href={sourceUrl(inst) || '#'}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="banner-jira"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  {inst.jira_key}
+                  {displayKey(inst)}
                 </a>
               )}
               {inst.repo && <span className="banner-repo">{inst.repo}</span>}

--- a/dashboard/src/pages/Tasks.tsx
+++ b/dashboard/src/pages/Tasks.tsx
@@ -50,8 +50,8 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
     });
   }, [onEvent, load]);
 
-  const handleDelete = async (jiraKey: string) => {
-    await deleteTask(jiraKey);
+  const handleDelete = async (key: string) => {
+    await deleteTask(key);
     setSelected(null);
     load();
   };

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -6,16 +6,16 @@ export interface SlackNotification {
 
 export interface Task {
   id: number;
-  jira_key: string;
-  external_key?: string;
-  source_type?: string;
-  source_url?: string;
-  artifacts?: Array<{ name: string; url: string; type: string }>;
+  external_key: string;
+  source_type: string;
+  source_url: string | null;
+  artifacts: Array<{ name: string; url: string; type: string }>;
+  jira_key?: string;
   status: 'in_progress' | 'pr_open' | 'pr_changes' | 'paused' | 'done';
   repo: string;
   branch: string;
-  pr_number: number | null;
-  pr_url: string | null;
+  pr_number?: number | null;
+  pr_url?: string | null;
   title: string | null;
   summary: string | null;
   created_at: string;
@@ -30,9 +30,9 @@ export interface Memory {
   id: number;
   category: string;
   repo: string;
-  jira_key: string | null;
-  external_key?: string;
-  source_type?: string;
+  external_key: string | null;
+  source_type: string | null;
+  jira_key?: string | null;
   title: string;
   content: string;
   tags: string[];
@@ -45,7 +45,10 @@ export interface BotInstance {
   instance_id: string;
   state: 'working' | 'idle' | 'error' | 'unknown';
   message: string;
-  jira_key: string | null;
+  external_key: string | null;
+  source_type: string | null;
+  source_url: string | null;
+  jira_key?: string | null;
   repo: string | null;
   cycle_start: string | null;
   updated_at: string;
@@ -56,7 +59,10 @@ export interface BotInstance {
 export interface BotStatus {
   state: 'working' | 'idle' | 'error' | 'unknown';
   message: string;
-  jira_key: string | null;
+  external_key: string | null;
+  source_type: string | null;
+  source_url: string | null;
+  jira_key?: string | null;
   repo: string | null;
   instance_id: string | null;
   cycle_start: string | null;
@@ -78,9 +84,9 @@ export interface CycleEntry {
   model: string;
   is_error: boolean;
   no_work: boolean;
-  jira_key: string | null;
-  external_key?: string;
-  source_type?: string;
+  external_key: string | null;
+  source_type: string | null;
+  jira_key?: string | null;
   repo: string | null;
   work_type: string | null;
   summary: string | null;
@@ -114,7 +120,8 @@ export interface EmbeddingPoint {
 
 export interface TaskCycleGroup {
   task_id: number | null;
-  jira_key: string | null;
+  external_key: string | null;
+  jira_key?: string | null;
   title: string | null;
   task_status: string | null;
   repo: string | null;
@@ -178,8 +185,8 @@ export interface RepoEntry {
 }
 
 export interface TicketEntry {
-  jira_key: string;
-  external_key?: string;
+  external_key: string;
+  jira_key?: string;
   title: string | null;
   status: string | null;
   repo: string | null;

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -21,4 +21,23 @@ export function formatTokens(n: number): string {
   return String(Math.round(n));
 }
 
-export const JIRA_BASE = 'https://redhat.atlassian.net/browse/';
+const JIRA_BASE = 'https://redhat.atlassian.net/browse/';
+
+interface SourceLike {
+  source_url?: string | null;
+  source_type?: string | null;
+  external_key?: string | null;
+  jira_key?: string | null;
+}
+
+export function sourceUrl(item: SourceLike): string | null {
+  if (item.source_url) return item.source_url;
+  const key = item.external_key || item.jira_key;
+  if (!key) return null;
+  if (item.source_type === 'jira') return JIRA_BASE + key;
+  return null;
+}
+
+export function displayKey(item: SourceLike): string {
+  return item.external_key || item.jira_key || '';
+}

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -854,7 +854,9 @@ async def api_cycle_runs(request: Request) -> JSONResponse:
     offset = int(request.query_params.get("offset", "0"))
 
     conditions, params, idx = [], [], 0
-    if task_id:
+    if task_id == "none":
+        conditions.append("task_id IS NULL")
+    elif task_id:
         idx += 1
         conditions.append(f"task_id = ${idx}")
         params.append(int(task_id))
@@ -1047,7 +1049,8 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
                 ) AS resolved_key,
                 COALESCE(t_direct.title, t_key.title) AS resolved_title,
                 COALESCE(t_direct.status, t_key.status) AS resolved_status,
-                COALESCE(t_direct.repo, t_key.repo, cr.progress->>'repo') AS resolved_repo
+                COALESCE(t_direct.repo, t_key.repo, cr.progress->>'repo') AS resolved_repo,
+                COALESCE(t_direct.source_type, t_key.source_type) AS resolved_source_type
             FROM cycle_runs cr
             LEFT JOIN tasks t_direct ON t_direct.id = cr.task_id
             LEFT JOIN tasks t_key ON cr.task_id IS NULL
@@ -1058,6 +1061,8 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
         SELECT
             MAX(resolved_task_id) AS task_id,
             resolved_key AS jira_key,
+            resolved_key AS external_key,
+            MAX(resolved_source_type) AS source_type,
             MAX(resolved_title) AS title,
             MAX(resolved_status::text) AS task_status,
             MAX(resolved_repo) AS repo,
@@ -1080,6 +1085,8 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
             {
                 "task_id": r["task_id"],
                 "jira_key": r["jira_key"],
+                "external_key": r["external_key"],
+                "source_type": r["source_type"],
                 "title": r["title"],
                 "task_status": r["task_status"],
                 "repo": r["repo"],

--- a/memory-server/bot_memory_server/migrations/m001_generic_tasks.py
+++ b/memory-server/bot_memory_server/migrations/m001_generic_tasks.py
@@ -68,6 +68,20 @@ async def run_migration(conn: asyncpg.Connection) -> dict:
         )
         stats["tasks"] += 1
 
+    # Backfill cycle_runs.task_id where NULL but progress has a matching task key
+    cr_result = await conn.execute(
+        """
+        UPDATE cycle_runs cr
+        SET task_id = t.id
+        FROM tasks t
+        WHERE cr.task_id IS NULL
+          AND t.external_key = COALESCE(cr.progress->>'external_key', cr.progress->>'jira_key')
+          AND t.source_type = 'jira'
+          AND COALESCE(cr.progress->>'external_key', cr.progress->>'jira_key') IS NOT NULL
+        """
+    )
+    stats["cycle_runs"] = int(cr_result.split()[-1]) if cr_result else 0
+
     for table in SIMPLE_TABLES:
         has_jira_key = await conn.fetchval(
             "SELECT EXISTS ("

--- a/memory-server/docker-compose.yml
+++ b/memory-server/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - "8080:8080"
     environment:
       DATABASE_URL: postgresql://bot:bot@postgres:5432/bot_memory
+      JIRA_URL: https://redhat.atlassian.net
     volumes:
       - ./bot_memory_server/static:/app/bot_memory_server/static
     depends_on:


### PR DESCRIPTION
## Summary

RHCLOUD-48379 — Stage 3 dashboard genericization for the generic task system migration (RHCLOUD-48375).

- **Dashboard**: Switch all 15 components/pages from hardcoded `JIRA_BASE + jira_key` to generic `sourceUrl()`/`displayKey()` helpers that use `external_key`, `source_type`, `source_url`, and `artifacts` fields
- **TaskCard**: Renders source-type badges (jira/github/gitlab/scheduled/manual) and artifacts instead of PR-specific fields
- **API**: `cycle-runs/by-task` endpoint returns `external_key` and `source_type`; supports `task_id=none` filter for true orphan cycles
- **Migration**: Backfills orphaned `cycle_runs.task_id` from matching task by `progress->>'jira_key'`
- **docker-compose**: Adds `JIRA_URL` env var

### Post-deploy

Re-run the migration to link orphaned cycle_runs:
```
python -m bot_memory_server.migrations.m001_generic_tasks
```

## Files changed (18)

**Dashboard** (15 files): types.ts, utils.ts, api.ts, TaskCard, BotBanner, DetailPanel, MemoryCard, CycleRunCard, Toasts, CycleRuns, Costs, Instances, App, Tasks, ArchivedTasks

**Backend** (3 files): api.py, m001_generic_tasks.py, docker-compose.yml

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `python -m pytest tests/ -v` — all 94 tests pass
- [x] No `JIRA_BASE` imports remain (only private const in utils.ts)
- [ ] Visual: dashboard shows task keys, source badges, artifact links correctly
- [ ] Orphan cycles group only shows truly orphaned cycles after migration