### PR TITLE
feat(presets): extract all env presets

### DIFF
--- a/presets/envs/browser/entrypoint.d/10-chromium.sh
+++ b/presets/envs/browser/entrypoint.d/10-chromium.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Start headless Chromium for chrome-devtools MCP
+
+# Skip if Chromium already running (idempotent during transition period)
+if curl -s http://127.0.0.1:9222/json/version > /dev/null 2>&1; then
+    echo "Chromium already running, skipping"
+    exit 0
+fi
+
+CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f | head -1)
+"$CHROME_BIN" \
+    --headless --no-sandbox --disable-gpu \
+    --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 \
+    --remote-allow-origins=* \
+    --ignore-certificate-errors \
+    --host-resolver-rules='MAP consent.trustarc.com 127.0.0.1' \
+    --proxy-server="${HTTPS_PROXY:-http://proxy:3128}" \
+    --proxy-bypass-list='*.foo.redhat.com;localhost;127.0.0.1' \
+    --no-first-run --disable-sync --disable-extensions --disable-popup-blocking &
+
+until curl -s http://127.0.0.1:9222/json/version > /dev/null 2>&1; do sleep 1; done
+echo "Chromium ready."

--- a/presets/envs/browser/install.sh
+++ b/presets/envs/browser/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Browser env preset — Chromium + Playwright + chrome-devtools MCP
+set -e
+
+# Skip if already installed (idempotent during transition period)
+if command -v chrome-devtools-mcp &>/dev/null && [ -d "${PLAYWRIGHT_BROWSERS_PATH:-/opt/pw-browsers}" ]; then
+    echo "browser preset: already installed, skipping"
+    exit 0
+fi
+
+# Chromium runtime libraries
+dnf install -y --nodocs \
+    alsa-lib atk at-spi2-atk at-spi2-core cairo cups-libs dbus-libs \
+    libdrm mesa-libgbm glib2 nspr nss pango \
+    libX11 libxcb libXcomposite libXdamage libXext libXfixes \
+    libxkbcommon libXrandr \
+    && dnf clean all
+
+# Headless Chromium via Playwright
+export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+npx playwright install chromium
+
+# chrome-devtools MCP server
+npm install -g chrome-devtools-mcp@latest

--- a/presets/envs/browser/manifest.yaml
+++ b/presets/envs/browser/manifest.yaml
@@ -10,8 +10,7 @@ provides:
   mcp_servers:
     chrome-devtools:
       type: stdio
-      command: npx
-      args: ["-y", "chrome-devtools-mcp"]
+      command: chrome-devtools-mcp
   skills:
     - gh-release-upload
 

--- a/presets/envs/browser/manifest.yaml
+++ b/presets/envs/browser/manifest.yaml
@@ -1,0 +1,20 @@
+name: browser
+type: env
+description: Chrome DevTools for visual verification and screenshot capture
+
+install: install.sh
+entrypoint_scripts:
+  - entrypoint.d/10-chromium.sh
+
+provides:
+  mcp_servers:
+    chrome-devtools:
+      type: stdio
+      command: npx
+      args: ["-y", "chrome-devtools-mcp"]
+  skills:
+    - gh-release-upload
+
+requires:
+  env_vars:
+    - PLAYWRIGHT_BROWSERS_PATH

--- a/presets/envs/browser/skills/gh-release-upload/SKILL.md
+++ b/presets/envs/browser/skills/gh-release-upload/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: gh-release-upload
+description: >
+  Upload a file to GitHub Releases via the proxy's upload endpoint.
+  Returns a stable download URL. Use instead of `gh release upload` which fails
+  through the thin client.
+when_to_use: >
+  Invoke when the bot needs to upload any file to GitHub Releases — screenshots,
+  test reports, build artifacts, etc. Triggers on: "upload screenshot", "upload file",
+  "attach image", "gh release upload", "release asset".
+user-invocable: true
+allowed-tools:
+  - "Bash(python3 .claude/skills/gh-release-upload/upload.py *)"
+  - Read
+---
+
+Upload a file to GitHub Releases:
+
+```bash
+python3 .claude/skills/gh-release-upload/upload.py <file_path> <owner/repo> [filename]
+```
+
+Arguments:
+- `file_path`: Path to the file to upload
+- `owner/repo`: GitHub repository (e.g. `RedHatInsights/insights-chrome`)
+- `filename` (optional): Override the asset filename. Defaults to the file's basename.
+
+Returns a markdown link: `![filename](url)` for images, `[filename](url)` for other files.

--- a/presets/envs/browser/skills/gh-release-upload/upload.py
+++ b/presets/envs/browser/skills/gh-release-upload/upload.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Upload a file to GitHub Releases via the proxy upload endpoint."""
+
+import json
+import mimetypes
+import os
+import sys
+import urllib.request
+
+UPLOAD_URL = os.environ.get("GH_RELEASE_UPLOAD_URL", "http://proxy:8446/upload")
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: upload.py <file_path> <owner/repo> [filename]")
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    repo = sys.argv[2]
+    filename = sys.argv[3] if len(sys.argv) > 3 else os.path.basename(file_path)
+
+    content_type, _ = mimetypes.guess_type(filename)
+    if not content_type:
+        content_type = "application/octet-stream"
+
+    with open(file_path, "rb") as f:
+        data = f.read()
+
+    req = urllib.request.Request(
+        UPLOAD_URL,
+        data=data,
+        headers={
+            "Content-Type": content_type,
+            "X-Repo": repo,
+            "X-Filename": filename,
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            result = json.loads(resp.read())
+            url = result["url"]
+            ext = os.path.splitext(filename)[1].lower()
+            if ext in IMAGE_EXTENSIONS:
+                print(f"![{filename}]({url})")
+            else:
+                print(f"[{filename}]({url})")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode() if e.fp else ""
+        print(f"ERR: {e.code} {body[:200]}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/presets/envs/container-scan/install.sh
+++ b/presets/envs/container-scan/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Container-scan env preset — grype + buildah
+set -e
+
+# Skip if already installed (idempotent during transition period)
+if command -v grype &>/dev/null && command -v buildah &>/dev/null; then
+    echo "container-scan preset: already installed, skipping"
+    exit 0
+fi
+
+# Grype (vulnerability scanner)
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.87.0_linux_${ARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin grype
+
+# Buildah (rootless container builder)
+dnf install -y --nodocs buildah fuse-overlayfs && dnf clean all

--- a/presets/envs/container-scan/manifest.yaml
+++ b/presets/envs/container-scan/manifest.yaml
@@ -1,0 +1,10 @@
+name: container-scan
+type: env
+description: Grype vulnerability scanning and Buildah container image building
+
+install: install.sh
+
+provides:
+  tools:
+    - grype
+    - buildah

--- a/presets/envs/dev-proxy/entrypoint.d/20-dev-proxy.sh
+++ b/presets/envs/dev-proxy/entrypoint.d/20-dev-proxy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Dev proxy is started on-demand by the bot via start-dev-proxy.sh,
+# not at container startup. This script just verifies availability.
+
+if ! command -v caddy &>/dev/null; then
+    echo "WARNING: caddy not found — dev-proxy will not be available"
+fi

--- a/presets/envs/dev-proxy/install.sh
+++ b/presets/envs/dev-proxy/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Dev-proxy env preset — custom Caddy for local UI verification against stage
+set -e
+
+# Skip if already installed (idempotent during transition period)
+# During transition, Caddy is built via multi-stage Dockerfile builder
+if command -v caddy &>/dev/null; then
+    echo "dev-proxy preset: caddy already installed, skipping"
+    exit 0
+fi
+
+# Build Caddy from source (for when multi-stage builder is removed)
+if [ -d /home/botuser/app/dev-proxy ]; then
+    cd /home/botuser/app/dev-proxy
+    go build -o /usr/local/bin/caddy .
+    cp Caddyfile /etc/caddy/Caddyfile
+    cp start-proxy.sh /usr/local/bin/start-dev-proxy.sh
+    chmod +x /usr/local/bin/start-dev-proxy.sh
+fi

--- a/presets/envs/dev-proxy/manifest.yaml
+++ b/presets/envs/dev-proxy/manifest.yaml
@@ -1,0 +1,21 @@
+name: dev-proxy
+type: env
+description: Custom Caddy reverse proxy for local UI verification against stage
+
+install: install.sh
+entrypoint_scripts:
+  - entrypoint.d/20-dev-proxy.sh
+
+provides:
+  tools:
+    - caddy
+  settings:
+    sandbox:
+      allowBash:
+        - "start-dev-proxy.sh"
+
+requires:
+  env_vars:
+    - PROXY_HOST
+  optional_env_vars:
+    - PROXY_PORT

--- a/presets/envs/slack/manifest.yaml
+++ b/presets/envs/slack/manifest.yaml
@@ -7,5 +7,5 @@ provides:
     - slack-notify
 
 requires:
-  optional_env_vars:
+  env_vars:
     - SLACK_WEBHOOK_URL

--- a/presets/envs/slack/manifest.yaml
+++ b/presets/envs/slack/manifest.yaml
@@ -1,0 +1,11 @@
+name: slack
+type: env
+description: Slack notifications via webhook
+
+provides:
+  skills:
+    - slack-notify
+
+requires:
+  optional_env_vars:
+    - SLACK_WEBHOOK_URL

--- a/presets/envs/slack/skills/slack-notify/SKILL.md
+++ b/presets/envs/slack/skills/slack-notify/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: slack-notify
+description: >
+  Send Slack notification. Reads SLACK_WEBHOOK_URL from env, calls memory-server
+  MCP slack_notify w/ webhook_url. No-ops if webhook not configured.
+when_to_use: >
+  Any Slack notification. Replaces direct slack_notify MCP calls.
+user-invocable: true
+allowed-tools:
+  - "Bash(python3 .claude/skills/slack-notify/slack_notify.py *)"
+---
+
+```bash
+python3 .claude/skills/slack-notify/slack_notify.py <JIRA_KEY> <EVENT_TYPE> "<MESSAGE>" 2>&1
+```
+
+Events: `pr_created`, `release_pending`, `needs_help`, `infra_error`, `review_reminder`.
+
+Msg = normal human language (NOT caveman). 1-2 sentences + links.
+
+Output: `{"sent": true/false, "reason": "..."}`. No webhook → silent no-op. 48h cooldown/ticket automatic.

--- a/presets/envs/slack/skills/slack-notify/slack_notify.py
+++ b/presets/envs/slack/skills/slack-notify/slack_notify.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Send Slack notification via memory-server MCP. Reads SLACK_WEBHOOK_URL from env.
+
+Usage:
+    python3 .claude/skills/slack-notify/slack_notify.py <jira_key> <event_type> <message>
+
+Event types: pr_created, release_pending, needs_help, infra_error, review_reminder
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from memory_mcp import memory_call, memory_cleanup
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(
+            "Usage: slack_notify.py <jira_key> <event_type> <message>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    jira_key = sys.argv[1]
+    event_type = sys.argv[2]
+    message = sys.argv[3]
+
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
+    if not webhook_url:
+        print(json.dumps({"sent": False, "reason": "SLACK_WEBHOOK_URL not set"}))
+        return
+
+    result = memory_call(
+        "slack_notify",
+        {
+            "external_key": jira_key,
+            "event_type": event_type,
+            "message": message,
+            "webhook_url": webhook_url,
+        },
+    )
+    memory_cleanup()
+
+    if result:
+        print(json.dumps(result))
+    else:
+        print(json.dumps({"sent": False, "reason": "MCP call failed"}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

RHCLOUD-48700 + RHCLOUD-48701

Extracts all four env capabilities into `presets/envs/` directories. Old hardcoded Dockerfile/entrypoint code stays untouched — presets exist alongside as the future replacement. All install scripts have idempotency guards.

### Browser preset (`presets/envs/browser/`)
- `install.sh` — Chromium libs, Playwright, chrome-devtools MCP (skips if already installed)
- `entrypoint.d/10-chromium.sh` — headless Chromium startup (skips if already running)
- `skills/gh-release-upload/` — screenshot upload skill
- `manifest.yaml` — uses globally installed `chrome-devtools-mcp` binary (not npx)

### Container-scan preset (`presets/envs/container-scan/`)
- `install.sh` — grype + buildah + fuse-overlayfs (skips if already installed)
- `manifest.yaml`

### Slack preset (`presets/envs/slack/`)
- `skills/slack-notify/` — Slack notification skill
- `manifest.yaml`

### Dev-proxy preset (`presets/envs/dev-proxy/`)
- `install.sh` — Caddy build from source (skips during transition — multi-stage builder handles it)
- `entrypoint.d/20-dev-proxy.sh` — availability check (Caddy is started on-demand, not at startup)
- `manifest.yaml`

## Test plan

- [ ] `docker build` succeeds — preset install scripts detect existing installs and skip
- [ ] Entrypoint runs without errors — scripts detect already-running services and skip
- [ ] No behavioral change from current image
- [ ] Preset directory structure matches design doc