### PR TITLE
feat(config): add instance.yaml support

### DIFF
--- a/bot/agent.py
+++ b/bot/agent.py
@@ -164,7 +164,8 @@ async def run_cycle(
     )
 
     instance_line = (
-        f' Your instance ID is: {instance_id}. Pass instance_id="{instance_id}" to ALL task tool calls (task_list, task_add, task_update, task_check_capacity, bot_status_update).'
+        f' Your instance ID is: {instance_id}. Pass instance_id="{instance_id}"'
+        f" to ALL task tool calls (task_list, task_add, task_update, task_check_capacity, bot_status_update)."
         if instance_id
         else ""
     )
@@ -245,7 +246,7 @@ async def run_cycle(
         # Extract a short summary from the result text
         if not ctx.summary and result_text:
             # Take the last meaningful line (usually the conclusion)
-            lines = [l.strip() for l in result_text.strip().splitlines() if l.strip()]
+            lines = [line.strip() for line in result_text.strip().splitlines() if line.strip()]
             if lines:
                 ctx.summary = lines[-1][:200]
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,5 +1,7 @@
 """Configuration loading for the dev bot."""
 
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -19,6 +21,99 @@ class Config:
     idle_interval: int
     cycle_timeout: int
     board_key: str
+
+
+@dataclass
+class InstanceConfig:
+    """Per-instance preset selection from instance.yaml or env var fallback."""
+
+    workflow: str = "jira-sprint"
+    source: str = "jira"
+    envs: list[str] | None = None  # None = all available, [] = none
+    claude_md_strategy: str = "ignore"  # replace / append / ignore
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> InstanceConfig:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        claude_md = data.get("claude_md")
+        strategy = claude_md.get("strategy", "ignore") if isinstance(claude_md, dict) else "ignore"
+        return cls(
+            workflow=data.get("workflow", "jira-sprint"),
+            source=data.get("source", "jira"),
+            envs=data.get("envs"),
+            claude_md_strategy=strategy,
+        )
+
+    @classmethod
+    def from_env(cls) -> InstanceConfig:
+        workflow = os.environ.get("BOT_WORKFLOW_PRESET", "jira-sprint")
+        envs_str = os.environ.get("BOT_ENV_PRESETS")
+        envs: list[str] | None = None
+        if envs_str is not None:
+            envs = [e.strip() for e in envs_str.split(",") if e.strip()]
+        return cls(workflow=workflow, envs=envs)
+
+
+def load_instance_config(remote_agent_dir: Path | None) -> InstanceConfig:
+    """Load instance.yaml from remote config, or fall back to env vars/defaults."""
+    logger = logging.getLogger(__name__)
+    if remote_agent_dir:
+        yaml_path = remote_agent_dir / "instance.yaml"
+        if yaml_path.is_file():
+            ic = InstanceConfig.from_yaml(yaml_path)
+            logger.info(
+                "Loaded instance.yaml: workflow=%s, source=%s, envs=%s",
+                ic.workflow,
+                ic.source,
+                ic.envs,
+            )
+            return ic
+
+    ic = InstanceConfig.from_env()
+    logger.info("No instance.yaml — env/defaults: workflow=%s, envs=%s", ic.workflow, ic.envs)
+    return ic
+
+
+def resolve_active_envs(script_dir: Path, instance_config: InstanceConfig) -> list[str]:
+    """Resolve which env presets are active. None = all available."""
+    if instance_config.envs is not None:
+        return list(instance_config.envs)
+    envs_dir = script_dir / "presets" / "envs"
+    if not envs_dir.is_dir():
+        return []
+    return sorted(d.name for d in envs_dir.iterdir() if d.is_dir() and d.name != ".gitkeep")
+
+
+def validate_instance_config(script_dir: Path, instance_config: InstanceConfig) -> None:
+    """Validate instance config references exist. FATAL on missing workflow, WARNING on missing env."""
+    logger = logging.getLogger(__name__)
+    presets = script_dir / "presets"
+
+    wf_dir = presets / "workflows" / instance_config.workflow
+    if not wf_dir.is_dir():
+        logger.error("FATAL: Workflow preset '%s' not found at %s", instance_config.workflow, wf_dir)
+        sys.exit(1)
+
+    if instance_config.envs is not None:
+        for env in instance_config.envs:
+            env_dir = presets / "envs" / env
+            if not env_dir.is_dir():
+                logger.warning("Env preset '%s' not found — skipping", env)
+
+    active = resolve_active_envs(script_dir, instance_config)
+    for env_name in active:
+        manifest_path = presets / "envs" / env_name / "manifest.yaml"
+        if not manifest_path.is_file():
+            continue
+        with open(manifest_path) as f:
+            manifest = yaml.safe_load(f) or {}
+        requires = manifest.get("requires", {})
+        for var in requires.get("env_vars", []):
+            if not os.environ.get(var):
+                logger.warning("Env preset '%s' requires '%s' (not set)", env_name, var)
+
+    logger.info("Instance config validated: workflow=%s, envs=%s", instance_config.workflow, active)
 
 
 def load_config(script_dir: Path) -> Config:

--- a/bot/run.py
+++ b/bot/run.py
@@ -19,7 +19,17 @@ from dotenv import load_dotenv
 from filelock import FileLock, Timeout
 
 from .agent import run_cycle
-from .config import ALLOWED_TOOLS, Config, load_config, load_mcp_servers, sanitize_env, validate_manifest
+from .config import (
+    ALLOWED_TOOLS,
+    Config,
+    InstanceConfig,
+    load_config,
+    load_instance_config,
+    load_mcp_servers,
+    sanitize_env,
+    validate_instance_config,
+    validate_manifest,
+)
 from .costs import record_cost
 from .merge import apply_merged_config
 from .transcripts import record_transcript
@@ -229,23 +239,46 @@ def _read_sleep_signal(config: Config, instance_id: str | None = None) -> int:
     return sleep_seconds
 
 
-def assemble_claude_md(script_dir: Path) -> None:
-    """Concatenate core + workflow preset CLAUDE.md into project root."""
+def assemble_claude_md(
+    script_dir: Path,
+    instance_config: InstanceConfig | None = None,
+    remote_agent_dir: Path | None = None,
+) -> None:
+    """Concatenate core + workflow preset CLAUDE.md into project root.
+
+    Supports instance CLAUDE.md via claude_md_strategy:
+      replace — core + instance CLAUDE.md (skip workflow)
+      append  — core + workflow + instance CLAUDE.md
+      ignore  — core + workflow only (default)
+    """
     logger = logging.getLogger(__name__)
     presets = script_dir / "presets"
     core = presets / "core" / "CLAUDE.md"
 
-    workflow = os.environ.get("BOT_WORKFLOW_PRESET", "jira-sprint")
-    wf_path = presets / "workflows" / workflow / "CLAUDE.md"
+    workflow = instance_config.workflow if instance_config else os.environ.get("BOT_WORKFLOW_PRESET", "jira-sprint")
+    strategy = instance_config.claude_md_strategy if instance_config else "ignore"
 
     if not core.is_file():
         logger.warning("Core CLAUDE.md not found at %s — skipping assembly", core)
         return
+
     parts = [core.read_text()]
-    if wf_path.is_file():
-        parts.append(wf_path.read_text())
+
+    instance_md = remote_agent_dir / "CLAUDE.md" if remote_agent_dir else None
+    has_instance_md = instance_md is not None and instance_md.is_file()
+
+    if strategy == "replace" and has_instance_md:
+        parts.append(instance_md.read_text())
+        logger.info("CLAUDE.md strategy=replace — using instance CLAUDE.md instead of workflow")
     else:
-        logger.warning("Workflow CLAUDE.md not found at %s — using core only", wf_path)
+        wf_path = presets / "workflows" / workflow / "CLAUDE.md"
+        if wf_path.is_file():
+            parts.append(wf_path.read_text())
+        else:
+            logger.warning("Workflow CLAUDE.md not found at %s — using core only", wf_path)
+        if strategy == "append" and has_instance_md:
+            parts.append(instance_md.read_text())
+            logger.info("CLAUDE.md strategy=append — appended instance CLAUDE.md")
 
     output = script_dir / "CLAUDE.md"
     output.write_text("".join(parts))
@@ -336,8 +369,15 @@ def main() -> None:
     config = load_config(SCRIPT_DIR)
     mcp_servers = load_mcp_servers(SCRIPT_DIR)
 
-    workflow = os.environ.get("BOT_WORKFLOW_PRESET", "jira-sprint")
-    validate_manifest(SCRIPT_DIR, workflow, mcp_servers)
+    # Initial config sync + instance config load (before validation so
+    # instance.yaml can override the workflow preset)
+    initial_agent_dir = sync_config_repo()
+    if initial_agent_dir:
+        apply_merged_config(SCRIPT_DIR, initial_agent_dir)
+    instance_config = load_instance_config(initial_agent_dir)
+
+    validate_manifest(SCRIPT_DIR, instance_config.workflow, mcp_servers)
+    validate_instance_config(SCRIPT_DIR, instance_config)
 
     # Remove secrets from env so Bash subprocesses can't leak them.
     # MCP servers already have resolved values. gh/glab use config files.
@@ -375,7 +415,8 @@ def main() -> None:
             if remote_agent_dir:
                 apply_merged_config(SCRIPT_DIR, remote_agent_dir)
 
-            assemble_claude_md(SCRIPT_DIR)
+            instance_config = load_instance_config(remote_agent_dir)
+            assemble_claude_md(SCRIPT_DIR, instance_config, remote_agent_dir)
 
             logger.info("Running agent cycle...")
 

--- a/bot/tests/test_instance_config.py
+++ b/bot/tests/test_instance_config.py
@@ -1,0 +1,187 @@
+"""Tests for instance.yaml loading, env var fallback, and validation."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from bot.config import InstanceConfig, load_instance_config, resolve_active_envs, validate_instance_config
+
+
+@pytest.fixture
+def preset_tree(tmp_path):
+    """Minimal preset tree with workflow + env presets."""
+    wf = tmp_path / "presets" / "workflows" / "jira-sprint"
+    wf.mkdir(parents=True)
+    (wf / "CLAUDE.md").write_text("# Jira Sprint Workflow\n")
+
+    for env_name, manifest in [
+        ("browser", {"name": "browser", "requires": {"env_vars": ["PLAYWRIGHT_BROWSERS_PATH"]}}),
+        ("slack", {"name": "slack", "requires": {"env_vars": ["SLACK_WEBHOOK_URL"]}}),
+        ("container-scan", {"name": "container-scan"}),
+    ]:
+        d = tmp_path / "presets" / "envs" / env_name
+        d.mkdir(parents=True)
+        (d / "manifest.yaml").write_text(yaml.dump(manifest))
+
+    return tmp_path
+
+
+@pytest.fixture
+def agent_dir(tmp_path):
+    """Remote agent dir with instance.yaml."""
+    d = tmp_path / "agent"
+    d.mkdir()
+    return d
+
+
+class TestInstanceConfigFromYaml:
+    def test_full_config(self, agent_dir):
+        (agent_dir / "instance.yaml").write_text(
+            yaml.dump(
+                {
+                    "workflow": "reviewer",
+                    "source": "github",
+                    "envs": ["browser"],
+                    "claude_md": {"strategy": "append"},
+                }
+            )
+        )
+        ic = InstanceConfig.from_yaml(agent_dir / "instance.yaml")
+        assert ic.workflow == "reviewer"
+        assert ic.source == "github"
+        assert ic.envs == ["browser"]
+        assert ic.claude_md_strategy == "append"
+
+    def test_minimal_config(self, agent_dir):
+        (agent_dir / "instance.yaml").write_text("workflow: jira-sprint\n")
+        ic = InstanceConfig.from_yaml(agent_dir / "instance.yaml")
+        assert ic.workflow == "jira-sprint"
+        assert ic.source == "jira"
+        assert ic.envs is None
+        assert ic.claude_md_strategy == "ignore"
+
+    def test_empty_envs(self, agent_dir):
+        (agent_dir / "instance.yaml").write_text(yaml.dump({"workflow": "jira-sprint", "envs": []}))
+        ic = InstanceConfig.from_yaml(agent_dir / "instance.yaml")
+        assert ic.envs == []
+
+    def test_empty_file(self, agent_dir):
+        (agent_dir / "instance.yaml").write_text("")
+        ic = InstanceConfig.from_yaml(agent_dir / "instance.yaml")
+        assert ic.workflow == "jira-sprint"
+        assert ic.envs is None
+
+    def test_replace_strategy(self, agent_dir):
+        (agent_dir / "instance.yaml").write_text(yaml.dump({"claude_md": {"strategy": "replace"}}))
+        ic = InstanceConfig.from_yaml(agent_dir / "instance.yaml")
+        assert ic.claude_md_strategy == "replace"
+
+
+class TestInstanceConfigFromEnv:
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            ic = InstanceConfig.from_env()
+        assert ic.workflow == "jira-sprint"
+        assert ic.envs is None
+
+    def test_custom_workflow(self):
+        with patch.dict(os.environ, {"BOT_WORKFLOW_PRESET": "reviewer"}, clear=True):
+            ic = InstanceConfig.from_env()
+        assert ic.workflow == "reviewer"
+
+    def test_env_presets_list(self):
+        with patch.dict(os.environ, {"BOT_ENV_PRESETS": "browser,slack"}, clear=True):
+            ic = InstanceConfig.from_env()
+        assert ic.envs == ["browser", "slack"]
+
+    def test_env_presets_empty_string(self):
+        with patch.dict(os.environ, {"BOT_ENV_PRESETS": ""}, clear=True):
+            ic = InstanceConfig.from_env()
+        assert ic.envs == []
+
+    def test_env_presets_with_spaces(self):
+        with patch.dict(os.environ, {"BOT_ENV_PRESETS": " browser , slack "}, clear=True):
+            ic = InstanceConfig.from_env()
+        assert ic.envs == ["browser", "slack"]
+
+
+class TestLoadInstanceConfig:
+    def test_from_yaml(self, agent_dir):
+        (agent_dir / "instance.yaml").write_text(yaml.dump({"workflow": "reviewer", "envs": ["browser"]}))
+        ic = load_instance_config(agent_dir)
+        assert ic.workflow == "reviewer"
+        assert ic.envs == ["browser"]
+
+    def test_no_yaml_falls_back_to_env(self, agent_dir):
+        with patch.dict(os.environ, {"BOT_WORKFLOW_PRESET": "kanban"}, clear=True):
+            ic = load_instance_config(agent_dir)
+        assert ic.workflow == "kanban"
+
+    def test_no_agent_dir(self):
+        with patch.dict(os.environ, {}, clear=True):
+            ic = load_instance_config(None)
+        assert ic.workflow == "jira-sprint"
+        assert ic.envs is None
+
+
+class TestResolveActiveEnvs:
+    def test_explicit_list(self, preset_tree):
+        ic = InstanceConfig(envs=["browser", "slack"])
+        assert resolve_active_envs(preset_tree, ic) == ["browser", "slack"]
+
+    def test_none_returns_all(self, preset_tree):
+        ic = InstanceConfig(envs=None)
+        result = resolve_active_envs(preset_tree, ic)
+        assert "browser" in result
+        assert "slack" in result
+        assert "container-scan" in result
+
+    def test_empty_list(self, preset_tree):
+        ic = InstanceConfig(envs=[])
+        assert resolve_active_envs(preset_tree, ic) == []
+
+    def test_no_envs_dir(self, tmp_path):
+        (tmp_path / "presets" / "workflows" / "jira-sprint").mkdir(parents=True)
+        ic = InstanceConfig(envs=None)
+        assert resolve_active_envs(tmp_path, ic) == []
+
+
+class TestValidateInstanceConfig:
+    def test_valid_config(self, preset_tree):
+        ic = InstanceConfig(envs=["browser"])
+        env = {"PLAYWRIGHT_BROWSERS_PATH": "/opt/pw"}
+        with patch.dict(os.environ, env, clear=False):
+            validate_instance_config(preset_tree, ic)
+
+    def test_missing_workflow_exits(self, preset_tree):
+        ic = InstanceConfig(workflow="nonexistent")
+        with pytest.raises(SystemExit) as exc_info:
+            validate_instance_config(preset_tree, ic)
+        assert exc_info.value.code == 1
+
+    def test_missing_env_preset_warns(self, preset_tree, caplog):
+        ic = InstanceConfig(envs=["browser", "nonexistent"])
+        env = {"PLAYWRIGHT_BROWSERS_PATH": "/opt/pw"}
+        with patch.dict(os.environ, env, clear=False):
+            validate_instance_config(preset_tree, ic)
+        assert "nonexistent" in caplog.text
+        assert "not found" in caplog.text
+
+    def test_missing_env_var_warns(self, preset_tree, caplog):
+        ic = InstanceConfig(envs=["slack"])
+        with patch.dict(os.environ, {}, clear=True):
+            validate_instance_config(preset_tree, ic)
+        assert "SLACK_WEBHOOK_URL" in caplog.text
+
+    def test_all_envs_default(self, preset_tree, caplog):
+        import logging
+
+        ic = InstanceConfig(envs=None)
+        env = {"PLAYWRIGHT_BROWSERS_PATH": "/opt/pw", "SLACK_WEBHOOK_URL": "https://hooks.slack.com/x"}
+        with caplog.at_level(logging.INFO):
+            with patch.dict(os.environ, env, clear=False):
+                validate_instance_config(preset_tree, ic)
+        assert "browser" in caplog.text
+        assert "container-scan" in caplog.text


### PR DESCRIPTION
## Summary

RHCLOUD-48702

Adds `instance.yaml` support to `run.py` for per-instance workflow and env preset selection.

- `InstanceConfig` dataclass — parses `instance.yaml` from config repos
- Env var fallback: `BOT_WORKFLOW_PRESET` + `BOT_ENV_PRESETS` for instances without config repo
- `resolve_active_envs()` — `None` = all available, `[]` = none, `["browser"]` = explicit
- `validate_instance_config()` — FATAL on missing workflow, WARNING on missing env preset
- CLAUDE.md strategy support: `replace` / `append` / `ignore` (default)
- Initial config sync moved before startup validation so instance.yaml overrides take effect
- Also fixes two pre-existing ruff errors in `agent.py`

**Fully backward compatible** — no `instance.yaml` = defaults = current behavior (jira-sprint + all envs).

## Test plan

- [x] 22 new tests in `test_instance_config.py` — all pass
- [x] 8 existing tests in `test_manifest.py` — still pass
- [x] `ruff check bot/` — clean