### PR TITLE
fix(preflight): skip already-addressed CI-only failures

### DIFF
--- a/bot/tests/test_preflight_shared.py
+++ b/bot/tests/test_preflight_shared.py
@@ -235,6 +235,99 @@ def test_changes_requested_still_unconditional():
         assert unconditional is True, f"{issue} should be unconditional feedback"
 
 
+# --- CI-only skip (bucket classification) ---
+
+
+def _make_ci_enriched(last_addressed=None, extra_issues=None, pr_comments=None):
+    """Helper to build enriched dicts for CI bucket tests."""
+    issues = ["ci_fail:lint,test"]
+    if extra_issues:
+        issues.extend(extra_issues)
+    return {
+        "task": {
+            "external_key": "TEST-1",
+            "status": "pr_open",
+            "repo": "test-repo",
+            **({"last_addressed": last_addressed} if last_addressed else {}),
+        },
+        "prs": [{"repo": "test-repo", "num": 1, "host": "github", "state": "OPEN", "issues": issues, "data": {}}],
+        "pr_comments": pr_comments or [],
+        "issues": issues,
+    }
+
+
+def _classify_bucket(enriched_list):
+    """Reproduce the bucket classification from main() for testing."""
+    merged, closed, ci_fail, conflict, feedback, clean = [], [], [], [], [], []
+    for e in enriched_list:
+        issues = e["issues"]
+        if "merged" in issues:
+            merged.append(e)
+        elif "closed" in issues:
+            closed.append(e)
+        elif any(i.startswith("ci_fail") for i in issues):
+            ci_only = all(i.startswith("ci_fail") for i in issues)
+            if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):
+                clean.append(e)
+            else:
+                ci_fail.append(e)
+        elif "conflict" in issues:
+            conflict.append(e)
+        elif any(i in ("changes_requested",) or i.startswith("review:") for i in issues):
+            feedback.append(e)
+        elif has_new_feedback(e):
+            feedback.append(e)
+        else:
+            clean.append(e)
+    return {"ci_fail": ci_fail, "clean": clean, "feedback": feedback}
+
+
+def test_ci_only_addressed_is_clean():
+    """CI-only failure with last_addressed set and no new feedback → clean."""
+    e = _make_ci_enriched(last_addressed="2026-07-14T17:49")
+    result = _classify_bucket([e])
+    assert len(result["clean"]) == 1
+    assert len(result["ci_fail"]) == 0
+
+
+def test_ci_only_no_last_addressed_is_actionable():
+    """CI-only failure without last_addressed → still actionable (first encounter)."""
+    e = _make_ci_enriched(last_addressed=None)
+    result = _classify_bucket([e])
+    assert len(result["ci_fail"]) == 1
+    assert len(result["clean"]) == 0
+
+
+def test_ci_plus_conflict_is_actionable():
+    """CI failure combined with conflict → actionable even with last_addressed."""
+    e = _make_ci_enriched(last_addressed="2026-07-14T17:49", extra_issues=["conflict"])
+    result = _classify_bucket([e])
+    assert len(result["ci_fail"]) == 1
+    assert len(result["clean"]) == 0
+
+
+def test_ci_only_with_new_feedback_is_actionable():
+    """CI-only with last_addressed but new human comment → actionable."""
+    e = _make_ci_enriched(
+        last_addressed="2026-07-14T10:00",
+        pr_comments=[{"a": "reviewer", "t": "2026-07-14T18:00", "b": "can you retry CI?"}],
+    )
+    result = _classify_bucket([e])
+    assert len(result["ci_fail"]) == 1
+    assert len(result["clean"]) == 0
+
+
+def test_ci_only_with_old_feedback_is_clean():
+    """CI-only with last_addressed after the last comment → clean."""
+    e = _make_ci_enriched(
+        last_addressed="2026-07-14T18:00",
+        pr_comments=[{"a": "reviewer", "t": "2026-07-14T10:00", "b": "can you retry CI?"}],
+    )
+    result = _classify_bucket([e])
+    assert len(result["clean"]) == 1
+    assert len(result["ci_fail"]) == 0
+
+
 # --- classify_gl ---
 
 

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -212,7 +212,11 @@ def main():
         elif "closed" in issues:
             closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
-            ci_fail.append(e)
+            ci_only = all(i.startswith("ci_fail") for i in issues)
+            if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):
+                clean.append(e)
+            else:
+                ci_fail.append(e)
         elif "conflict" in issues:
             conflict.append(e)
         elif any(i in ("changes_requested",) or i.startswith("review:") for i in issues):


### PR DESCRIPTION
## Summary

- CI-only failures with `last_addressed` set and no new feedback were unconditionally classified as actionable, causing repeated AI sessions ($0.30-$0.38 each) that concluded NO_WORK_FOUND
- Preexisting CI checks (Grype security scan, Konflux) that the bot already documented kept triggering every 5-minute cycle
- Now these are classified as `clean` — if a non-CI issue appears or new feedback arrives, the PR still triggers correctly

## Verified in production

Ran the updated script directly in `devbot-framework-77d9b6fc9d-d6tt9`:

**Before**: `"status": "start"` — 3 PRs in CI FAILING (all preexisting, all already documented)  
**After**: `"status": "skip"` — all 5 PRs classified as CLEAN

## Test plan

- [x] Verified in production pod — false positives eliminated
- [ ] CI-only + no `last_addressed` → still triggers (first encounter)
- [ ] CI + conflict → still triggers (non-CI issue present)
- [ ] CI + new comment → still triggers (new feedback)
- [ ] CI-only + `last_addressed` + no new feedback → skip (the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)