### PR TITLE
fix(runner): add env preset install loop

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -152,6 +152,7 @@ ENV BUILDAH_ISOLATION=chroot
 COPY dev-bot/config.json dev-bot/CLAUDE.md dev-bot/.mcp.json dev-bot/entrypoint.sh ./
 COPY dev-bot/.claude/ .claude/
 COPY dev-bot/presets/ presets/
+RUN bash -c 'shopt -s nullglob; for script in presets/envs/*/install.sh; do bash "$script"; done'
 
 ENV HOME=/home/botuser
 USER botuser


### PR DESCRIPTION
## Summary

Adds the env preset install loop to `Dockerfile.runner`, matching what the main `Dockerfile` already has.

```dockerfile
RUN bash -c 'shopt -s nullglob; for script in presets/envs/*/install.sh; do bash "$script"; done'
```

Currently a no-op since the hardcoded installs (Chromium, grype, buildah, caddy, chrome-devtools-mcp) are still in the Dockerfile and the install scripts are idempotent (skip if already installed). But this is required for RHCLOUD-48705 when we remove the hardcoded steps — the preset install loop will take over.

Bug ticket: RHCLOUD-48795

## Test plan
- [ ] Konflux build passes (scripts detect existing tools and skip)
- [ ] No regression — existing instances still work as before