### PR TITLE
feat(dashboard): add ability to wake bot from dashboard

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
 
 from dotenv import load_dotenv
 from filelock import FileLock, Timeout
@@ -164,13 +166,32 @@ def sync_config_repo() -> Path | None:
 
 SLEEP_SIGNAL_FILE = DATA_DIR / "cycle-sleep.json"
 LOW_DISK_THRESHOLD_MB = 512
+WAKE_POLL_INTERVAL = 5
+
+DASHBOARD_BASE_URL = os.environ.get(
+    "BOT_DASHBOARD_URL", "http://localhost:8080/api/bot-status"
+).rsplit("/bot-status", 1)[0]
 
 
-def _read_sleep_signal(config: Config) -> int:
+def _check_wake_signal(instance_id: str) -> bool:
+    """Poll the memory server for a wake trigger. Returns True if wake requested."""
+    try:
+        url = f"{DASHBOARD_BASE_URL}/instances/{instance_id}/wake"
+        with urlopen(url, timeout=2) as resp:
+            data = json.loads(resp.read())
+            return data.get("wake", False)
+    except (URLError, OSError, json.JSONDecodeError, Exception):
+        return False
+
+
+def _read_sleep_signal(config: Config, instance_id: str | None = None) -> int:
     """Read sleep duration from skill-written signal file.
 
     Skills write data/cycle-sleep.json with {"recommended_sleep": N, "reason": "..."}.
     No file = standard interval (work was done). File is always deleted after reading.
+
+    Instead of blocking for the full duration, sleeps in short intervals and polls
+    the memory server for a wake trigger so the dashboard can interrupt the sleep.
     """
     logger = logging.getLogger(__name__)
     sleep_seconds = config.interval
@@ -188,8 +209,23 @@ def _read_sleep_signal(config: Config) -> int:
     else:
         logger.info("No sleep signal, using default %ds", config.interval)
 
+    sleep_seconds = max(sleep_seconds, WAKE_POLL_INTERVAL)
     logger.info("Sleeping for %ds...", sleep_seconds)
-    time.sleep(sleep_seconds)
+
+    if instance_id:
+        elapsed = 0
+        while elapsed < sleep_seconds:
+            time.sleep(WAKE_POLL_INTERVAL)
+            elapsed += WAKE_POLL_INTERVAL
+            if _check_wake_signal(instance_id):
+                logger.info(
+                    "Wake signal received after %ds — starting next cycle early",
+                    elapsed,
+                )
+                return elapsed
+    else:
+        time.sleep(sleep_seconds)
+
     return sleep_seconds
 
 
@@ -353,7 +389,7 @@ def main() -> None:
             else:
                 logger.warning("Cycle produced no result")
 
-            sleep_seconds = _read_sleep_signal(config)
+            sleep_seconds = _read_sleep_signal(config, instance_id)
 
             cleanup_between_cycles(SCRIPT_DIR)
     finally:

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -406,6 +406,36 @@ header {
   color: var(--text-dim);
 }
 
+.instance-footer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wake-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--green);
+  border: 1px solid var(--green);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+  line-height: 1;
+}
+.wake-btn:hover {
+  background: rgba(63, 185, 80, 0.15);
+}
+.wake-btn.waking {
+  opacity: 0.6;
+  cursor: default;
+  color: var(--text-dim);
+  border-color: var(--text-dim);
+}
+
 /* Tab nav */
 .tab-nav {
   display: flex;

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -95,6 +95,11 @@ export async function fetchCycleRunTranscript(id: number): Promise<string> {
   return res.text();
 }
 
+export async function wakeInstance(instanceId: string): Promise<{ ok: boolean }> {
+  const res = await fetch(`/api/instances/${encodeURIComponent(instanceId)}/wake`, { method: 'POST' });
+  return res.json();
+}
+
 export async function fetchAnalytics(days = 30, dateFrom?: string, dateTo?: string) {
   const qs = new URLSearchParams();
   if (dateFrom) qs.set('from', dateFrom);

--- a/dashboard/src/pages/Instances.tsx
+++ b/dashboard/src/pages/Instances.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { BotInstance } from '../types';
-import { fetchInstances } from '../api';
+import { fetchInstances, wakeInstance } from '../api';
 import { useWS } from '../hooks/useWebSocket';
 import { timeAgo, sourceUrl, displayKey } from '../utils';
 
 export default function Instances() {
   const [instances, setInstances] = useState<BotInstance[]>([]);
+  const [wakingIds, setWakingIds] = useState<Set<string>>(new Set());
   const navigate = useNavigate();
   const { onEvent } = useWS();
 
@@ -23,11 +24,33 @@ export default function Instances() {
     load();
   }, [load]);
 
+  const handleWake = useCallback(async (e: React.MouseEvent, instanceId: string) => {
+    e.stopPropagation();
+    setWakingIds((prev) => new Set(prev).add(instanceId));
+    try {
+      await wakeInstance(instanceId);
+    } catch {
+      setWakingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(instanceId);
+        return next;
+      });
+    }
+  }, []);
+
   useEffect(() => {
     return onEvent((event) => {
       if (event.type === 'bot_status') {
+        const id = event.data.instance_id;
+        if (id && event.data.state === 'working') {
+          setWakingIds((prev) => {
+            if (!prev.has(id)) return prev;
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+          });
+        }
         setInstances((prev) => {
-          const id = event.data.instance_id;
           if (!id) return prev;
           const idx = prev.findIndex((i) => i.instance_id === id);
           if (idx >= 0) {
@@ -91,8 +114,26 @@ export default function Instances() {
               <span className="instance-tasks">
                 {inst.active_tasks}/{inst.max_tasks} tasks
               </span>
-              <span className="instance-updated" title={inst.updated_at}>
-                {timeAgo(inst.updated_at)}
+              <span className="instance-footer-right">
+                {inst.state === 'idle' && (
+                  <button
+                    className={`wake-btn${wakingIds.has(inst.instance_id) ? ' waking' : ''}`}
+                    disabled={wakingIds.has(inst.instance_id)}
+                    onClick={(e) => handleWake(e, inst.instance_id)}
+                    title="Wake bot — start next cycle immediately"
+                  >
+                    {wakingIds.has(inst.instance_id) ? (
+                      'Waking…'
+                    ) : (
+                      <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+                        <path d="M0 0 L12 7 L0 14 Z" />
+                      </svg>
+                    )}
+                  </button>
+                )}
+                <span className="instance-updated" title={inst.updated_at}>
+                  {timeAgo(inst.updated_at)}
+                </span>
               </span>
             </div>
           </div>

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -16,6 +16,8 @@ from .events import Event, bus
 
 logger = logging.getLogger(__name__)
 
+wake_signals: set[str] = set()
+
 
 async def api_tasks(request: Request) -> JSONResponse:
     pool = get_pool()
@@ -1076,6 +1078,38 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
             }
         )
     return JSONResponse(groups)
+
+
+async def api_instance_wake_trigger(request: Request) -> JSONResponse:
+    """POST /api/instances/{instance_id}/wake — request a sleeping bot to wake up."""
+    pool = get_pool()
+    instance_id = request.path_params.get("instance_id")
+    if not instance_id:
+        return JSONResponse({"error": "missing instance_id"}, status_code=400)
+
+    row = await pool.fetchrow(
+        "SELECT instance_id FROM bot_instances WHERE instance_id = $1", instance_id
+    )
+    if not row:
+        return JSONResponse(
+            {"error": f"Instance {instance_id} not found"}, status_code=404
+        )
+
+    wake_signals.add(instance_id)
+    await bus.publish(Event("instance_wake", {"instance_id": instance_id}))
+    return JSONResponse({"ok": True})
+
+
+async def api_instance_wake_check(request: Request) -> JSONResponse:
+    """GET /api/instances/{instance_id}/wake — poll for a wake signal (consumed on read)."""
+    instance_id = request.path_params.get("instance_id")
+    if not instance_id:
+        return JSONResponse({"error": "missing instance_id"}, status_code=400)
+
+    if instance_id in wake_signals:
+        wake_signals.discard(instance_id)
+        return JSONResponse({"wake": True})
+    return JSONResponse({"wake": False})
 
 
 def _task(row, slack_notif=None) -> dict:

--- a/memory-server/bot_memory_server/server.py
+++ b/memory-server/bot_memory_server/server.py
@@ -91,6 +91,8 @@ from .api import (  # noqa: E402
     api_stats,
     api_bot_status,
     api_instances,
+    api_instance_wake_trigger,
+    api_instance_wake_check,
     api_costs,
     api_analytics,
     api_cycle_runs,
@@ -111,6 +113,12 @@ mcp.custom_route("/api/memories/{id}", methods=["GET"])(api_memory_get)
 mcp.custom_route("/api/memories/{id}", methods=["DELETE"])(api_memory_delete)
 mcp.custom_route("/api/bot-status", methods=["GET", "POST"])(api_bot_status)
 mcp.custom_route("/api/instances", methods=["GET"])(api_instances)
+mcp.custom_route("/api/instances/{instance_id}/wake", methods=["POST"])(
+    api_instance_wake_trigger
+)
+mcp.custom_route("/api/instances/{instance_id}/wake", methods=["GET"])(
+    api_instance_wake_check
+)
 mcp.custom_route("/api/costs", methods=["GET", "POST"])(api_costs)
 mcp.custom_route("/api/tags", methods=["GET"])(api_tags)
 mcp.custom_route("/api/stats", methods=["GET"])(api_stats)


### PR DESCRIPTION
 ## Description

  Add a "wake" button to the bot instance dashboard that interrupts a sleeping bot's idle period and triggers the next work cycle immediately. Currently, bots sleep 300s between cycles (3600s when no work is found) with no way to cut that short. This lets operators trigger an early cycle when they know new Jira work is available, without waiting for the sleep timer to expire.

  **How it works:**
  - Dashboard UI shows a play button on idle instance cards
  - Click sends POST /api/instances/{id}/wake to the memory server
  - Memory server validates the instance exists in bot_instances, stores a signal in an in-memory set, and broadcasts a WebSocket event
  - Bot runner polls GET /api/instances/{id}/wake every 5s during sleep (pure Python, zero AI tokens burned)
  - On wake signal, bot breaks out of sleep and starts its next cycle
  - Signal is consumed on read (one click = one wake)

  No database schema changes. No new dependencies. Backward compatible — bots without an instance_id fall back to blocking sleep.

  ### Future auth note:
  Currently all dashboards have visibility into all instances across teams (e.g. framework bot dashboard can see UI bot instances). The wake endpoint is designed so that auth gates cleanly at the POST handler — when we eventually separate instance dashboards with per-team visibility and access controls, the wake trigger will inherit those restrictions without structural changes. The instance existence validation is a lightweight guard in the interim.

  ---
  ## Blast radius
  
  - memory-server: New API endpoints (POST/GET /api/instances/{id}/wake), new WebSocket event type instance_wake. No changes to existing endpoints.
  - bot/run.py: time.sleep() replaced with a polling loop. Only affects sleep behavior between cycles — no changes to cycle execution, agent SDK calls, or MCP tools.
  - dashboard: UI-only addition to instance cards. No changes to existing components or data flow.

  No downstream repos or external consumers affected — all changes are internal to this repo.
  
  ---
  ## Rollback plan

  git revert is sufficient. The wake endpoints would 404 (harmless), the dashboard button would disappear, and the bot runner would revert to blocking time.sleep(). No persistent state (DB, config) is modified by this feature.

  ---
  ## Checklist
  
  - [ ] Tested against at least one consuming repo/service
  - [ ] No breaking changes to existing consumers (or migration path documented)
  - [ ] No hardcoded secrets, tokens, or passwords
  - [ ] Container images pinned to specific tags, not latest

 ## AI disclosure

  Assisted by: Claude Code (Claude Opus 4.6)