### PR TITLE
feat(presets): add manifest schema and startup validation

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,10 +1,14 @@
 """Configuration loading for the dev bot."""
 
 import json
+import logging
 import os
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
 
 
 @dataclass
@@ -82,6 +86,68 @@ def _resolve_env_vars(obj):
     if isinstance(obj, list):
         return [_resolve_env_vars(v) for v in obj]
     return obj
+
+
+def load_manifest(script_dir: Path, workflow: str) -> dict | None:
+    """Load manifest.yaml for a workflow preset. Returns None if not found."""
+    path = script_dir / "presets" / "workflows" / workflow / "manifest.yaml"
+    if not path.is_file():
+        return None
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def validate_manifest(
+    script_dir: Path,
+    workflow: str,
+    mcp_servers: dict,
+) -> None:
+    """Validate workflow manifest requirements at startup.
+
+    FATAL (sys.exit) on missing required MCP servers or env vars.
+    WARNING on missing optional env vars or absent manifest.
+    """
+    logger = logging.getLogger(__name__)
+    manifest = load_manifest(script_dir, workflow)
+    if manifest is None:
+        logger.warning("No manifest.yaml for workflow '%s' — skipping validation", workflow)
+        return
+
+    requires = manifest.get("requires", {})
+    errors: list[str] = []
+
+    # Collect all available MCP server names: bot/mcp.json + merged + persona
+    # servers are in `mcp_servers`; root .mcp.json (SDK-loaded) checked separately.
+    available_servers = set(mcp_servers.keys())
+    root_mcp = script_dir / ".mcp.json"
+    if root_mcp.is_file():
+        with open(root_mcp) as f:
+            root_data = json.load(f)
+        available_servers.update(root_data.get("mcpServers", {}).keys())
+
+    for server in requires.get("mcp_servers", []):
+        if server not in available_servers:
+            errors.append(f"Required MCP server '{server}' not configured")
+
+    for var in requires.get("env_vars", []):
+        if not os.environ.get(var):
+            errors.append(f"Required env var '{var}' not set")
+
+    if errors:
+        for err in errors:
+            logger.error("FATAL: %s", err)
+        logger.error(
+            "Workflow '%s' manifest validation failed — %d error(s). Check deployment config.",
+            workflow,
+            len(errors),
+        )
+        sys.exit(1)
+
+    for var in requires.get("optional_env_vars", []):
+        if not os.environ.get(var):
+            logger.warning("Optional env var '%s' not set", var)
+
+    logger.info("Manifest validation passed for workflow '%s'", workflow)
 
 
 # Env vars that contain secrets and must be removed before starting

--- a/bot/run.py
+++ b/bot/run.py
@@ -19,7 +19,7 @@ from dotenv import load_dotenv
 from filelock import FileLock, Timeout
 
 from .agent import run_cycle
-from .config import ALLOWED_TOOLS, Config, load_config, load_mcp_servers, sanitize_env
+from .config import ALLOWED_TOOLS, Config, load_config, load_mcp_servers, sanitize_env, validate_manifest
 from .costs import record_cost
 from .merge import apply_merged_config
 from .transcripts import record_transcript
@@ -335,6 +335,9 @@ def main() -> None:
 
     config = load_config(SCRIPT_DIR)
     mcp_servers = load_mcp_servers(SCRIPT_DIR)
+
+    workflow = os.environ.get("BOT_WORKFLOW_PRESET", "jira-sprint")
+    validate_manifest(SCRIPT_DIR, workflow, mcp_servers)
 
     # Remove secrets from env so Bash subprocesses can't leak them.
     # MCP servers already have resolved values. gh/glab use config files.

--- a/bot/tests/test_manifest.py
+++ b/bot/tests/test_manifest.py
@@ -1,0 +1,106 @@
+"""Tests for manifest loading and startup validation."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from bot.config import load_manifest, validate_manifest
+
+
+@pytest.fixture
+def tmp_preset_dir(tmp_path):
+    """Create a minimal preset directory with a jira-sprint manifest."""
+    wf_dir = tmp_path / "presets" / "workflows" / "jira-sprint"
+    wf_dir.mkdir(parents=True)
+
+    manifest = {
+        "name": "jira-sprint",
+        "type": "workflow",
+        "requires": {
+            "mcp_servers": ["bot-memory", "mcp-atlassian"],
+            "env_vars": ["BOT_LABEL", "BOT_INSTANCE_ID", "BOT_JIRA_EMAIL"],
+            "optional_env_vars": ["SLACK_WEBHOOK_URL", "BOT_BOARD_ID"],
+        },
+    }
+    (wf_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+    root_mcp = {"mcpServers": {"bot-memory": {"type": "stdio"}}}
+    (tmp_path / ".mcp.json").write_text(json.dumps(root_mcp))
+
+    return tmp_path
+
+
+class TestLoadManifest:
+    def test_loads_valid_manifest(self, tmp_preset_dir):
+        result = load_manifest(tmp_preset_dir, "jira-sprint")
+        assert result is not None
+        assert result["name"] == "jira-sprint"
+        assert "bot-memory" in result["requires"]["mcp_servers"]
+
+    def test_returns_none_for_missing(self, tmp_path):
+        result = load_manifest(tmp_path, "nonexistent")
+        assert result is None
+
+
+class TestValidateManifest:
+    def test_all_satisfied(self, tmp_preset_dir):
+        mcp_servers = {"mcp-atlassian": {"type": "stdio"}}
+        env = {
+            "BOT_LABEL": "hcc-ai-bot",
+            "BOT_INSTANCE_ID": "test-1",
+            "BOT_JIRA_EMAIL": "bot@example.com",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/x",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            validate_manifest(tmp_preset_dir, "jira-sprint", mcp_servers)
+
+    def test_missing_mcp_server_exits(self, tmp_preset_dir):
+        mcp_servers = {}
+        env = {
+            "BOT_LABEL": "hcc-ai-bot",
+            "BOT_INSTANCE_ID": "test-1",
+            "BOT_JIRA_EMAIL": "bot@example.com",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with pytest.raises(SystemExit) as exc_info:
+                validate_manifest(tmp_preset_dir, "jira-sprint", mcp_servers)
+            assert exc_info.value.code == 1
+
+    def test_missing_required_env_exits(self, tmp_preset_dir):
+        mcp_servers = {"mcp-atlassian": {"type": "stdio"}}
+        env = {"BOT_LABEL": "hcc-ai-bot", "BOT_INSTANCE_ID": "test-1"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("BOT_JIRA_EMAIL", None)
+            with pytest.raises(SystemExit) as exc_info:
+                validate_manifest(tmp_preset_dir, "jira-sprint", mcp_servers)
+            assert exc_info.value.code == 1
+
+    def test_missing_optional_env_warns(self, tmp_preset_dir, caplog):
+        mcp_servers = {"mcp-atlassian": {"type": "stdio"}}
+        env = {
+            "BOT_LABEL": "hcc-ai-bot",
+            "BOT_INSTANCE_ID": "test-1",
+            "BOT_JIRA_EMAIL": "bot@example.com",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("SLACK_WEBHOOK_URL", None)
+            os.environ.pop("BOT_BOARD_ID", None)
+            validate_manifest(tmp_preset_dir, "jira-sprint", mcp_servers)
+
+        assert "SLACK_WEBHOOK_URL" in caplog.text
+        assert "Optional" in caplog.text or "optional" in caplog.text.lower()
+
+    def test_no_manifest_degrades_gracefully(self, tmp_path, caplog):
+        (tmp_path / ".mcp.json").write_text("{}")
+        validate_manifest(tmp_path, "nonexistent", {})
+        assert "skipping validation" in caplog.text.lower()
+
+    def test_error_lists_all_failures(self, tmp_preset_dir):
+        """All missing requirements reported in one exit, not one at a time."""
+        mcp_servers = {}
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(SystemExit):
+                validate_manifest(tmp_preset_dir, "jira-sprint", mcp_servers)

--- a/presets/workflows/jira-sprint/manifest.yaml
+++ b/presets/workflows/jira-sprint/manifest.yaml
@@ -1,0 +1,31 @@
+name: jira-sprint
+type: workflow
+description: Jira sprint workflow — triage, implementation, PR maintenance
+
+shared_skills:
+  - push-and-pr
+  - post-pr
+  - auto-fork
+
+provides:
+  claude_md: CLAUDE.md
+  skills:
+    - triage
+    - new-work
+    - claim-ticket
+    - wrap-up
+
+requires:
+  mcp_servers:
+    - bot-memory
+    - mcp-atlassian
+  env_vars:
+    - BOT_LABEL
+    - BOT_INSTANCE_ID
+    - BOT_JIRA_EMAIL
+  optional_env_vars:
+    - BOT_CONFIG_REPO
+    - BOT_BOARD_ID
+    - BOT_BOARD_NAME
+    - SLACK_WEBHOOK_URL
+    - BOT_INCLUDE_BACKLOG

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "filelock",
     "httpx",
     "python-dotenv",
+    "pyyaml>=6.0",
     "zstandard>=0.23",
 ]
 
@@ -33,6 +34,7 @@ dev-bot = "bot.run:main"
 
 [tool.pytest.ini_options]
 testpaths = [
+    "bot/tests",
     ".claude/skills/auto-fork/tests",
     ".claude/skills/claim-ticket/tests",
     ".claude/skills/post-pr/tests",


### PR DESCRIPTION
## Summary

- Add `manifest.yaml` to jira-sprint workflow preset declaring required MCP servers, env vars, and optional env vars
- Add `validate_manifest()` to `bot/config.py` — checks requirements at startup, exits with clear errors on missing config
- Graceful degradation when no manifest exists (warns + continues)

Closes RHCLOUD-48697

## Test plan

- [ ] `python3 -m pytest bot/tests/test_manifest.py -v` — 8 tests covering valid, missing, and partial configs
- [ ] Existing skill tests unaffected (`python3 -m pytest .claude/skills/ -v`)
- [ ] Verify no false positives on existing deployed instances (all required env vars are already set)