### PR TITLE
feat(presets): add env preset infrastructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ COPY .claude/ .claude/
 COPY presets/ presets/
 
 # Run env preset install scripts (no-op until presets are extracted)
-RUN for script in presets/envs/*/install.sh; do [ -f "$script" ] && bash "$script"; done
+RUN bash -c 'shopt -s nullglob; for script in presets/envs/*/install.sh; do bash "$script"; done'
 
 ENV HOME=/home/botuser
 USER botuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,8 @@ COPY config.json CLAUDE.md .mcp.json entrypoint.sh ./
 COPY .claude/ .claude/
 COPY presets/ presets/
 
+# Run env preset install scripts (no-op until presets are extracted)
+RUN for script in presets/envs/*/install.sh; do [ -f "$script" ] && bash "$script"; done
 
 ENV HOME=/home/botuser
 USER botuser

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -193,5 +193,8 @@ CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f | head -1)
 # Wait for Chromium to be ready
 until curl -s http://127.0.0.1:9222/json/version > /dev/null 2>&1; do sleep 1; done
 
+# Run env preset entrypoint scripts (no-op until presets are extracted)
+for script in presets/envs/*/entrypoint.d/*.sh; do [ -f "$script" ] && bash "$script"; done
+
 echo "Credentials configured. Chromium started. Starting bot with label: ${BOT_LABEL}"
 exec uv run dev-bot --label "$BOT_LABEL"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -194,7 +194,9 @@ CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f | head -1)
 until curl -s http://127.0.0.1:9222/json/version > /dev/null 2>&1; do sleep 1; done
 
 # Run env preset entrypoint scripts (no-op until presets are extracted)
-for script in presets/envs/*/entrypoint.d/*.sh; do [ -f "$script" ] && bash "$script"; done
+shopt -s nullglob
+for script in presets/envs/*/entrypoint.d/*.sh; do bash "$script"; done
+shopt -u nullglob
 
 echo "Credentials configured. Chromium started. Starting bot with label: ${BOT_LABEL}"
 exec uv run dev-bot --label "$BOT_LABEL"


### PR DESCRIPTION
## Summary

RHCLOUD-48699

Adds the build-time and runtime infrastructure for env presets — no-ops until presets are extracted in subsequent stories (RHCLOUD-48700/48701).

- `presets/envs/` directory with `.gitkeep`
- Dockerfile: `RUN for script in presets/envs/*/install.sh` loop (runs at build time, currently no scripts to find)
- entrypoint.sh: `for script in presets/envs/*/entrypoint.d/*.sh` dispatcher (runs at startup, currently no scripts to find)

Existing hardcoded Dockerfile sections and entrypoint code are untouched. Image builds identically.

## Test plan

- [ ] `docker build` succeeds — glob finds no scripts, loop is a no-op
- [ ] Entrypoint runs without errors — glob finds no scripts, bot starts normally
- [ ] No behavioral change from current image