### PR TITLE
fix(deploy): zero-downtime rollout strategy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,6 +60,11 @@ objects:
       app.kubernetes.io/part-of: devbot
   spec:
     replicas: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
     selector:
       matchLabels:
         app.kubernetes.io/name: memory-server
@@ -187,6 +192,11 @@ objects:
       app.kubernetes.io/part-of: devbot
   spec:
     replicas: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
     selector:
       matchLabels:
         app.kubernetes.io/name: ${PROXY_NAME}


### PR DESCRIPTION
## Summary
- Set `maxUnavailable: 0` + `maxSurge: 1` on both memory-server and proxy deployments
- Old pod stays alive until new pod passes health checks — no downtime window during rollouts
- Fixes bot disruptions caused by memory-server being unavailable during image pulls

## Test plan
- [ ] Deploy to stage, trigger a rollout (merge any change)
- [ ] Verify old pod stays Running until new pod is Ready
- [ ] Verify no bot errors during rollout window

🤖 Generated with [Claude Code](https://claude.com/claude-code)