### PR TITLE
feat(presets): add node, go, patternfly-mcp env presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An autonomous developer agent that picks groomed Jira tickets, implements them, 
 | [Setup](SETUP.md) | Local development setup and configuration |
 | [Operations](OPERATIONS.md) | Production operations, monitoring, troubleshooting |
 | [Onboarding a New Instance](docs/onboarding-new-instance.md) | Step-by-step guide for adding a new bot instance |
+| [Presets](docs/presets/README.md) | Preset system — env presets (node, go, browser...) and workflow presets |
 | [Scheduling](docs/scheduling.md) | KEDA cron scaling for bot instances (business hours only) |
 
 ## Prerequisites

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -1,0 +1,121 @@
+# Presets
+
+Presets are the modular building blocks that define what a bot instance can do. Each instance selects presets in its `instance.yaml` to configure its workflow and capabilities.
+
+## Quick Start
+
+In your instance repo at `instance/<your-config>/agent/instance.yaml`:
+
+```yaml
+workflow: jira-sprint        # The bot's decision loop (required)
+source: jira                 # Ticket source
+envs:                        # Tools and runtimes to install (pick what you need)
+  - node                     # Node.js via nvm (version switching)
+  - go                       # Go via goenv (version switching)
+  - browser                  # Chromium for visual verification
+  - slack                    # Slack notifications
+  - container-scan           # Grype + Buildah for CVE scanning
+```
+
+The bot reads this file at startup and activates only the selected presets.
+
+## Preset Types
+
+| Type | What it does | How many |
+|------|-------------|----------|
+| [**Workflow**](workflows.md) | Defines the bot's decision loop — triage, implement, PR maintenance | Exactly 1 per instance |
+| [**Env**](envs.md) | Adds tools, runtimes, MCP servers — Node.js, Go, browser, scanning | 0 or more per instance |
+
+## How Instances Use Presets
+
+All presets live in the core `dev-bot` repo (your submodule) under `presets/`. You don't copy preset files — you just reference them by name in `instance.yaml`.
+
+```
+your-bot-instance/                      # Your instance repo
+├── dev-bot/                            # Git submodule (this repo)
+│   └── presets/
+│       ├── workflows/jira-sprint/      # Workflow preset
+│       ├── envs/node/                  # Env presets
+│       ├── envs/go/
+│       ├── envs/browser/
+│       └── ...
+├── instance/<your-config>/agent/
+│   ├── instance.yaml                   # ← Your preset selection goes here
+│   ├── project-repos.json
+│   ├── mcp.json
+│   └── personas/
+└── setup.sh
+```
+
+### What Each Field Does
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `workflow` | string | `jira-sprint` | Which workflow preset to use. Must match a directory under `presets/workflows/`. |
+| `source` | string | `jira` | Ticket source. Currently only `jira`. |
+| `envs` | list | `null` | Env presets to activate. `null`/omitted = all available. `[]` = none. |
+
+### Choosing Env Presets
+
+List only the presets your instance actually needs:
+
+- **Frontend repos** (React/TypeScript): `node`, `browser`, `patternfly-mcp`, `slack`
+- **Backend repos** (Go): `go`, `container-scan`, `slack`
+- **Mixed repos**: `node`, `go`, `browser`, `slack`, `container-scan`
+- **Config-only repos** (app-interface): `slack`
+
+Unused presets waste Docker build time and image size. The `node` and `go` presets install version managers and compilers — skip them if your repos don't need them.
+
+## Preset Reference
+
+| Env Preset | What it installs | When you need it |
+|------------|-----------------|------------------|
+| [`node`](envs.md#node) | nvm + Node.js 22 LTS + npm/npx | Frontend repos, any repo with `package.json` |
+| [`go`](envs.md#go) | goenv + Go 1.24/1.25 + golangci-lint | Go repos, any repo with `go.mod` |
+| [`patternfly-mcp`](envs.md#patternfly-mcp) | PatternFly component guidance MCP server | Frontend repos using PatternFly (requires `node`) |
+| [`browser`](envs.md#browser) | Chromium + chrome-devtools MCP | UI repos needing visual verification/screenshots |
+| [`container-scan`](envs.md#container-scan) | Grype + Buildah | CVE scanning, container image analysis |
+| [`dev-proxy`](envs.md#dev-proxy) | Caddy reverse proxy | Local UI verification against stage environments |
+| [`slack`](envs.md#slack) | Slack notification skill | Any instance wanting Slack alerts |
+
+| Workflow | Description |
+|----------|-------------|
+| [`jira-sprint`](workflows.md#jira-sprint) | Full autonomous loop: Jira triage → implement → PR → maintain |
+
+## Real-World Examples
+
+Here are actual instance configurations from deployed bots:
+
+**Frontend instance** (hcc-ui-agent-dev) — works on React/PatternFly UI repos:
+```yaml
+workflow: jira-sprint
+source: jira
+envs:
+  - slack
+  - container-scan
+  - browser
+```
+
+**Backend instance** (fleetshift-bot-instance) — works on Go services:
+```yaml
+workflow: jira-sprint
+source: jira
+envs:
+  - slack
+  - container-scan
+```
+
+**Full-stack instance** (test-preset-instance) — works on both frontend and backend:
+```yaml
+workflow: jira-sprint
+source: jira
+envs:
+  - node
+  - go
+  - patternfly-mcp
+```
+
+## Related Docs
+
+- [Onboarding a new instance](../onboarding-new-instance.md) — full setup guide including presets
+- [Presets design doc](../presets-design.md) — architecture decisions and rationale

--- a/docs/presets/envs.md
+++ b/docs/presets/envs.md
@@ -1,0 +1,208 @@
+# Env Presets
+
+Env presets add tools, runtimes, and capabilities to your bot instance. Each preset is a self-contained package under `presets/envs/<name>/` in the dev-bot repo.
+
+## Using Env Presets
+
+Add preset names to the `envs` list in your `instance.yaml`:
+
+```yaml
+# instance/<your-config>/agent/instance.yaml
+workflow: jira-sprint
+source: jira
+envs:
+  - node          # nvm + Node.js
+  - go            # goenv + Go
+  - browser       # Chromium + chrome-devtools MCP
+  - slack         # Slack notifications
+```
+
+Presets are installed during `docker build` — their `install.sh` scripts run automatically. No runtime setup needed.
+
+---
+
+## node
+
+**Path**: `presets/envs/node/`
+
+Installs [nvm](https://github.com/nvm-sh/nvm) (Node Version Manager) with Node.js 22 LTS as the default. The bot can switch versions per-repo at runtime.
+
+**What gets installed**:
+- nvm v0.40.3 at `/usr/local/nvm`
+- Node.js 22 (LTS) as default
+- `node`, `npm`, `npx` symlinked to `/usr/local/bin/`
+- Shell init via `/etc/profile.d/nvm.sh`
+
+**When to use**: Any instance working on repos with `package.json` — frontend, Node.js backends, monorepos.
+
+**Version switching** (the bot does this automatically if a repo needs a different version):
+```bash
+nvm install 20    # install Node 20
+nvm use 20        # switch to it
+```
+
+**Depends on**: nothing
+
+---
+
+## go
+
+**Path**: `presets/envs/go/`
+
+Installs [goenv](https://github.com/go-nv/goenv) (Go version manager) with Go 1.24.2 and 1.25.7, plus golangci-lint.
+
+**What gets installed**:
+- goenv at `/usr/local/goenv`
+- Go 1.24.2 (default) and 1.25.7
+- golangci-lint v2.1.6
+- `go`, `gofmt`, `golangci-lint` symlinked to `/usr/local/bin/`
+- Shell init via `/etc/profile.d/goenv.sh`
+
+**When to use**: Any instance working on repos with `go.mod` — Go services, operators, CLI tools.
+
+**Version switching**:
+```bash
+goenv install 1.23.0    # install a specific version
+goenv global 1.23.0     # set as default
+```
+
+**Depends on**: nothing
+
+---
+
+## patternfly-mcp
+
+**Path**: `presets/envs/patternfly-mcp/`
+
+Installs the [hcc-pf-mcp](https://www.npmjs.com/package/@redhat-cloud-services/hcc-pf-mcp) MCP server, which gives the bot PatternFly component guidance — available components, props, examples, and CSS utilities.
+
+**What gets installed**:
+- `@redhat-cloud-services/hcc-pf-mcp` (npm global package)
+- Registered as the `hcc-patternfly-data-view` MCP server
+
+**When to use**: Frontend instances working on PatternFly-based UIs. Helps the bot use correct PF components and patterns.
+
+**Depends on**: `node` preset (needs npm)
+
+```yaml
+envs:
+  - node              # must come before patternfly-mcp
+  - patternfly-mcp
+```
+
+---
+
+## browser
+
+**Path**: `presets/envs/browser/`
+
+Installs Chromium and the chrome-devtools MCP server for visual verification. The bot can take screenshots, inspect the DOM, and verify UI changes in a real browser.
+
+**What gets installed**:
+- Chromium (via Playwright)
+- `chrome-devtools-mcp` MCP server
+- `gh-release-upload` skill (for uploading screenshots to PR comments)
+- Runtime init script at `entrypoint.d/10-chromium.sh`
+
+**When to use**: Any instance working on UI repos where visual verification matters. The bot starts a dev server, navigates to the relevant page, and takes screenshots.
+
+**Requires env var**: `PLAYWRIGHT_BROWSERS_PATH` (set automatically in the container)
+
+**Depends on**: nothing
+
+---
+
+## container-scan
+
+**Path**: `presets/envs/container-scan/`
+
+Installs Grype (vulnerability scanner) and Buildah (container image builder) for CVE investigation and scanning.
+
+**What gets installed**:
+- [Grype](https://github.com/anchore/grype) — scans container images for known vulnerabilities
+- [Buildah](https://github.com/containers/buildah) — builds container images without Docker daemon
+
+**When to use**: Instances handling CVE tickets or security scanning. The bot builds the Dockerfile, scans the image, and reports findings.
+
+**Depends on**: nothing
+
+---
+
+## dev-proxy
+
+**Path**: `presets/envs/dev-proxy/`
+
+Installs a custom Caddy reverse proxy for verifying frontend changes against stage environments.
+
+**What gets installed**:
+- Custom Caddy build with HCC-specific modules
+- `start-dev-proxy.sh` script
+- Runtime init script at `entrypoint.d/20-dev-proxy.sh`
+
+**When to use**: Frontend instances that need to verify UI changes against a running stage deployment (e.g. console.redhat.com stage).
+
+**Requires env var**: `PROXY_HOST` (the stage hostname to proxy to)
+
+**Depends on**: nothing
+
+---
+
+## slack
+
+**Path**: `presets/envs/slack/`
+
+Adds the Slack notification skill. The bot sends alerts when PRs are created, tickets are blocked, or infrastructure errors occur. 48-hour cooldown per ticket prevents spam.
+
+**What gets installed**:
+- `slack-notify` skill
+
+**When to use**: Any instance where the team wants Slack notifications about bot activity.
+
+**Requires env var**: `SLACK_WEBHOOK_URL` (Slack incoming webhook URL)
+
+**Depends on**: nothing
+
+---
+
+## Creating a New Env Preset
+
+1. Create `presets/envs/<name>/` in the dev-bot repo
+2. Add `install.sh` — must be idempotent (detect existing installs and skip):
+   ```bash
+   #!/bin/bash
+   # presets/envs/my-tool/install.sh
+   set -e
+   if command -v my-tool &>/dev/null; then
+       echo "my-tool preset: already installed, skipping"
+       exit 0
+   fi
+   # ... install logic ...
+   ```
+3. Add `manifest.yaml`:
+   ```yaml
+   name: my-tool
+   type: env
+   description: What this preset adds
+
+   install: install.sh
+
+   provides:
+     binaries:
+       - my-tool
+
+   requires:
+     presets:
+       - node           # if it depends on another preset
+     env_vars:
+       - MY_REQUIRED_VAR
+   ```
+4. Test: build a Docker image, run `my-tool --version` inside it
+5. Add to your `instance.yaml` `envs:` list
+6. Open a PR against dev-bot
+
+Install scripts run during `docker build` via the loop in `Dockerfile.runner` (line 155):
+```dockerfile
+RUN for script in presets/envs/*/install.sh; do bash "$script"; done
+```
+
+They run as root and must be idempotent — the Docker layer cache means they may run multiple times during development.

--- a/docs/presets/workflows.md
+++ b/docs/presets/workflows.md
@@ -1,0 +1,134 @@
+# Workflow Presets
+
+A workflow preset defines what the bot does each cycle — its decision loop. Every instance has exactly one workflow, set in `instance.yaml`.
+
+```yaml
+# instance/<your-config>/agent/instance.yaml
+workflow: jira-sprint     # ← this selects the workflow
+source: jira
+envs:
+  - ...
+```
+
+Currently there is one workflow. The system is designed for future alternatives (review-only, visual QA, monitoring).
+
+---
+
+## jira-sprint
+
+**Path**: `presets/workflows/jira-sprint/`
+
+The default and currently only workflow. Implements the full autonomous development loop:
+
+```
+Preflight → Triage → PR Maintenance → New Work → Implement → Open PR → Maintain
+```
+
+### What It Does Each Cycle
+
+1. **Preflight** (no AI tokens) — Python scripts check PR statuses, Jira comments, and capacity. If nothing is actionable, the cycle ends without starting a Claude session.
+
+2. **Triage** — classify active tasks into buckets:
+   - MERGED — PR merged, ready for wrap-up
+   - CI FAILING — tests broken, needs fix
+   - CONFLICTS — merge conflicts, needs rebase
+   - FEEDBACK — unaddressed review comments or Jira comments
+   - CLEAN — nothing to do
+
+3. **PR maintenance** (Priority 0-1) — address feedback, fix CI, resolve conflicts, wrap up merged PRs
+
+4. **New work** (Priority 2) — only when everything is clean:
+   - Search Jira sprint for unassigned tickets with the bot's label
+   - Claim ticket, create branch, implement, test, open PR
+
+### Preflight Scripts
+
+These run before each Claude session to avoid burning tokens on idle cycles:
+
+| Script | Path | What it checks |
+|--------|------|---------------|
+| `01-gh-pr-status.py` | `presets/workflows/jira-sprint/preflight/` | GitHub PR states — CI, conflicts, reviews |
+| `02-gl-mr-status.py` | `presets/workflows/jira-sprint/preflight/` | GitLab MR states — pipelines, threads |
+| `03-jira-triage.py` | `presets/workflows/jira-sprint/preflight/` | Jira comments on active tasks |
+| `04-find-work.py` | `presets/workflows/jira-sprint/preflight/` | New Jira candidates if capacity available |
+
+Each outputs `{"status": "start"|"skip", "content": "..."}`. If all return `skip`, no Claude session starts — the cycle sleeps.
+
+### Skills Included
+
+| Skill | Purpose |
+|-------|---------|
+| `triage` | Task classification and prioritization |
+| `new-work` | Jira candidate search (3-tier: sprint → backlog → all) |
+| `claim-ticket` | Ticket assignment + sprint placement |
+| `wrap-up` | Post-merge cleanup (archival, Jira transition, branch deletion) |
+| `push-and-pr` | Push branch and open PR with template detection |
+| `post-pr` | Post-PR Jira comment, linked issue updates, Slack notification |
+| `auto-fork` | Fork creation for new repos |
+
+### Required Configuration
+
+Your instance needs these env vars set in the deploy template:
+
+| Env Var | Description | Example |
+|---------|-------------|---------|
+| `BOT_LABEL` | Jira label for ticket filtering | `hcc-ai-framework` |
+| `BOT_INSTANCE_ID` | Unique instance identifier | `Framework Bot` |
+| `BOT_JIRA_EMAIL` | Email for Jira ticket assignment | `bot@company.com` |
+
+These MCP servers must be available (typically via the shared proxy):
+
+| MCP Server | Description |
+|------------|-------------|
+| `bot-memory` | Task tracking, RAG memory, cycle progress |
+| `mcp-atlassian` | Jira API access |
+
+### Optional Configuration
+
+| Env Var | Description | Default |
+|---------|-------------|---------|
+| `BOT_BOARD_ID` or `BOT_BOARD_NAME` | Jira board for sprint assignment | Skip sprint assignment |
+| `BOT_SPRINT_PREFIX` | Sprint name filter (e.g. `"Framework"`) | No filter |
+| `BOT_INCLUDE_BACKLOG` | Include backlog tickets in search | `false` |
+| `SLACK_WEBHOOK_URL` | Slack webhook for notifications | No notifications |
+
+### Directory Structure
+
+```
+presets/workflows/jira-sprint/
+├── CLAUDE.md              # Decision loop instructions (the bot's "brain")
+├── manifest.yaml          # Metadata — preflight list, skills, requirements
+├── skills/                # Workflow-specific skills
+│   ├── triage/
+│   │   └── triage.py
+│   ├── new-work/
+│   │   └── new_work.py
+│   ├── claim-ticket/
+│   │   └── claim_ticket.py
+│   └── wrap-up/
+│       └── wrap_up.py
+├── preflight/             # Pre-session scripts
+│   ├── 01-gh-pr-status.py
+│   ├── 02-gl-mr-status.py
+│   ├── 03-jira-triage.py
+│   └── 04-find-work.py
+└── personas/              # Tech-stack guidelines
+    ├── frontend/prompt.md
+    ├── backend/prompt.md
+    ├── config/prompt.md
+    ├── tooling/prompt.md
+    └── cve/prompt.md
+```
+
+### Instance Personas Override
+
+Your instance can override or extend personas by placing them in your config repo:
+
+```
+instance/<your-config>/agent/
+└── personas/
+    └── frontend/
+        └── prompt.md      # Your custom frontend guidelines
+```
+
+Instance personas take precedence over the workflow's built-in personas for the same name.

--- a/presets/envs/go/install.sh
+++ b/presets/envs/go/install.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Go env preset — goenv (go-nv) + default Go versions + golangci-lint
+set -e
+
+export GOENV_ROOT="${GOENV_ROOT:-/usr/local/goenv}"
+
+# Skip if already installed (idempotent during transition period)
+if [ -d "$GOENV_ROOT" ] && command -v go &>/dev/null && command -v golangci-lint &>/dev/null; then
+    echo "go preset: already installed ($(go version)), skipping"
+    exit 0
+fi
+
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+
+# Install goenv
+if [ ! -d "$GOENV_ROOT" ]; then
+    git clone --depth 1 https://github.com/go-nv/goenv.git "$GOENV_ROOT"
+fi
+
+# Add goenv to PATH for this script
+export PATH="$GOENV_ROOT/bin:$PATH"
+eval "$(goenv init -)"
+
+# Pre-install default Go versions
+GOVERSIONS="${GOVERSIONS:-1.24.2 1.25.7}"
+DEFAULT=$(echo $GOVERSIONS | awk '{print $1}')
+for v in $GOVERSIONS; do
+    if goenv versions --bare 2>/dev/null | grep -q "^${v}$"; then
+        echo "Go ${v} already installed, skipping"
+        continue
+    fi
+    echo "Installing Go ${v}..."
+    goenv install "${v}"
+done
+
+# Set default (global) version
+goenv global "${DEFAULT}"
+
+# Add goenv init to profile so interactive shells get goenv
+cat > /etc/profile.d/goenv.sh << 'PROFILE'
+export GOENV_ROOT="/usr/local/goenv"
+export PATH="$GOENV_ROOT/bin:$PATH"
+eval "$(goenv init -)"
+PROFILE
+
+# Symlink go to /usr/local/bin for non-interactive shells
+GO_BIN="$(goenv prefix)/bin/go"
+if [ -f "$GO_BIN" ]; then
+    ln -sf "$GO_BIN" /usr/local/bin/go
+    ln -sf "$(goenv prefix)/bin/gofmt" /usr/local/bin/gofmt
+fi
+
+# golangci-lint
+if ! command -v golangci-lint &>/dev/null; then
+    curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-linux-${ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/golangci-lint'
+fi

--- a/presets/envs/go/manifest.yaml
+++ b/presets/envs/go/manifest.yaml
@@ -1,0 +1,15 @@
+name: go
+type: env
+description: Go via goenv (version manager) + golangci-lint — switch versions with goenv install/global
+
+install: install.sh
+
+provides:
+  binaries:
+    - go
+    - goenv
+    - golangci-lint
+
+env_vars:
+  GOENV_ROOT: "/usr/local/goenv"
+  GOPATH: "/home/botuser/go"

--- a/presets/envs/node/install.sh
+++ b/presets/envs/node/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Node.js env preset — nvm + Node.js 22 LTS
+set -e
+
+export NVM_DIR="${NVM_DIR:-/usr/local/nvm}"
+
+# Skip if already installed (idempotent during transition period)
+if [ -s "$NVM_DIR/nvm.sh" ] && command -v node &>/dev/null; then
+    echo "node preset: already installed ($(node --version)), skipping"
+    exit 0
+fi
+
+# Install nvm
+mkdir -p "$NVM_DIR"
+curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+
+# Source nvm and install default Node version
+. "$NVM_DIR/nvm.sh"
+nvm install 22
+nvm alias default 22
+nvm use default
+
+# Make node/npm available system-wide (symlink for non-interactive shells)
+NODE_PATH=$(nvm which current)
+NODE_DIR=$(dirname "$NODE_PATH")
+ln -sf "$NODE_DIR/node" /usr/local/bin/node
+ln -sf "$NODE_DIR/npm" /usr/local/bin/npm
+ln -sf "$NODE_DIR/npx" /usr/local/bin/npx
+
+# Add nvm init to profile so interactive shells get nvm
+cat > /etc/profile.d/nvm.sh << 'PROFILE'
+export NVM_DIR="/usr/local/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+PROFILE

--- a/presets/envs/node/manifest.yaml
+++ b/presets/envs/node/manifest.yaml
@@ -1,0 +1,15 @@
+name: node
+type: env
+description: Node.js via nvm (version manager) — switch versions with nvm use/install
+
+install: install.sh
+
+provides:
+  binaries:
+    - node
+    - npm
+    - npx
+    - nvm
+
+env_vars:
+  NVM_DIR: "/usr/local/nvm"

--- a/presets/envs/patternfly-mcp/install.sh
+++ b/presets/envs/patternfly-mcp/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# PatternFly MCP env preset — hcc-pf-mcp server for PatternFly component guidance
+set -e
+
+# Skip if already installed (idempotent during transition period)
+if npm list -g @redhat-cloud-services/hcc-pf-mcp &>/dev/null 2>&1; then
+    echo "patternfly-mcp preset: already installed, skipping"
+    exit 0
+fi
+
+# Requires node preset (npm must be available)
+if ! command -v npm &>/dev/null; then
+    echo "ERROR: patternfly-mcp preset requires node preset (npm not found)" >&2
+    exit 1
+fi
+
+npm install -g @redhat-cloud-services/hcc-pf-mcp

--- a/presets/envs/patternfly-mcp/manifest.yaml
+++ b/presets/envs/patternfly-mcp/manifest.yaml
@@ -1,0 +1,15 @@
+name: patternfly-mcp
+type: env
+description: PatternFly component guidance MCP server
+
+install: install.sh
+
+requires:
+  presets:
+    - node
+
+provides:
+  mcp_servers:
+    hcc-patternfly-data-view:
+      type: stdio
+      command: hcc-patternfly-data-view


### PR DESCRIPTION
## Summary

- Add three new env presets for modular toolchain installation (RHCLOUD-48895)
- **node**: nvm + Node.js 22 LTS — bot can switch versions with `nvm install/use`
- **go**: goenv + Go 1.24.2/1.25.7 + golangci-lint — bot can switch with `goenv install/global`
- **patternfly-mcp**: hcc-pf-mcp MCP server (depends on node preset)
- All presets are idempotent and coexist with existing hardcoded installs during transition

## Test plan

- [x] Docker build succeeds with all three presets
- [x] Node, Go, golangci-lint, hcc-pf-mcp verified working inside container
- [ ] Instance repos add presets to their `instance.yaml` envs list