### PR TITLE
fix(skills): rename jira_key to external_key in API field reads

### DIFF
--- a/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
+++ b/.claude/skills/claim-ticket/scripts/claim_ticket_operations.py
@@ -566,7 +566,7 @@ class ClaimTicketOperations:
         logger.info(f"Adding {jira_key} to memory server...")
 
         task_payload = {
-            "jira_key": jira_key,
+            "external_key": jira_key,
             "status": "in_progress",
             "assigned_to": self.bot_account_id or "unknown",
             "board_id": self.board_id,

--- a/.claude/skills/memory_mcp.py
+++ b/.claude/skills/memory_mcp.py
@@ -5,7 +5,7 @@ Uses the MCP Python SDK for proper session handling over streamable HTTP.
 Usage:
     from memory_mcp import memory_call
 
-    data = memory_call("slack_notify", {"jira_key": "X", ...})
+    data = memory_call("slack_notify", {"external_key": "X", ...})
 """
 
 import asyncio
@@ -30,8 +30,8 @@ async def _ensure_session():
     if not MEMORY_MCP_URL:
         raise RuntimeError("BOT_MEMORY_URL not set")
 
-    from mcp.client.streamable_http import streamablehttp_client
     from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
 
     _cm_transport = streamablehttp_client(MEMORY_MCP_URL)
     _read, _write, _ = await _cm_transport.__aenter__()

--- a/.claude/skills/post-pr/post_pr.py
+++ b/.claude/skills/post-pr/post_pr.py
@@ -87,11 +87,11 @@ def get_task(jira_key):
             return None
 
         for t in data["items"]:
-            if t.get("jira_key") == jira_key:
+            if t.get("external_key") == jira_key:
                 logger.info(f"Found task {jira_key}")
                 return t
 
-        available = [t.get("jira_key") for t in data.get("items", [])]
+        available = [t.get("external_key") for t in data.get("items", [])]
         logger.error(f"Task {jira_key} not found. Available tasks: {available}")
         return None
     except Exception as e:

--- a/.claude/skills/post-pr/tests/test_wrapper.py
+++ b/.claude/skills/post-pr/tests/test_wrapper.py
@@ -73,15 +73,25 @@ class TestGetTask:
         """Test successful task retrieval."""
         mock_http.return_value = {
             "items": [
-                {"jira_key": "TEST-123", "pr_url": "https://github.com/org/repo/pull/1", "pr_number": 1},
-                {"jira_key": "TEST-456", "pr_url": "https://github.com/org/repo/pull/2", "pr_number": 2},
+                {
+                    "external_key": "TEST-123",
+                    "jira_key": "TEST-123",
+                    "pr_url": "https://github.com/org/repo/pull/1",
+                    "pr_number": 1,
+                },
+                {
+                    "external_key": "TEST-456",
+                    "jira_key": "TEST-456",
+                    "pr_url": "https://github.com/org/repo/pull/2",
+                    "pr_number": 2,
+                },
             ]
         }
 
         task = post_pr.get_task("TEST-123")
 
         assert task is not None
-        assert task["jira_key"] == "TEST-123"
+        assert task["external_key"] == "TEST-123"
         assert task["pr_number"] == 1
 
     @patch("post_pr.http_request")
@@ -89,7 +99,12 @@ class TestGetTask:
         """Test task not found."""
         mock_http.return_value = {
             "items": [
-                {"jira_key": "TEST-456", "pr_url": "https://github.com/org/repo/pull/2", "pr_number": 2},
+                {
+                    "external_key": "TEST-456",
+                    "jira_key": "TEST-456",
+                    "pr_url": "https://github.com/org/repo/pull/2",
+                    "pr_number": 2,
+                },
             ]
         }
 
@@ -219,7 +234,7 @@ class TestMainFunction:
         """Test successful main execution."""
         # Setup mocks
         mock_get_task.return_value = {
-            "jira_key": "TEST-123",
+            "external_key": "TEST-123",
             "pr_url": "https://github.com/org/repo/pull/1",
             "pr_number": 1,
             "summary": "Test PR",
@@ -252,7 +267,7 @@ class TestMainFunction:
     def test_main_invalid_task_data(self, mock_get_task):
         """Test main exits when task data is invalid."""
         mock_get_task.return_value = {
-            "jira_key": "TEST-123",
+            "external_key": "TEST-123",
             # Missing pr_url and pr_number
         }
 
@@ -267,7 +282,7 @@ class TestMainFunction:
     def test_main_workflow_failure(self, mock_workflow, mock_get_task):
         """Test main exits with error when workflow fails."""
         mock_get_task.return_value = {
-            "jira_key": "TEST-123",
+            "external_key": "TEST-123",
             "pr_url": "https://github.com/org/repo/pull/1",
             "pr_number": 1,
             "summary": "Test PR",

--- a/.claude/skills/slack-notify/slack_notify.py
+++ b/.claude/skills/slack-notify/slack_notify.py
@@ -36,7 +36,7 @@ def main():
     result = memory_call(
         "slack_notify",
         {
-            "jira_key": jira_key,
+            "external_key": jira_key,
             "event_type": event_type,
             "message": message,
             "webhook_url": webhook_url,

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -319,7 +319,7 @@ def enrich(task):
                 all_issues.extend(issues)
                 pr_comments.extend(gl_mr_notes(up, pr_num))
 
-    jira = jira_issue(task.get("jira_key", ""))
+    jira = jira_issue(task.get("external_key", ""))
     jira_comments = []
     if jira:
         jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
@@ -336,7 +336,7 @@ def enrich(task):
 
 def fmt_task(e):
     t = e["task"]
-    key, status, repo = t.get("jira_key", "?"), t.get("status", "?"), t.get("repo", "?")
+    key, status, repo = t.get("external_key", "?"), t.get("status", "?"), t.get("repo", "?")
     meta = t.get("metadata") or {}
     lines = [f"{key} [{status}] {repo}"]
     if t.get("title"):
@@ -366,9 +366,8 @@ def fmt_task(e):
             lt = lk.get("type", {}).get("name", "?")
             linked = lk.get("inwardIssue") or lk.get("outwardIssue", {})
             if linked:
-                lines.append(
-                    f"  link: {lt} {linked.get('key', '?')} [{linked.get('fields', {}).get('status', {}).get('name', '?')}]"
-                )
+                status = linked.get("fields", {}).get("status", {}).get("name", "?")
+                lines.append(f"  link: {lt} {linked.get('key', '?')} [{status}]")
         jc = [
             {
                 "author": c.get("author", {}).get("displayName", "?"),
@@ -444,9 +443,9 @@ def main():
     if not active:
         print("NO ACTIVE TASKS -> Priority 2 (new Jira work)")
         if done:
-            print(f"done pending archival: {','.join(t.get('jira_key', '?') for t in done)}")
+            print(f"done pending archival: {','.join(t.get('external_key', '?') for t in done)}")
         if paused:
-            print(f"paused: {','.join(t.get('jira_key', '?') for t in paused)}")
+            print(f"paused: {','.join(t.get('external_key', '?') for t in paused)}")
         return
 
     enriched = [enrich(t) for t in active]
@@ -530,13 +529,14 @@ def main():
         print(f"== CLEAN ({len(clean)}) — no action ==")
         for e in clean:
             t = e["task"]
-            print(f"  {t.get('jira_key', '?')} [{t.get('status', '?')}] {t.get('repo', '?')}")
+            print(f"  {t.get('external_key', '?')} [{t.get('status', '?')}] {t.get('repo', '?')}")
         print()
 
     if paused:
-        print(f"PAUSED: {' | '.join(t.get('jira_key', '?') + ':' + str(t.get('paused_reason', '')) for t in paused)}")
+        parts = (t.get("external_key", "?") + ":" + str(t.get("paused_reason", "")) for t in paused)
+        print(f"PAUSED: {' | '.join(parts)}")
     if done:
-        print(f"DONE (archive?): {','.join(t.get('jira_key', '?') for t in done)}")
+        print(f"DONE (archive?): {','.join(t.get('external_key', '?') for t in done)}")
 
     total = len(merged) + len(closed) + len(ci_fail) + len(conflict) + len(feedback) + len(interrupted)
     if total == 0:

--- a/.claude/skills/wrap-up/wrap_up.py
+++ b/.claude/skills/wrap-up/wrap_up.py
@@ -46,7 +46,7 @@ def get_task(jira_key):
     if not data or "items" not in data:
         return None
     for t in data["items"]:
-        if t.get("jira_key") == jira_key:
+        if t.get("external_key") == jira_key:
             return t
     return None
 
@@ -152,7 +152,7 @@ def slack_notify(jira_key, pr_info):
     result = memory_call(
         "slack_notify",
         {
-            "jira_key": jira_key,
+            "external_key": jira_key,
             "event_type": "release_pending",
             "message": msg,
             "webhook_url": webhook_url,

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -39,8 +39,10 @@ async def api_tasks(request: Request) -> JSONResponse:
         total = await pool.fetchval(f"SELECT COUNT(*) FROM tasks {where}", *base_params)
         order_col = "last_addressed" if status == "archived" else "created_at"
         base_params.extend([limit, offset])
+        lim_idx = len(base_params) - 1
+        off_idx = len(base_params)
         rows = await pool.fetch(
-            f"SELECT * FROM tasks {where} ORDER BY {order_col} DESC LIMIT ${len(base_params) - 1} OFFSET ${len(base_params)}",
+            f"SELECT * FROM tasks {where} ORDER BY {order_col} DESC LIMIT ${lim_idx} OFFSET ${off_idx}",
             *base_params,
         )
     elif exclude:
@@ -53,8 +55,10 @@ async def api_tasks(request: Request) -> JSONResponse:
 
         total = await pool.fetchval(f"SELECT COUNT(*) FROM tasks {where}", *base_params)
         base_params.extend([limit, offset])
+        lim_idx = len(base_params) - 1
+        off_idx = len(base_params)
         rows = await pool.fetch(
-            f"SELECT * FROM tasks {where} ORDER BY created_at DESC LIMIT ${len(base_params) - 1} OFFSET ${len(base_params)}",
+            f"SELECT * FROM tasks {where} ORDER BY created_at DESC LIMIT ${lim_idx} OFFSET ${off_idx}",
             *base_params,
         )
     else:
@@ -127,7 +131,8 @@ async def api_task_unarchive(request: Request) -> JSONResponse:
     if not key:
         return JSONResponse({"error": "missing key"}, status_code=400)
     row = await pool.fetchrow(
-        "UPDATE tasks SET status = 'in_progress'::task_status, paused_reason = NULL WHERE external_key = $1 AND status = 'archived'::task_status RETURNING *",
+        "UPDATE tasks SET status = 'in_progress'::task_status, paused_reason = NULL"
+        " WHERE external_key = $1 AND status = 'archived'::task_status RETURNING *",
         key,
     )
     if not row:
@@ -174,8 +179,9 @@ async def api_memories(request: Request) -> JSONResponse:
     params.append(offset)
     offset_idx = idx
 
+    mem_cols = "id, category, repo, external_key, source_type, title, content, tags, created_at, metadata"
     rows = await pool.fetch(
-        f"SELECT id, category, repo, external_key, source_type, title, content, tags, created_at, metadata FROM memories {where} ORDER BY created_at DESC LIMIT ${limit_idx} OFFSET ${offset_idx}",
+        f"SELECT {mem_cols} FROM memories {where} ORDER BY created_at DESC LIMIT ${limit_idx} OFFSET ${offset_idx}",
         *params,
     )
     return JSONResponse(
@@ -283,8 +289,9 @@ async def api_memory_get(request: Request) -> JSONResponse:
     memory_id = request.path_params.get("id")
     if not memory_id:
         return JSONResponse({"error": "missing memory id"}, status_code=400)
+    mem_cols = "id, category, repo, external_key, source_type, title, content, tags, created_at, metadata"
     row = await pool.fetchrow(
-        "SELECT id, category, repo, external_key, source_type, title, content, tags, created_at, metadata FROM memories WHERE id = $1",
+        f"SELECT {mem_cols} FROM memories WHERE id = $1",
         int(memory_id),
     )
     if not row:
@@ -1090,6 +1097,7 @@ def _task(row, slack_notif=None) -> dict:
     result = {
         "id": row["id"],
         "external_key": row["external_key"],
+        "jira_key": row["external_key"],
         "source_type": row["source_type"],
         "source_url": row.get("source_url"),
         "artifacts": artifacts,


### PR DESCRIPTION
## Summary

Phase 5 migration renamed DB column and API response field from `jira_key` to `external_key`, but all skill scripts still read `jira_key` from API responses — getting empty strings, breaking triage on deployed instances.

### Changes
- **triage.py** — 7 `task.get("jira_key")` → `task.get("external_key")`
- **wrap-up.py** — API response lookup + MCP `slack_notify` parameter
- **post-pr.py** — API response lookups (lines 90, 94)
- **slack-notify.py** — MCP tool parameter
- **claim-ticket** — REST API payload field
- **memory_mcp.py** — docstring example
- **api.py** — added `jira_key` compat alias in `_task()` helper (backward compat)
- **test_wrapper.py** — updated mock data to include `external_key`

### Testing
- All 27 post-pr wrapper tests pass
- Compat alias ensures old code reading `jira_key` still works

RHCLOUD-48381