### PR TITLE
fix(preflight): filter stale reviews and repo-less candidates

### DIFF
--- a/bot/tests/test_gh_pr_status.py
+++ b/bot/tests/test_gh_pr_status.py
@@ -1,0 +1,146 @@
+"""Tests for gh_pr_status preflight."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
+sys.path.insert(0, str(SHARED_DIR))
+
+from gh_pr_status import classify_gh  # noqa: E402
+
+
+# --- classify_gh ---
+
+
+def _make_pr(state="OPEN", mergeable="MERGEABLE", reviews=None, checks=None, review_decision=None):
+    pr = {"state": state, "mergeable": mergeable, "reviews": reviews or [], "statusCheckRollup": checks or []}
+    if review_decision:
+        pr["reviewDecision"] = review_decision
+    return pr
+
+
+def test_merged():
+    state, issues = classify_gh(_make_pr(state="MERGED"))
+    assert state == "MERGED"
+    assert issues == ["merged"]
+
+
+def test_closed():
+    state, issues = classify_gh(_make_pr(state="CLOSED"))
+    assert state == "CLOSED"
+    assert issues == ["closed"]
+
+
+def test_conflict():
+    state, issues = classify_gh(_make_pr(mergeable="CONFLICTING"))
+    assert "conflict" in issues
+
+
+def test_ci_failure():
+    checks = [{"name": "lint", "conclusion": "FAILURE"}]
+    state, issues = classify_gh(_make_pr(checks=checks))
+    assert "ci_fail:lint" in issues
+
+
+def test_changes_requested_review():
+    reviews = [{"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T10:00:00Z"}]
+    state, issues = classify_gh(_make_pr(reviews=reviews))
+    assert "review:alice" in issues
+
+
+def test_commented_review_with_body():
+    reviews = [
+        {
+            "state": "COMMENTED",
+            "author": {"login": "bob"},
+            "body": "This needs a much longer explanation of the approach",
+            "submittedAt": "2026-07-03T10:00:00Z",
+        }
+    ]
+    state, issues = classify_gh(_make_pr(reviews=reviews))
+    assert "review_comment:bob" in issues
+
+
+def test_commented_review_short_body_ignored():
+    reviews = [
+        {"state": "COMMENTED", "author": {"login": "bob"}, "body": "LGTM", "submittedAt": "2026-07-03T10:00:00Z"}
+    ]
+    state, issues = classify_gh(_make_pr(reviews=reviews))
+    assert not any(i.startswith("review") for i in issues)
+
+
+def test_clean_pr():
+    state, issues = classify_gh(_make_pr())
+    assert state == "OPEN"
+    assert issues == []
+
+
+# --- last_addressed filtering ---
+
+
+def test_old_review_before_last_addressed_ignored():
+    """Reviews submitted before last_addressed should not trigger FEEDBACK."""
+    reviews = [
+        {
+            "state": "CHANGES_REQUESTED",
+            "author": {"login": "coderabbitai"},
+            "submittedAt": "2026-06-30T10:00:00Z",
+        }
+    ]
+    state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="2026-07-03T07:37:00+00:00")
+    assert "review:coderabbitai" not in issues
+    assert issues == []
+
+
+def test_new_review_after_last_addressed_kept():
+    """Reviews submitted after last_addressed should still trigger."""
+    reviews = [
+        {"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T09:00:00Z"}
+    ]
+    state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="2026-07-03T07:37:00+00:00")
+    assert "review:alice" in issues
+
+
+def test_no_last_addressed_keeps_all_reviews():
+    """Without last_addressed, all reviews should be considered."""
+    reviews = [
+        {"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-06-20T10:00:00Z"}
+    ]
+    state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="")
+    assert "review:alice" in issues
+
+
+def test_mixed_old_and_new_reviews():
+    """Only new reviews should trigger, old ones filtered out."""
+    reviews = [
+        {
+            "state": "CHANGES_REQUESTED",
+            "author": {"login": "coderabbitai"},
+            "submittedAt": "2026-06-28T10:00:00Z",
+        },
+        {"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T09:00:00Z"},
+    ]
+    state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="2026-07-03T07:37:00+00:00")
+    assert "review:coderabbitai" not in issues
+    assert "review:alice" in issues
+
+
+def test_review_at_exact_last_addressed_ignored():
+    """Review at exactly last_addressed timestamp should be ignored (already seen)."""
+    reviews = [
+        {"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T07:37:00Z"}
+    ]
+    state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="2026-07-03T07:37:00+00:00")
+    assert "review:alice" not in issues
+
+
+def test_conflict_and_ci_not_affected_by_last_addressed():
+    """Conflicts and CI failures are current-state, not affected by last_addressed."""
+    checks = [{"name": "lint", "conclusion": "FAILURE"}]
+    state, issues = classify_gh(
+        _make_pr(mergeable="CONFLICTING", checks=checks), last_addressed="2026-07-03T07:37:00+00:00"
+    )
+    assert "conflict" in issues
+    assert "ci_fail:lint" in issues

--- a/bot/tests/test_gh_pr_status.py
+++ b/bot/tests/test_gh_pr_status.py
@@ -96,18 +96,14 @@ def test_old_review_before_last_addressed_ignored():
 
 def test_new_review_after_last_addressed_kept():
     """Reviews submitted after last_addressed should still trigger."""
-    reviews = [
-        {"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T09:00:00Z"}
-    ]
+    reviews = [{"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T09:00:00Z"}]
     state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="2026-07-03T07:37:00+00:00")
     assert "review:alice" in issues
 
 
 def test_no_last_addressed_keeps_all_reviews():
     """Without last_addressed, all reviews should be considered."""
-    reviews = [
-        {"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-06-20T10:00:00Z"}
-    ]
+    reviews = [{"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-06-20T10:00:00Z"}]
     state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="")
     assert "review:alice" in issues
 
@@ -129,9 +125,7 @@ def test_mixed_old_and_new_reviews():
 
 def test_review_at_exact_last_addressed_ignored():
     """Review at exactly last_addressed timestamp should be ignored (already seen)."""
-    reviews = [
-        {"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T07:37:00Z"}
-    ]
+    reviews = [{"state": "CHANGES_REQUESTED", "author": {"login": "alice"}, "submittedAt": "2026-07-03T07:37:00Z"}]
     state, issues = classify_gh(_make_pr(reviews=reviews), last_addressed="2026-07-03T07:37:00+00:00")
     assert "review:alice" not in issues
 

--- a/bot/tests/test_jira_sprint_preflight.py
+++ b/bot/tests/test_jira_sprint_preflight.py
@@ -277,6 +277,79 @@ def test_at_capacity_no_investigations_returns_skip(env_vars, monkeypatch, capsy
     assert "capacity" in out["content"].lower()
 
 
+def test_candidates_without_repo_labels_returns_skip(env_vars, monkeypatch, capsys):
+    """Candidates exist but none have repo: labels → skip (the RHCLOUD-48805 fix)."""
+    tasks = _mock_tasks()
+    candidates = [
+        {
+            "key": "RHCLOUD-48805",
+            "summary": "No repo label ticket",
+            "status": "New",
+            "priority": "Major",
+            "type": "Story",
+            "labels": ["hcc-ai-framework"],
+            "repos": [],
+            "description": "Missing repo label",
+            "comments": [],
+            "links": [],
+        }
+    ]
+    monkeypatch.setattr("jira_sprint_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_sprint_preflight.get_capacity", lambda: (0, 10))
+    monkeypatch.setattr("jira_sprint_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_sprint_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_sprint_preflight._get_candidates", lambda rl: candidates)
+    monkeypatch.setattr("jira_sprint_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "skip"
+    assert "lack repo: labels" in out["content"]
+
+
+def test_mixed_candidates_only_starts_with_repos(env_vars, monkeypatch, capsys):
+    """Mix of candidates with and without repos → start, but only shows those with repos."""
+    tasks = _mock_tasks()
+    candidates = [
+        {
+            "key": "TEST-10",
+            "summary": "Has repo",
+            "status": "New",
+            "priority": "High",
+            "type": "Bug",
+            "labels": ["hcc-ai-test", "repo:my-repo"],
+            "repos": ["my-repo"],
+            "description": "Fix it",
+            "comments": [],
+            "links": [],
+        },
+        {
+            "key": "TEST-11",
+            "summary": "No repo",
+            "status": "New",
+            "priority": "Major",
+            "type": "Story",
+            "labels": ["hcc-ai-test"],
+            "repos": [],
+            "description": "Missing label",
+            "comments": [],
+            "links": [],
+        },
+    ]
+    monkeypatch.setattr("jira_sprint_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_sprint_preflight.get_capacity", lambda: (0, 10))
+    monkeypatch.setattr("jira_sprint_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_sprint_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_sprint_preflight._get_candidates", lambda rl: candidates)
+    monkeypatch.setattr("jira_sprint_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "TEST-10" in out["content"]
+    assert "1 with matching repos, 1 without" in out["content"]
+
+
 def test_missing_instance_id_returns_error(monkeypatch, capsys):
     monkeypatch.setattr("jira_sprint_preflight.INSTANCE_ID", "")
 

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -69,8 +69,12 @@ def gh_pr_comments(owner_repo, num):
     return comments
 
 
-def classify_gh(pr):
-    """Classify a GH PR into (state, issues_list)."""
+def classify_gh(pr, last_addressed=""):
+    """Classify a GH PR into (state, issues_list).
+
+    Reviews submitted before last_addressed are ignored — the bot already
+    handled them in a prior cycle.
+    """
     state = pr.get("state", "UNKNOWN")
     if state == "MERGED":
         return "MERGED", ["merged"]
@@ -85,8 +89,12 @@ def classify_gh(pr):
         issues.append(f"ci_fail:{','.join(failed)}")
     if pr.get("reviewDecision") == "CHANGES_REQUESTED":
         issues.append("changes_requested")
+    last_prefix = last_addressed[:16] if last_addressed else ""
     for rv in pr.get("reviews") or []:
         rstate = rv.get("state", "")
+        submitted = (rv.get("submittedAt") or "")[:16]
+        if last_prefix and submitted and submitted <= last_prefix:
+            continue
         author = rv.get("author", {}).get("login", "?")
         if rstate == "CHANGES_REQUESTED":
             issues.append(f"review:{author}")
@@ -118,7 +126,7 @@ def enrich_gh(task):
         data = gh_pr(up, pr_num)
         if not data:
             continue
-        state, issues = classify_gh(data)
+        state, issues = classify_gh(data, last_addressed=task.get("last_addressed", ""))
         pr_results.append(
             {
                 "repo": pr_repo,

--- a/presets/shared/preflight/jira_sprint_preflight.py
+++ b/presets/shared/preflight/jira_sprint_preflight.py
@@ -348,23 +348,28 @@ def main():
     candidates = _get_candidates(repo_lookup)
     jira_cleanup()
 
-    if not candidates:
-        lines.append("No eligible work candidates in sprint/backlog")
+    with_repos = [c for c in candidates if c["repos"]]
+    without_repos = [c for c in candidates if not c["repos"]]
+
+    if not with_repos:
+        if without_repos:
+            lines.append(f"No eligible work — {len(without_repos)} candidate(s) lack repo: labels")
+            for c in without_repos:
+                lines.append(f"  {c['key']}: {c['summary']} (no repo: label)")
+        else:
+            lines.append("No eligible work candidates in sprint/backlog")
         save_state({"jira": {"feedback": 0, "interrupted": 0}})
         output_result("skip", "\n".join(lines))
         return
 
-    lines.append(f"### New Work Candidates ({len(candidates)})")
+    lines.append(f"### New Work Candidates ({len(with_repos)})")
     lines.append("")
-    for c in candidates:
+    for c in with_repos:
         lines.append(_fmt_candidate(c))
         lines.append("")
 
-    with_repos = [c for c in candidates if c["repos"]]
-    without_repos = [c for c in candidates if not c["repos"]]
     lines.append(f"-> {len(with_repos)} with matching repos, {len(without_repos)} without")
-    if with_repos:
-        lines.append(f"-> Top pick: {with_repos[0]['key']} repos={','.join(with_repos[0]['repos'])}")
+    lines.append(f"-> Top pick: {with_repos[0]['key']} repos={','.join(with_repos[0]['repos'])}")
 
     save_state({"jira": {"feedback": 0, "interrupted": 0}})
     output_result("start", "\n".join(lines))


### PR DESCRIPTION
## Summary

Two preflight bugs causing wasted Claude sessions:

- **GH PR preflight (`gh_pr_status.py`)**: `classify_gh()` checked all reviews regardless of timestamp — old bot reviews (e.g. coderabbitai `CHANGES_REQUESTED` from days ago) kept triggering `FEEDBACK` classification every cycle even though `last_addressed` was current. Fix: skip reviews submitted at or before `last_addressed`.

- **Jira sprint preflight (`jira_sprint_preflight.py`)**: Returned `start` when candidates existed but none had `repo:` labels (e.g. RHCLOUD-48805). The bot can't act on tickets without repo labels. Fix: only return `start` if candidates have matching repos.

## Test plan

- [x] 14 new tests for `classify_gh` including `last_addressed` filtering
- [x] 2 new tests for jira sprint preflight repo-label filtering
- [x] All 30 tests pass (`test_gh_pr_status.py` + `test_jira_sprint_preflight.py`)
- [x] Hotpatched kessel pod — verified preflight no longer triggers on stale coderabbitai reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)