### PR TITLE
feat(sleep-wake): add sleep wake play button to bot instance banner

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -435,6 +435,13 @@ header {
   color: var(--text-dim);
   border-color: var(--text-dim);
 }
+.bot-banner .wake-btn {
+  border: none;
+  padding: 2px 4px;
+}
+.bot-banner .wake-btn:hover {
+  background: rgba(63, 185, 80, 0.15);
+}
 
 /* Tab nav */
 .tab-nav {

--- a/dashboard/src/components/BotBanner.tsx
+++ b/dashboard/src/components/BotBanner.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import type { BotStatus } from '../types';
+import { wakeInstance } from '../api';
+import { useWS } from '../hooks/useWebSocket';
 import { timeAgo, sourceUrl, displayKey } from '../utils';
 
 interface Props {
@@ -9,6 +11,30 @@ interface Props {
 export default function BotBanner({ status }: Props) {
   const [elapsed, setElapsed] = useState('');
   const [expanded, setExpanded] = useState(false);
+  const [waking, setWaking] = useState(false);
+  const { onEvent } = useWS();
+
+  const handleWake = useCallback(async () => {
+    if (!status.instance_id) return;
+    setWaking(true);
+    try {
+      await wakeInstance(status.instance_id);
+    } catch {
+      setWaking(false);
+    }
+  }, [status.instance_id]);
+
+  useEffect(() => {
+    return onEvent((event) => {
+      if (
+        event.type === 'bot_status' &&
+        event.data.instance_id === status.instance_id &&
+        event.data.state === 'working'
+      ) {
+        setWaking(false);
+      }
+    });
+  }, [onEvent, status.instance_id]);
 
   useEffect(() => {
     if (status.state !== 'working' || !status.cycle_start) {
@@ -65,6 +91,22 @@ export default function BotBanner({ status }: Props) {
         <span className="banner-updated" title={status.updated_at}>
           {timeAgo(status.updated_at)}
         </span>
+        {status.state === 'idle' && status.instance_id && (
+          <button
+            className={`wake-btn${waking ? ' waking' : ''}`}
+            disabled={waking}
+            onClick={handleWake}
+            title="Wake bot \u2014 start next cycle immediately"
+          >
+            {waking ? (
+              'Waking\u2026'
+            ) : (
+              <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+                <path d="M0 0 L12 7 L0 14 Z" />
+              </svg>
+            )}
+          </button>
+        )}
         <button
           className="banner-toggle"
           onClick={() => setExpanded(!expanded)}


### PR DESCRIPTION
 ### Description
  
  Add wake button to the BotBanner component so operators can interrupt a sleeping bot instance from any tab page (tasks, archive, memories, etc.), not just the overview grid.

  Previously the wake button was only available on the Instances overview page. This adds it to the shared BotBanner header that appears across all instance-scoped pages, using the same wake signal API and optimistic UI pattern. The banner version is borderless to avoid visual clutter against the green idle banner border.

  RHCLOUD-48684 (https://issues.redhat.com/browse/RHCLOUD-48684)

  ---
  ### Blast radius

  - dashboard/ only — two files changed (BotBanner.tsx, App.css)
  - No backend changes; reuses existing POST /api/instances/{id}/wake endpoint from PR #266
  - No downstream repos affected — dashboard is self-contained

  ---
 ### Rollback plan

  git revert is sufficient. No database changes, no API changes, no config changes.

  ---
  ### Checklist

  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest
  
 ### AI disclosure

  Assisted by: Claude Code (Opus)