### PR TITLE
fix(config): support relative workflow paths from instance config

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -75,6 +75,19 @@ def load_instance_config(remote_agent_dir: Path | None) -> InstanceConfig:
     return ic
 
 
+def resolve_workflow_dir(
+    script_dir: Path,
+    workflow: str,
+    remote_agent_dir: Path | None = None,
+) -> Path:
+    """Resolve workflow directory. './' prefix = relative to remote agent dir."""
+    if workflow.startswith("./"):
+        if remote_agent_dir is None:
+            raise SystemExit(f"Workflow '{workflow}' uses relative path but no remote config available")
+        return remote_agent_dir / workflow[2:]
+    return script_dir / "presets" / "workflows" / workflow
+
+
 def resolve_active_envs(script_dir: Path, instance_config: InstanceConfig) -> list[str]:
     """Resolve which env presets are active. None = all available."""
     if instance_config.envs is not None:
@@ -85,16 +98,20 @@ def resolve_active_envs(script_dir: Path, instance_config: InstanceConfig) -> li
     return sorted(d.name for d in envs_dir.iterdir() if d.is_dir() and d.name != ".gitkeep")
 
 
-def validate_instance_config(script_dir: Path, instance_config: InstanceConfig) -> None:
+def validate_instance_config(
+    script_dir: Path,
+    instance_config: InstanceConfig,
+    remote_agent_dir: Path | None = None,
+) -> None:
     """Validate instance config references exist. FATAL on missing workflow, WARNING on missing env."""
     logger = logging.getLogger(__name__)
-    presets = script_dir / "presets"
 
-    wf_dir = presets / "workflows" / instance_config.workflow
+    wf_dir = resolve_workflow_dir(script_dir, instance_config.workflow, remote_agent_dir)
     if not wf_dir.is_dir():
         logger.error("FATAL: Workflow preset '%s' not found at %s", instance_config.workflow, wf_dir)
         sys.exit(1)
 
+    presets = script_dir / "presets"
     if instance_config.envs is not None:
         for env in instance_config.envs:
             env_dir = presets / "envs" / env
@@ -183,9 +200,13 @@ def _resolve_env_vars(obj):
     return obj
 
 
-def load_manifest(script_dir: Path, workflow: str) -> dict | None:
+def load_manifest(
+    script_dir: Path,
+    workflow: str,
+    remote_agent_dir: Path | None = None,
+) -> dict | None:
     """Load manifest.yaml for a workflow preset. Returns None if not found."""
-    path = script_dir / "presets" / "workflows" / workflow / "manifest.yaml"
+    path = resolve_workflow_dir(script_dir, workflow, remote_agent_dir) / "manifest.yaml"
     if not path.is_file():
         return None
     with open(path) as f:
@@ -196,6 +217,7 @@ def validate_manifest(
     script_dir: Path,
     workflow: str,
     mcp_servers: dict,
+    remote_agent_dir: Path | None = None,
 ) -> None:
     """Validate workflow manifest requirements at startup.
 
@@ -203,7 +225,7 @@ def validate_manifest(
     WARNING on missing optional env vars or absent manifest.
     """
     logger = logging.getLogger(__name__)
-    manifest = load_manifest(script_dir, workflow)
+    manifest = load_manifest(script_dir, workflow, remote_agent_dir)
     if manifest is None:
         logger.warning("No manifest.yaml for workflow '%s' — skipping validation", workflow)
         return

--- a/bot/preflight.py
+++ b/bot/preflight.py
@@ -46,7 +46,9 @@ def discover_preflight_scripts(
     """Find preflight scripts from workflow preset + instance config, sorted by name."""
     scripts: list[Path] = []
 
-    workflow_preflight = script_dir / "presets" / "workflows" / workflow / "preflight"
+    from .config import resolve_workflow_dir
+
+    workflow_preflight = resolve_workflow_dir(script_dir, workflow, remote_agent_dir) / "preflight"
     if workflow_preflight.is_dir():
         scripts.extend(sorted(f for f in workflow_preflight.iterdir() if f.suffix == ".py" and f.is_file()))
 

--- a/bot/run.py
+++ b/bot/run.py
@@ -26,6 +26,7 @@ from .config import (
     load_config,
     load_instance_config,
     load_mcp_servers,
+    resolve_workflow_dir,
     sanitize_env,
     validate_instance_config,
     validate_manifest,
@@ -278,7 +279,7 @@ def assemble_claude_md(
         parts.append(instance_md.read_text())
         logger.info("CLAUDE.md strategy=replace — using instance CLAUDE.md instead of workflow")
     else:
-        wf_path = presets / "workflows" / workflow / "CLAUDE.md"
+        wf_path = resolve_workflow_dir(script_dir, workflow, remote_agent_dir) / "CLAUDE.md"
         if wf_path.is_file():
             parts.append(wf_path.read_text())
         else:
@@ -383,8 +384,8 @@ def main() -> None:
         apply_merged_config(SCRIPT_DIR, initial_agent_dir)
     instance_config = load_instance_config(initial_agent_dir)
 
-    validate_manifest(SCRIPT_DIR, instance_config.workflow, mcp_servers)
-    validate_instance_config(SCRIPT_DIR, instance_config)
+    validate_manifest(SCRIPT_DIR, instance_config.workflow, mcp_servers, initial_agent_dir)
+    validate_instance_config(SCRIPT_DIR, instance_config, initial_agent_dir)
 
     # Remove secrets from env so Bash subprocesses can't leak them.
     # MCP servers already have resolved values. gh/glab use config files.


### PR DESCRIPTION
## Summary

- Implements the `./` prefix for workflow paths in `instance.yaml`, as specified in the presets design doc (`docs/presets-design.md` line 330)
- `workflow: ./workflows/watchduty` resolves relative to the instance config's agent dir (cloned from `BOT_CONFIG_REPO`)
- `workflow: jira-sprint` continues to resolve from `presets/workflows/` as before (no change for existing instances)
- Adds `resolve_workflow_dir()` helper and threads it through all 4 resolution sites: validation, manifest loading, CLAUDE.md assembly, and preflight discovery

## Why

Instance repos that define custom workflows (e.g. obsint-processing's `watchduty`) currently have no supported way to make the bot find them. The design doc specifies `./` prefix for this, but it was never implemented. The obsint team worked around this with a `setup.sh` hack that symlinks instance workflows into `presets/workflows/` at container startup.

## Test plan

- [ ] Existing tests pass (107/107)
- [ ] `workflow: jira-sprint` still works (no behavioral change for current instances)
- [ ] `workflow: ./workflows/watchduty` resolves to `<remote_agent_dir>/workflows/watchduty/`
- [ ] `./` path with no config repo exits with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)