### PR TITLE
fix(triage): handle qualified repo names from artifacts

### DIFF
--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -284,7 +284,10 @@ def enrich(task):
         )
         if not pr_num:
             continue
-        up, dh = upstream_repo(pr_repo)
+        if "/" in pr_repo:
+            up, dh = pr_repo, pr_host or "github"
+        else:
+            up, dh = upstream_repo(pr_repo)
         host = pr_host or dh
 
         if host == "github" and up:


### PR DESCRIPTION
## Summary

Fixes a bug where triage classifies tasks with unaddressed PR feedback as CLEAN when the PR info comes from task artifacts instead of `metadata.prs`.

### Root cause

When PR info is extracted from artifacts (e.g. URL `https://github.com/project-kessel/inventory-api/pull/1385`), the repo is already fully qualified (`project-kessel/inventory-api`). But `upstream_repo()` only matches bare names from `project-repos.json` (e.g. `inventory-api`), so it returns empty string. This causes `gh_pr_comments()` to silently fail, returning 0 comments, and triage marks the task as CLEAN even when there's unaddressed feedback.

### Fix

Skip `upstream_repo()` lookup when the repo string already contains `/` — it's already in `owner/repo` format and can be used directly.

### Impact

Affected the kessel bot instance — RHCLOUD-42184 had unaddressed review feedback from snehagunta (June 25) and Adam0Brien (June 30) that was being ignored for 5+ days.