### PR TITLE
fix(slack): support Incoming Webhook payload format

### DIFF
--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -488,7 +488,7 @@ After deploying, verify in order:
 | `BOT_BOARD_NAME` | no | Jira board name (for sprint assignment only) |
 | `BOT_SPRINT_PREFIX` | no | Sprint name prefix filter (for sprint assignment only) |
 | `BOT_INCLUDE_BACKLOG` | no | `'true'` to include backlog tickets |
-| `SLACK_WEBHOOK_URL` | no | Slack webhook for notifications |
+| `SLACK_WEBHOOK_URL` | no | Slack webhook — Incoming (`/services/`, recommended) or Workflow Builder (`/triggers/`) |
 | `PROXY_IMAGE` | no | Proxy container image (only needed if `PROXY_REPLICAS=1`) |
 | `PROXY_IMAGE_TAG` | no | Proxy image tag (default: `latest`) |
 | `PROXY_REPLICAS` | no | `'0'` = use shared proxy (default), `'1'` = deploy own proxy |

--- a/docs/presets/envs.md
+++ b/docs/presets/envs.md
@@ -158,7 +158,11 @@ Adds the Slack notification skill. The bot sends alerts when PRs are created, ti
 
 **When to use**: Any instance where the team wants Slack notifications about bot activity.
 
-**Requires env var**: `SLACK_WEBHOOK_URL` (Slack incoming webhook URL)
+**Requires env var**: `SLACK_WEBHOOK_URL` — supports two webhook types:
+- **Incoming Webhook** (`https://hooks.slack.com/services/...`) — full mrkdwn support including `<url|label>` hyperlinks, `<!subteam^ID>` mentions, bold, block quotes. Recommended.
+- **Workflow Builder Webhook** (`https://hooks.slack.com/triggers/...`) — variable content is plain text inside rich_text blocks; mrkdwn link syntax and mentions are not rendered.
+
+The payload key is auto-detected from the URL: `{"text": ...}` for Incoming Webhooks, `{"msg": ...}` for Workflow Builder.
 
 **Depends on**: nothing
 

--- a/docs/presets/workflows.md
+++ b/docs/presets/workflows.md
@@ -101,7 +101,7 @@ These MCP servers must be available (typically via the shared proxy):
 | `BOT_BOARD_ID` or `BOT_BOARD_NAME` | Jira board for sprint assignment | Skip sprint assignment |
 | `BOT_SPRINT_PREFIX` | Sprint name filter (e.g. `"Framework"`) | No filter |
 | `BOT_INCLUDE_BACKLOG` | Include backlog tickets in search | `false` |
-| `SLACK_WEBHOOK_URL` | Slack webhook for notifications | No notifications |
+| `SLACK_WEBHOOK_URL` | Slack webhook — Incoming (`/services/`) or Workflow Builder (`/triggers/`) | No notifications |
 
 ### Directory Structure
 

--- a/memory-server/bot_memory_server/tools/slack.py
+++ b/memory-server/bot_memory_server/tools/slack.py
@@ -54,8 +54,12 @@ def register_slack_tools(mcp: FastMCP):
             }
 
         try:
+            if "/services/" in webhook_url:
+                payload = {"text": message}
+            else:
+                payload = {"msg": message}
             async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(webhook_url, json={"msg": message})
+                resp = await client.post(webhook_url, json=payload)
                 resp.raise_for_status()
         except Exception as e:
             logger.error("Slack webhook failed: %s", e)


### PR DESCRIPTION
## Summary
- Auto-detect webhook type from URL: `{"text": ...}` for Incoming Webhooks (`/services/`), `{"msg": ...}` for Workflow Builder (`/triggers/`)
- Backward compatible — existing Workflow Builder webhooks continue to work unchanged
- Docs updated in `envs.md`, `workflows.md`, `onboarding-new-instance.md` to document both webhook types and recommend Incoming Webhooks

## Why
Slack Workflow Builder's "Send a message" step wraps variable content in `rich_text` blocks, which means mrkdwn features like `<url|label>` hyperlinks and `<!subteam^ID>` mentions don't render. Incoming Webhooks (`hooks.slack.com/services/`) support full mrkdwn, making notifications richer and more useful.

## Changes
- `memory-server/bot_memory_server/tools/slack.py` — detect `/services/` in the webhook URL and use `{"text": message}` payload; fall back to `{"msg": message}` for Workflow Builder URLs
- `docs/presets/envs.md` — documented both webhook types with formatting capabilities
- `docs/presets/workflows.md` — updated `SLACK_WEBHOOK_URL` description
- `docs/onboarding-new-instance.md` — updated env var table

## Test plan
- [ ] Test with Incoming Webhook URL (`hooks.slack.com/services/...`) — message delivered with full mrkdwn
- [ ] Test with Workflow Builder URL (`hooks.slack.com/triggers/...`) — existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)