### PR TITLE
fix(triage): fall back to artifacts for PR info

### DIFF
--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -7,6 +7,7 @@ PR comments, capacity. Groups by action bucket.
 
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.parse
@@ -257,6 +258,16 @@ def enrich(task):
     repo = task.get("repo", "")
     meta = task.get("metadata") or {}
     prs_info = meta.get("prs", [])
+    if not prs_info:
+        for a in task.get("artifacts") or []:
+            if a.get("type") == "pull_request" and a.get("url"):
+                m = re.search(r"github\.com/([^/]+/[^/]+)/pull/(\d+)", a["url"])
+                if m:
+                    prs_info.append({"repo": m.group(1), "number": int(m.group(2)), "host": "github"})
+                    continue
+                m = re.search(r"gitlab[^/]*/([^/]+(?:/[^/]+)+)/-/merge_requests/(\d+)", a["url"])
+                if m:
+                    prs_info.append({"repo": m.group(1), "number": int(m.group(2)), "host": "gitlab"})
     if not prs_info and task.get("pr_number"):
         _, host = upstream_repo(repo)
         prs_info = [{"repo": repo, "number": task["pr_number"], "host": host}]


### PR DESCRIPTION
## Summary

- When tasks store PR references only in `artifacts` (new external_key schema) but not in `metadata.prs` (legacy field), triage `enrich()` couldn't find PR data — reviews like `CHANGES_REQUESTED` were invisible
- Adds fallback: parse PR URLs from `artifacts` when `metadata.prs` is empty (supports GitHub + GitLab URLs)
- Also hotfixed the fleetshift OME-160 task record in the DB to unblock immediately

Fixes RHCLOUD-48738

## Test plan

- [x] All 190 existing skill tests pass
- [x] Ruff lint + format clean
- [ ] Verify fleetshift bot sees CHANGES_REQUESTED on next triage cycle