### PR TITLE
fix(runner): reduce skill sleep from 3600s to 300s

### DIFF
--- a/.claude/skills/new-work/new_work.py
+++ b/.claude/skills/new-work/new_work.py
@@ -196,7 +196,7 @@ def main():
     if not candidates:
         print("NO CANDIDATES FOUND")
         SLEEP_FILE.parent.mkdir(parents=True, exist_ok=True)
-        SLEEP_FILE.write_text(json.dumps({"recommended_sleep": 3600, "reason": "no_eligible_work"}))
+        SLEEP_FILE.write_text(json.dumps({"recommended_sleep": 300, "reason": "no_eligible_work"}))
         return
 
     print(f"NEW WORK CANDIDATES ({len(candidates)})")

--- a/.claude/skills/triage/triage.py
+++ b/.claude/skills/triage/triage.py
@@ -557,7 +557,7 @@ def main():
         print("-> all clean -> Priority 2")
         if active_n >= max_n:
             SLEEP_FILE.parent.mkdir(parents=True, exist_ok=True)
-            SLEEP_FILE.write_text(json.dumps({"recommended_sleep": 3600, "reason": "at_capacity_all_clean"}))
+            SLEEP_FILE.write_text(json.dumps({"recommended_sleep": 300, "reason": "at_capacity_all_clean"}))
     else:
         print(f"-> {total} task(s) need work. Top bucket first. ONE/cycle.")
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -124,7 +124,7 @@ def load_config(script_dir: Path) -> Config:
         model=raw["claude"]["model"],
         max_turns=raw["claude"]["maxTurns"],
         interval=raw["polling"]["intervalSeconds"],
-        idle_interval=raw["polling"].get("idleIntervalSeconds", 3600),
+        idle_interval=raw["polling"].get("idleIntervalSeconds", 300),
         cycle_timeout=raw["claude"].get("cycleTimeoutSeconds", 1800),
         board_key=raw["jira"]["boardKey"],
     )

--- a/presets/workflows/jira-sprint/CLAUDE.md
+++ b/presets/workflows/jira-sprint/CLAUDE.md
@@ -11,8 +11,8 @@ ONE item per cycle. Priority order:
 - Error: `error`, "<what went wrong>"
 
 **Sleep signaling**: Skills write `data/cycle-sleep.json` to tell the Python runner how long to sleep. The agent does NOT need to manage this — it's automatic:
-- `/triage` writes `recommended_sleep: 3600` when at capacity + all tasks clean (nothing actionable)
-- `/new-work` writes `recommended_sleep: 3600` when no eligible candidates found
+- `/triage` writes `recommended_sleep: 300` when at capacity + all tasks clean (nothing actionable)
+- `/new-work` writes `recommended_sleep: 300` when no eligible candidates found
 - No signal file = standard 300s sleep (work was done)
 - The runner reads and deletes the file after each cycle
 


### PR DESCRIPTION
## Summary

- Reduce sleep signal from triage and new-work skills from 3600s to 300s
- Update `idle_interval` default in config.py from 3600 to 300
- Update workflow CLAUDE.md docs to match

With preflight scripts now handling idle cycle detection (0 tokens), the 1-hour sleep written by skills is excessive. When a Claude session does start, it means preflight decided there's work — so the standard 300s interval is appropriate for the next cycle.

## Files changed

- `.claude/skills/triage/triage.py` — 3600 → 300
- `.claude/skills/new-work/new_work.py` — 3600 → 300
- `bot/config.py` — idle_interval default 3600 → 300
- `presets/workflows/jira-sprint/CLAUDE.md` — docs updated