### PR TITLE
fix(preflight): review_comment bucketing bypass

### DIFF
--- a/bot/tests/test_preflight_shared.py
+++ b/bot/tests/test_preflight_shared.py
@@ -190,6 +190,51 @@ def test_classify_gh_review_comment():
     assert any("review_comment" in i for i in issues)
 
 
+def test_review_comment_not_unconditional_feedback():
+    """review_comment: should NOT trigger unconditional feedback bucketing.
+
+    It must fall through to has_new_feedback() which checks timestamps and bot authors.
+    """
+    issues = ["review_comment:coderabbitai[bot]"]
+    unconditional = any(i in ("changes_requested",) or i.startswith("review:") for i in issues)
+    assert unconditional is False, "review_comment: must not match unconditional feedback check"
+
+
+def test_review_comment_bot_old_is_clean():
+    """PR with only an old bot review_comment should be CLEAN, not FEEDBACK."""
+    enriched = {
+        "task": {"last_addressed": "2026-07-01T10:00"},
+        "issues": ["review_comment:coderabbitai[bot]"],
+        "pr_comments": [{"a": "coderabbitai[bot]", "t": "2026-07-01T08:00", "b": "auto review"}],
+        "prs": [],
+    }
+    issues = enriched["issues"]
+    unconditional = any(i in ("changes_requested",) or i.startswith("review:") for i in issues)
+    assert unconditional is False
+    assert has_new_feedback(enriched) is False
+
+
+def test_review_comment_human_new_is_feedback():
+    """PR with a new human review_comment should be FEEDBACK via has_new_feedback."""
+    enriched = {
+        "task": {"last_addressed": "2026-06-30T10:00"},
+        "issues": ["review_comment:reviewer"],
+        "pr_comments": [{"a": "reviewer", "t": "2026-07-01T10:00", "b": "please fix this"}],
+        "prs": [],
+    }
+    issues = enriched["issues"]
+    unconditional = any(i in ("changes_requested",) or i.startswith("review:") for i in issues)
+    assert unconditional is False
+    assert has_new_feedback(enriched) is True
+
+
+def test_changes_requested_still_unconditional():
+    """changes_requested and review: should still be unconditional feedback."""
+    for issue in ["changes_requested", "review:someuser"]:
+        unconditional = any(i in ("changes_requested",) or i.startswith("review:") for i in [issue])
+        assert unconditional is True, f"{issue} should be unconditional feedback"
+
+
 # --- classify_gl ---
 
 

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -207,9 +207,7 @@ def main():
             ci_fail.append(e)
         elif "conflict" in issues:
             conflict.append(e)
-        elif any(
-            i in ("changes_requested",) or i.startswith("review:") or i.startswith("review_comment:") for i in issues
-        ):
+        elif any(i in ("changes_requested",) or i.startswith("review:") for i in issues):
             feedback.append(e)
         elif has_new_feedback(e):
             feedback.append(e)


### PR DESCRIPTION
## Summary

- `review_comment:` was included in the unconditional feedback check in `gh_pr_status.py`, causing bot review comments (e.g. coderabbitai[bot]) that were already addressed to falsely trigger a `start` result
- Now `review_comment:` falls through to `has_new_feedback()` which properly checks timestamps and filters bot authors via `is_bot_author()`
- Added 4 tests covering: unconditional check exclusion, old bot comment → CLEAN, new human comment → FEEDBACK, and `changes_requested`/`review:` still unconditional

## Test plan

- [x] All 37 preflight tests pass
- [x] Lint clean on changed files