### PR TITLE
docs: add custom workflow and preflight documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ An autonomous developer agent that picks groomed Jira tickets, implements them, 
 | [Operations](OPERATIONS.md) | Production operations, monitoring, troubleshooting |
 | [Onboarding a New Instance](docs/onboarding-new-instance.md) | Step-by-step guide for adding a new bot instance |
 | [Presets](docs/presets/README.md) | Preset system — env presets (node, go, browser...) and workflow presets |
+| [Custom Workflows](docs/presets/custom-workflows.md) | Guide to building custom workflows for your instance |
+| [Custom Preflight Scripts](docs/presets/custom-preflight.md) | Guide to writing pre-session data-gathering scripts |
 | [Scheduling](docs/scheduling.md) | KEDA cron scaling for bot instances (business hours only) |
 
 ## Prerequisites

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -81,6 +81,7 @@ Unused presets waste Docker build time and image size. The `node` and `go` prese
 | Workflow | Description |
 |----------|-------------|
 | [`jira-sprint`](workflows.md#jira-sprint) | Full autonomous loop: Jira triage → implement → PR → maintain |
+| [Custom workflows](custom-workflows.md) | Build your own workflow for monitoring, review-only, or specialized automation |
 
 ## Real-World Examples
 
@@ -118,4 +119,6 @@ envs:
 ## Related Docs
 
 - [Onboarding a new instance](../onboarding-new-instance.md) — full setup guide including presets
+- [Custom workflows](custom-workflows.md) — guide to building your own workflow
+- [Custom preflight scripts](custom-preflight.md) — guide to writing pre-session data-gathering scripts
 - [Presets design doc](../presets-design.md) — architecture decisions and rationale

--- a/docs/presets/custom-preflight.md
+++ b/docs/presets/custom-preflight.md
@@ -1,0 +1,389 @@
+# Writing Custom Preflight Scripts
+
+Preflight scripts run **before** each Claude session to gather data and decide whether to start a session. They execute as plain Python — no AI tokens consumed. If there's nothing to do, the cycle ends without starting a Claude session at all.
+
+## Output Contract
+
+Every preflight script must print **exactly one JSON object** to stdout:
+
+```json
+{"status": "start", "content": "Work found — details here..."}
+```
+
+| Status | Meaning | Session starts? |
+|--------|---------|-----------------|
+| `start` | Work found. `content` becomes part of the session prompt. | Yes |
+| `skip` | Nothing to do. `content` is logged but no session starts. | No |
+
+The runner also recognizes `error` status, but you don't need to emit it — the runner produces it automatically when your script fails (non-zero exit, timeout, invalid JSON, etc.).
+
+### Rules
+
+- Print JSON to **stdout**. Use **stderr** for debug logging — it won't interfere with the output.
+- `content` is required when `status` is `start`. It becomes the AI's input prompt, so include all data the bot needs for its decision.
+- `content` is optional for `skip`. If provided, it's logged for debugging (e.g. "All 12 Jenkins jobs healthy").
+
+## Where Scripts Go
+
+Scripts can live in two places:
+
+### 1. Workflow preflight directory
+
+```
+presets/workflows/<workflow-name>/preflight/
+└── 01-check-something.py
+```
+
+Runs for **every instance** that uses this workflow. Use for checks that are fundamental to the workflow's decision loop (e.g. the jira-sprint workflow's PR status and Jira comment checks).
+
+### 2. Instance preflight directory
+
+```
+instance/<config>/agent/preflight/
+└── 01-check-something.py
+```
+
+Runs **only for that instance**. Use for instance-specific checks (e.g. monitoring a Jenkins server only your team cares about).
+
+Both directories are scanned. Scripts from the workflow directory run first, then instance scripts, all sorted by filename within each group.
+
+## Naming Convention
+
+```
+NN-description.py
+```
+
+- **`NN`** — Two-digit number controlling execution order (`01`, `02`, etc.)
+- **`description`** — Kebab-case summary of what the script checks
+
+Examples from the built-in jira-sprint workflow:
+
+```
+01-gh-pr-status.py     # Check GitHub PR states
+02-gl-mr-status.py     # Check GitLab MR states
+03-jira-sprint.py      # Check Jira sprint for comments and new work
+```
+
+Only `.py` files are discovered. Other file types are ignored.
+
+## Lifecycle
+
+When the bot's polling loop fires, here's what happens:
+
+```
+1. discover_preflight_scripts()
+   ├── Scan workflow preflight/ dir
+   └── Scan instance preflight/ dir (if exists)
+
+2. For each script (sorted by filename):
+   ├── Set PYTHONPATH (shared modules + skills)
+   ├── Run: python3 <script>
+   │   ├── cwd = bot repo root (script_dir)
+   │   ├── timeout = 120 seconds
+   │   └── env = parent process env + PYTHONPATH
+   └── Parse JSON from stdout → ScriptResult
+
+3. Aggregate results
+   ├── Errors are excluded from the decision
+   ├── Any "start" → session starts (all content concatenated)
+   ├── All "skip" → no session
+   └── All errors → cycle logged as error, backoff applied
+```
+
+### PYTHONPATH
+
+Before running each script, the runner prepends two directories to `PYTHONPATH`:
+
+| Path | Contents |
+|------|----------|
+| `presets/shared/preflight/` | Shared utility modules (see below) |
+| `.claude/skills/` | Skill scripts (e.g. triage_jenkins.py) |
+
+This means your script can `import common` or `from common import output_result` without path manipulation.
+
+## Aggregation Logic
+
+When multiple scripts run, results are combined:
+
+1. **Errored scripts are excluded** from the start/skip decision. A transient API failure in one script doesn't block work found by another.
+2. **Any `start`** among non-errored scripts → the session starts. Content from all `start` scripts is concatenated.
+3. **All `skip`** → no session starts. Skip content is logged.
+4. **All scripts errored** → the cycle is recorded as an error. Consecutive errors trigger exponential backoff (runner-managed, up to 300s).
+
+Error summaries from failed scripts are prepended to the session prompt (prefixed with `[PREFLIGHT ERROR]`) so the AI has context about partial data.
+
+## Shared Modules
+
+These modules are available via PYTHONPATH from `presets/shared/preflight/`:
+
+### `common.py`
+
+The main utility module. Key functions:
+
+| Function | Description |
+|----------|-------------|
+| `output_result(status, content)` | Print the JSON output protocol to stdout |
+| `load_state()` | Load inter-script state from `data/preflight-state.json` |
+| `save_state(updates)` | Merge updates into inter-script state file |
+| `get_tasks()` | Fetch active tasks from the memory server (cached via state) |
+| `get_capacity()` | Get `(active_count, max)` capacity tuple (cached via state) |
+| `load_project_repos()` | Load `project-repos.json` |
+| `build_repo_lookup()` | Build name → canonical key mapping from project-repos |
+| `upstream_repo(repo_name)` | Resolve repo name to `(upstream_path, host)` |
+| `fmt_comments(comments, label)` | Format a list of comments for the prompt |
+| `fmt_task_header(task)` | Format common task fields as header lines |
+| `get_task_prs(task)` | Extract PR info from task metadata |
+| `is_bot_author(author)` | Check if a comment author is a known bot |
+
+### Other shared modules
+
+| Module | Description |
+|--------|-------------|
+| `gh_pr_status.py` | GitHub PR status checking (CI, reviews, conflicts) |
+| `gl_mr_status.py` | GitLab MR status checking (pipelines, threads) |
+| `jira_sprint_preflight.py` | Jira sprint data fetching |
+| `jira_triage.py` | Jira comment triage helpers |
+
+## Inter-Script State
+
+Scripts within the same preflight run can share data through a state file:
+
+```python
+from common import load_state, save_state
+
+# Script 01: fetch tasks once
+tasks = fetch_tasks_from_api()
+save_state({"tasks": tasks})
+
+# Script 02: reuse cached tasks
+state = load_state()
+tasks = state.get("tasks", [])
+```
+
+The state file (`data/preflight-state.json`) is automatically cleaned up after each preflight run completes. It only persists for the duration of a single run — not across cycles.
+
+This is useful for expensive API calls. For example, the built-in scripts use it to fetch the task list once in the first script and reuse it in subsequent scripts.
+
+## Error Handling
+
+The runner handles all failure modes — your script doesn't need to catch these:
+
+| Failure | What the runner does |
+|---------|---------------------|
+| Non-zero exit code | `ScriptResult(status="error", content=stderr)` |
+| Timeout (120s) | `ScriptResult(status="error", content="timed out after 120s")` |
+| Empty stdout | `ScriptResult(status="error", content="produced no output")` |
+| Invalid JSON | `ScriptResult(status="error", content="invalid JSON: ...")` |
+| Unknown status | `ScriptResult(status="error", content="unknown status: ...")` |
+| `start` with empty content | `ScriptResult(status="error", content="returned start with empty content")` |
+
+**Your script should still handle its own internal errors gracefully** — catch API failures, missing env vars, etc. and output a `skip` status with an explanation rather than crashing:
+
+```python
+data = fetch_from_api()
+if data is None:
+    output_result("skip", "API unreachable — skipping this check")
+    return
+```
+
+## Complete Skeleton
+
+Minimal preflight script:
+
+```python
+#!/usr/bin/env python3
+"""Pre-flight: check if there's work to do."""
+
+import json
+import sys
+
+
+def main():
+    # Gather data (API calls, file checks, etc.)
+    work_items = check_for_work()
+
+    if not work_items:
+        json.dump(
+            {"status": "skip", "content": "No work found."},
+            sys.stdout,
+        )
+        return
+
+    # Build prompt content for the AI session
+    content = f"Found {len(work_items)} items to process:\n"
+    for item in work_items:
+        content += f"- {item}\n"
+
+    json.dump(
+        {"status": "start", "content": content},
+        sys.stdout,
+    )
+
+
+def check_for_work():
+    """Replace with your actual check logic."""
+    return []
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### Using shared utilities
+
+```python
+#!/usr/bin/env python3
+"""Pre-flight: check tasks and PR statuses."""
+
+from common import get_tasks, get_task_prs, output_result
+
+
+def main():
+    tasks = get_tasks()
+    if not tasks:
+        output_result("skip", "No active tasks.")
+        return
+
+    actionable = []
+    for task in tasks:
+        prs = get_task_prs(task)
+        if prs:
+            actionable.append(task)
+
+    if not actionable:
+        output_result("skip", f"{len(tasks)} tasks, none with open PRs.")
+        return
+
+    lines = [f"{len(actionable)} tasks with open PRs:"]
+    for t in actionable:
+        lines.append(f"  {t.get('external_key', '?')} [{t.get('status', '?')}]")
+
+    output_result("start", "\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Real Example Pattern
+
+A common pattern for custom preflight scripts is fetching data from an external service, classifying it, and deciding whether to start a session. Here's the general structure:
+
+```python
+#!/usr/bin/env python3
+"""Pre-flight: check external service for issues."""
+
+import json
+import subprocess
+import sys
+
+
+def fetch_data():
+    """Fetch data from your service. Return None on failure."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "path/to/fetch_script.py"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return None
+        return json.loads(proc.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+
+
+def classify(data):
+    """Classify items. Return (actionable, healthy, has_issues)."""
+    items = data.get("items", [])
+    if not items:
+        return [], [], False
+
+    actionable = [i for i in items if i.get("status") == "failing"]
+    healthy = [i for i in items if i.get("status") != "failing"]
+    return actionable, healthy, len(actionable) > 0
+
+
+def main():
+    data = fetch_data()
+    if data is None:
+        json.dump(
+            {"status": "skip", "content": "Service unreachable. Skipping."},
+            sys.stdout,
+        )
+        return
+
+    actionable, healthy, has_issues = classify(data)
+
+    if not has_issues:
+        json.dump(
+            {"status": "skip",
+             "content": f"All {len(healthy)} items healthy. Skipping."},
+            sys.stdout,
+        )
+        return
+
+    content = f"{len(actionable)} failing, {len(healthy)} healthy.\n"
+    content += json.dumps({"failing": actionable}, indent=2)
+
+    json.dump(
+        {"status": "start", "content": content},
+        sys.stdout,
+    )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Key principles:
+- **Fail gracefully**: If your API is down, output `skip`, not a crash. The bot can try again next cycle.
+- **Include only actionable data**: Don't dump everything into the prompt. Healthy items waste tokens — summarize them with a count.
+- **Deterministic classification**: Do filtering, sorting, and priority in Python (free), not in the AI session (expensive).
+
+## Testing
+
+### Run standalone
+
+```bash
+# Set any env vars your script needs
+export BOT_INSTANCE_ID="test"
+
+# Run from the bot repo root (scripts expect cwd = script_dir)
+cd /path/to/dev-bot
+PYTHONPATH=presets/shared/preflight:.claude/skills python3 path/to/your-script.py
+```
+
+### Validate output
+
+The output should be exactly one JSON object. Verify with:
+
+```bash
+python3 your-script.py | python3 -m json.tool
+```
+
+You should see `{"status": "start"|"skip", "content": "..."}`.
+
+### Common mistakes
+
+- **Printing debug info to stdout** — Use `print(..., file=sys.stderr)` for logging. Anything on stdout is parsed as the JSON result.
+- **Return value mismatch** — If a helper function returns N values, the caller must unpack exactly N. The runner won't catch this — Python will raise a `ValueError` and your script exits non-zero.
+- **Missing env vars** — Check `os.environ.get()` and handle gracefully rather than crashing with `KeyError`.
+- **Forgetting `if __name__ == "__main__"`** — Without this guard, importing the script (e.g. for testing) will run `main()`.
+
+## Declaring in manifest.yaml
+
+The `preflight:` field in your workflow's `manifest.yaml` is for documentation — it lists which scripts exist:
+
+```yaml
+preflight:
+  - 01-check-service.py
+  - 02-check-capacity.py
+```
+
+Discovery is **filesystem-based**: the runner scans the `preflight/` directory for `.py` files. Adding or removing a file is sufficient — you don't need to update `manifest.yaml` for scripts to run. But keeping the manifest in sync is good practice for documentation.
+
+## Related Docs
+
+- [Workflow presets](workflows.md) — How workflows (including preflight) fit into the preset system
+- [Custom workflows](custom-workflows.md) — Building complete custom workflows with preflight scripts
+- [Presets overview](README.md) — How presets work together

--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -1,0 +1,396 @@
+# Creating Custom Workflows
+
+A workflow defines what the bot does each cycle — its decision loop. Every instance has exactly one workflow, set in `instance.yaml`. The built-in `jira-sprint` workflow handles the full autonomous development loop, but you can create custom workflows for specialized use cases like monitoring, scheduled tasks, or domain-specific automation.
+
+## Built-in vs Custom Workflows
+
+### Built-in (core image)
+
+Reference a workflow by name. It resolves from the core bot image at `presets/workflows/<name>/`:
+
+```yaml
+# instance.yaml
+workflow: jira-sprint
+```
+
+### Custom (instance config repo)
+
+Use the `./` prefix to reference a workflow relative to your instance config repo's agent directory:
+
+```yaml
+# instance.yaml
+workflow: ./workflows/watchduty
+```
+
+This resolves to `<your-config-repo>/agent/workflows/watchduty/`. Use this when your workflow is specific to your team and doesn't belong in the core bot image.
+
+## Directory Structure
+
+A workflow directory contains:
+
+```
+workflows/my-workflow/
+├── CLAUDE.md              # Required — the bot's instructions for this workflow
+├── manifest.yaml          # Recommended — metadata, requirements, preflight declaration
+├── preflight/             # Optional — pre-session data-gathering scripts
+│   ├── 01-check-service.py
+│   └── 02-check-capacity.py
+└── skills/                # Optional — workflow-specific skill scripts
+    └── my-skill/
+        ├── SKILL.md
+        └── my_skill.py
+```
+
+### Required: `CLAUDE.md`
+
+This is the core of your workflow. At startup, the runner assembles the final `CLAUDE.md` by combining:
+
+1. **Core instructions** (`presets/core/CLAUDE.md`) — security rules, tool usage, general behavior
+2. **Workflow instructions** (your workflow's `CLAUDE.md`) — what to do each cycle
+3. **Instance instructions** (your config repo's `agent/CLAUDE.md`) — instance-specific overrides (strategy-dependent)
+
+Your workflow CLAUDE.md should be written as imperative instructions telling the bot what to do. Think of it as a runbook.
+
+### Recommended: `manifest.yaml`
+
+Declares metadata and requirements. Validated at startup — missing required MCP servers or env vars cause a fatal error, catching deployment misconfigurations early.
+
+### Optional: `preflight/`
+
+Pre-session scripts that run before each Claude session. See [Writing Custom Preflight Scripts](custom-preflight.md) for the full guide.
+
+### Optional: `skills/`
+
+Python scripts that the bot can invoke during its session (e.g. triage logic, data fetching). These are copied to `.claude/skills/` at startup.
+
+## manifest.yaml Schema
+
+```yaml
+name: my-workflow
+type: workflow
+description: Brief description of what this workflow does
+
+# Preflight scripts (documentation — discovery is filesystem-based)
+preflight:
+  - 01-check-service.py
+  - 02-check-capacity.py
+
+# Core skills to include alongside this workflow's own skills
+shared_skills:
+  - push-and-pr        # Git push + PR creation
+  - post-pr            # Post-PR Jira comment + Slack notification
+  - auto-fork          # Fork creation for new repos
+
+# What this workflow provides
+provides:
+  claude_md: CLAUDE.md
+  skills:
+    - my-skill          # Skill directories under this workflow's skills/
+
+# What this workflow requires to function
+requires:
+  mcp_servers:
+    - bot-memory         # Must be configured in MCP settings
+    - mcp-atlassian
+  env_vars:
+    - BOT_LABEL          # Fatal if not set
+    - BOT_INSTANCE_ID
+  optional_env_vars:
+    - SLACK_WEBHOOK_URL  # Warning if not set, but not fatal
+```
+
+### Field Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Workflow identifier |
+| `type` | Yes | Must be `workflow` |
+| `description` | Yes | One-line summary |
+| `preflight` | No | List of preflight script filenames (documentation only) |
+| `shared_skills` | No | Core skill names to include (from `presets/shared/skills/`) |
+| `provides.claude_md` | No | CLAUDE.md filename (always `CLAUDE.md`) |
+| `provides.skills` | No | Skill directory names provided by this workflow |
+| `requires.mcp_servers` | No | MCP servers that must be configured. Fatal if missing. |
+| `requires.env_vars` | No | Environment variables that must be set. Fatal if missing. |
+| `requires.optional_env_vars` | No | Env vars that should be set. Warning if missing. |
+
+## instance.yaml Configuration
+
+Your instance config repo's `instance.yaml` controls which workflow runs and how:
+
+```yaml
+# instance/<config>/agent/instance.yaml
+workflow: ./workflows/my-workflow   # ./ = relative to this agent dir
+source: scheduled                   # or "jira"
+envs:
+  - slack
+  - node
+claude_md:
+  strategy: append                  # ignore | append | replace
+```
+
+### Fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `workflow` | `jira-sprint` | Workflow name (built-in) or `./path` (custom) |
+| `source` | `jira` | Ticket source. `jira` = Jira sprint polling. `scheduled` = time-based. |
+| `envs` | `null` (all) | Env presets to activate. `null` = all available, `[]` = none. |
+| `claude_md.strategy` | `ignore` | How instance CLAUDE.md combines with workflow CLAUDE.md |
+
+## CLAUDE.md Assembly Strategies
+
+The `claude_md.strategy` field controls how your instance's `agent/CLAUDE.md` combines with the workflow's CLAUDE.md:
+
+### `ignore` (default)
+
+```
+Final CLAUDE.md = core + workflow
+```
+
+Instance `CLAUDE.md` is ignored. Use when the workflow's instructions are complete and the instance doesn't need to add anything.
+
+**When to use**: Most workflows. The workflow CLAUDE.md has everything the bot needs.
+
+### `append`
+
+```
+Final CLAUDE.md = core + workflow + instance
+```
+
+Instance `CLAUDE.md` is appended after the workflow instructions. Use when you want to add instance-specific context on top of the workflow.
+
+**When to use**: Your team has extra context (team conventions, specific repos, escalation contacts) that supplements the workflow's decision loop.
+
+```yaml
+# instance.yaml
+claude_md:
+  strategy: append
+```
+
+```markdown
+<!-- agent/CLAUDE.md (instance) -->
+## Team-Specific Context
+
+- Our Jenkins is at jenkins.example.com
+- Escalate P0 issues to #team-oncall in Slack
+- Prod jobs are prefixed with "prod-"
+```
+
+### `replace`
+
+```
+Final CLAUDE.md = core + instance
+```
+
+The workflow's CLAUDE.md is skipped entirely. Instance CLAUDE.md replaces it. Use when you want complete control over the bot's instructions while still keeping core security rules.
+
+**When to use**: Rarely. Only when the workflow is just a container for preflight/skills and the instructions are fully custom per instance.
+
+## Path Resolution
+
+The `resolve_workflow_dir()` function in `bot/config.py` handles path resolution:
+
+- **Plain name** (e.g. `jira-sprint`) → `<bot-repo>/presets/workflows/jira-sprint/`
+- **`./` prefix** (e.g. `./workflows/watchduty`) → `<config-repo>/agent/workflows/watchduty/`
+
+This resolution is used consistently across:
+- Startup validation (`validate_instance_config`)
+- Manifest loading and validation (`load_manifest`, `validate_manifest`)
+- CLAUDE.md assembly (`assemble_claude_md`)
+- Preflight script discovery (`discover_preflight_scripts`)
+
+## What Workflows Don't Handle
+
+Workflows define the decision loop. Everything else comes from instance config merging:
+
+| Handled by workflow | Handled by instance config merge |
+|--------------------|----------------------------------|
+| CLAUDE.md instructions | Personas |
+| Preflight scripts | Skills (instance-level) |
+| Workflow-specific skills | MCP server configs |
+|  | Settings (`.claude/settings.json`) |
+|  | Hooks (`.claude/hooks/`) |
+|  | `project-repos.json` |
+
+The merge system (`bot/merge.py` → `apply_merged_config()`) combines persona files, MCP configs, skills, settings, and hooks from both the core image and your instance config. Workflows are independent of this — they provide their own CLAUDE.md and preflight scripts.
+
+## Complete Example: Review-Only Workflow
+
+Let's build a workflow that only reviews PRs — no new Jira work, no ticket claiming.
+
+### 1. Create the directory
+
+```
+instance/my-config/agent/
+├── instance.yaml
+├── workflows/
+│   └── review-only/
+│       ├── CLAUDE.md
+│       ├── manifest.yaml
+│       └── preflight/
+│           └── 01-check-prs.py
+└── project-repos.json
+```
+
+### 2. Write the CLAUDE.md
+
+```markdown
+# Review-Only Workflow
+
+Each cycle: check for PRs needing review, review them, post feedback.
+
+## Cycle Loop
+
+1. Read the preflight data — it contains PR statuses and review requests.
+2. If no PRs need attention, stop.
+3. For each PR needing review (one per cycle):
+   a. Clone the repo if needed
+   b. Read the diff
+   c. Post a code review with actionable feedback
+   d. Update task tracking
+
+## Rules
+
+- ONE PR per cycle
+- Only review, never push code
+- Be constructive — suggest improvements, don't just list problems
+```
+
+### 3. Write the manifest.yaml
+
+```yaml
+name: review-only
+type: workflow
+description: Review PRs without implementing new work
+
+preflight:
+  - 01-check-prs.py
+
+shared_skills:
+  - push-and-pr    # For reading PR templates/conventions
+
+provides:
+  claude_md: CLAUDE.md
+
+requires:
+  mcp_servers:
+    - bot-memory
+  env_vars:
+    - BOT_INSTANCE_ID
+  optional_env_vars:
+    - SLACK_WEBHOOK_URL
+```
+
+### 4. Write the preflight script
+
+```python
+#!/usr/bin/env python3
+"""Pre-flight: check for PRs needing review."""
+
+import json
+import sys
+
+from common import get_tasks, get_task_prs, output_result
+
+
+def main():
+    tasks = get_tasks()
+    review_needed = []
+
+    for task in tasks:
+        if task.get("status") not in ("pr_open", "pr_changes"):
+            continue
+        prs = get_task_prs(task)
+        if prs:
+            review_needed.append({
+                "key": task.get("external_key", "?"),
+                "repo": task.get("repo", "?"),
+                "prs": prs,
+            })
+
+    if not review_needed:
+        output_result("skip", f"{len(tasks)} tasks, none with PRs needing review.")
+        return
+
+    content = f"{len(review_needed)} PRs need review:\n"
+    content += json.dumps(review_needed, indent=2)
+    output_result("start", content)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### 5. Configure instance.yaml
+
+```yaml
+workflow: ./workflows/review-only
+source: jira
+envs:
+  - slack
+claude_md:
+  strategy: ignore    # Workflow CLAUDE.md has everything needed
+```
+
+## Real-World Pattern: Scheduled Monitoring
+
+For workflows that run on a schedule (not driven by Jira), use `source: scheduled` and a preflight script that checks an external service:
+
+```yaml
+# instance.yaml
+workflow: ./workflows/watchduty
+source: scheduled
+envs:
+  - slack
+claude_md:
+  strategy: append
+```
+
+The key differences from a Jira-driven workflow:
+- **`source: scheduled`** — The bot runs on a timer rather than polling Jira for new tickets
+- **Preflight decides everything** — No Jira triage phase. The preflight script checks the external service and determines whether action is needed.
+- **`strategy: append`** — Instance CLAUDE.md adds team-specific context (service URLs, escalation paths) on top of the workflow's general instructions.
+
+The preflight script for this pattern typically:
+1. Fetches data from the external service (Jenkins, Grafana, custom API)
+2. Classifies items deterministically (failing vs healthy, priority ordering)
+3. Outputs `start` with only the actionable items, or `skip` if everything is healthy
+
+See [Writing Custom Preflight Scripts](custom-preflight.md) for the implementation details.
+
+## Checklist: Shipping a Custom Workflow
+
+1. **Create the workflow directory** in your config repo under `agent/workflows/<name>/`
+
+2. **Write `CLAUDE.md`** — imperative instructions for the bot's decision loop. Be specific about:
+   - What to check each cycle
+   - When to take action vs skip
+   - How to report results
+   - What "done" looks like
+
+3. **Write `manifest.yaml`** — declare requirements so deployment failures are caught at startup, not mid-session
+
+4. **Add preflight scripts** (if needed) — pre-session data gathering to avoid wasting tokens on idle cycles
+
+5. **Update `instance.yaml`** — set `workflow: ./workflows/<name>` and choose the right `claude_md.strategy`
+
+6. **Test locally**:
+   ```bash
+   # Test preflight scripts standalone
+   cd /path/to/dev-bot
+   PYTHONPATH=presets/shared/preflight:.claude/skills python3 path/to/preflight/01-check.py
+
+   # Test CLAUDE.md assembly
+   python3 bot/run.py  # Check assembled output
+   ```
+
+7. **Deploy** — set `BOT_CONFIG_PATH` in your deployment template to point to your instance config
+
+## Related Docs
+
+- [Workflow presets](workflows.md) — Built-in workflow reference (jira-sprint)
+- [Writing custom preflight scripts](custom-preflight.md) — Detailed guide to preflight scripts
+- [Env presets](envs.md) — Available env presets for tools and runtimes
+- [Presets overview](README.md) — How all preset types work together
+- [Presets design doc](../presets-design.md) — Architecture decisions and rationale

--- a/docs/presets/workflows.md
+++ b/docs/presets/workflows.md
@@ -155,3 +155,12 @@ instance/<your-config>/agent/
     ├── backend/prompt.md     # Go/Python guidelines
     └── config/prompt.md      # YAML/Jsonnet guidelines
 ```
+
+---
+
+## Custom Workflows
+
+The preset system supports custom workflows beyond the built-in `jira-sprint`. You can create workflows for monitoring, scheduled tasks, review-only bots, or any specialized automation.
+
+- [Creating custom workflows](custom-workflows.md) — Full guide to building your own workflow with directory structure, manifest, CLAUDE.md assembly, and examples
+- [Writing custom preflight scripts](custom-preflight.md) — How to write pre-session data-gathering scripts for your workflow


### PR DESCRIPTION
## Summary

- Add `docs/presets/custom-preflight.md` — comprehensive guide to writing custom preflight scripts (output contract, lifecycle, shared modules, aggregation, error handling, complete skeleton, real-world patterns, testing tips)
- Add `docs/presets/custom-workflows.md` — comprehensive guide to creating custom workflows (directory structure, manifest.yaml schema, CLAUDE.md assembly strategies, resolution internals, complete review-only example, scheduled monitoring pattern, shipping checklist)
- Update `docs/presets/workflows.md` with "Custom Workflows" section linking to new docs
- Update `docs/presets/README.md` with entries in Preset Reference and Related Docs
- Update main `README.md` documentation table with links to the new guides

## Context

Instance teams (e.g. obsint-processing) building custom workflows had to reverse-engineer the system from source code and hit bugs due to lack of documentation. These docs cover the full lifecycle so teams can build custom workflows and preflight scripts without reading `bot/preflight.py` or `bot/config.py`.

## Test plan

- [ ] All cross-doc links resolve correctly (relative paths between `docs/presets/*.md`)
- [ ] Code examples match actual function signatures in config.py, preflight.py, run.py
- [ ] No internal URLs, secrets, or team-specific details leaked
- [ ] Skeleton examples are self-contained and runnable

🤖 Generated with [Claude Code](https://claude.com/claude-code)