### PR TITLE
fix(preflight): search new work with active clean tasks

### DIFF
--- a/bot/tests/test_jira_sprint_preflight.py
+++ b/bot/tests/test_jira_sprint_preflight.py
@@ -149,7 +149,8 @@ def test_active_with_feedback_returns_start(env_vars, monkeypatch, capsys):
     assert "JIRA FEEDBACK" in out["content"]
 
 
-def test_active_all_clean_returns_skip(env_vars, monkeypatch, capsys):
+def test_active_all_clean_no_candidates_returns_skip(env_vars, monkeypatch, capsys):
+    """Active tasks all Jira-clean, falls through to Phase 2, no candidates → skip."""
     tasks = _mock_tasks(
         active=[
             {
@@ -172,12 +173,64 @@ def test_active_all_clean_returns_skip(env_vars, monkeypatch, capsys):
     monkeypatch.setattr("jira_sprint_preflight.get_tasks", lambda: tasks)
     monkeypatch.setattr("jira_sprint_preflight.get_capacity", lambda: (1, 10))
     monkeypatch.setattr("jira_sprint_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_sprint_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_sprint_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_sprint_preflight._get_candidates", lambda rl: [])
     monkeypatch.setattr("jira_sprint_preflight.jira_cleanup", lambda: None)
 
     main()
     out = json.loads(capsys.readouterr().out.strip())
     assert out["status"] == "skip"
-    assert "CLEAN" in out["content"]
+    assert "No eligible work" in out["content"]
+
+
+def test_active_all_clean_with_candidates_returns_start(env_vars, monkeypatch, capsys):
+    """Active tasks all Jira-clean but capacity + candidates → start (the bug fix)."""
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "TEST-3",
+                "status": "pr_open",
+                "repo": "my-repo",
+                "last_addressed": "2026-07-01T12:00:00",
+                "metadata": {"prs": [{"repo": "my-repo", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "Code Review"},
+            "labels": [],
+            "issuelinks": [],
+            "comment": {"comments": []},
+        }
+    }
+    candidates = [
+        {
+            "key": "TEST-99",
+            "summary": "New feature",
+            "status": "New",
+            "priority": "High",
+            "type": "Story",
+            "labels": ["hcc-ai-test", "repo:my-repo"],
+            "repos": ["my-repo"],
+            "description": "Build it",
+            "comments": [],
+            "links": [],
+        }
+    ]
+    monkeypatch.setattr("jira_sprint_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_sprint_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_sprint_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_sprint_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_sprint_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_sprint_preflight._get_candidates", lambda rl: candidates)
+    monkeypatch.setattr("jira_sprint_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "TEST-99" in out["content"]
 
 
 def test_at_capacity_investigation_only(env_vars, monkeypatch, capsys):

--- a/presets/shared/preflight/jira_sprint_preflight.py
+++ b/presets/shared/preflight/jira_sprint_preflight.py
@@ -3,9 +3,10 @@
 Single script replacing the former 03-jira-triage + 04-find-work split.
 Returns start only when there's genuinely actionable work:
   - Active tasks with Jira feedback or interrupted work → start
+  - Active tasks all clean + capacity + new candidates → start
   - No active tasks + new candidates found → start
   - No active tasks + no candidates → skip
-  - Active tasks, all Jira-clean → skip (PR status scripts handle CI/reviews)
+  - Active tasks, all Jira-clean, no capacity or no candidates → skip
 """
 
 import os
@@ -312,14 +313,11 @@ def main():
             jira_cleanup()
             return
 
-        # Active tasks but all Jira-clean — PR status scripts handle CI/reviews
-        save_state({"jira": {"feedback": 0, "interrupted": 0}})
-        output_result("skip", "\n".join(lines))
-        jira_cleanup()
-        return
+        # Active tasks but all Jira-clean — still search for new work if capacity allows
 
-    # Phase 2: No active tasks — include done/paused info, then search for new work
-    lines.append("No active tasks")
+    # Phase 2: Search for new work candidates (capacity permitting)
+    if not active:
+        lines.append("No active tasks")
     if done:
         lines.append(f"done pending archival: {','.join(t.get('external_key', '?') for t in done)}")
     if paused:


### PR DESCRIPTION
## Summary
- Jira-sprint preflight previously returned `skip` immediately when all active tasks were Jira-clean
- This meant the bot never searched for new work candidates while it had any active tasks
- Now it falls through to candidate search when there's capacity, even with active clean tasks
- Fixes RHCLOUD-48935 and similar tickets not being picked up

## Test plan
- [ ] Run preflight in pod with active clean tasks — verify new candidates appear
- [ ] Verify `start` returned when candidates found
- [ ] Verify `skip` still returned when no candidates + all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)