### PR TITLE
fix(proxy): enable global credential fallback for mcp-atlassian

### DIFF
--- a/proxy/start.sh
+++ b/proxy/start.sh
@@ -60,6 +60,7 @@ SQUID_PID=$!
 MCP_PID=""
 if [ -n "${JIRA_URL:-}" ] && [ -n "${JIRA_USERNAME:-}" ] && [ -n "${JIRA_API_TOKEN:-}" ]; then
     MCP_PORT="${MCP_ATLASSIAN_PORT:-8444}"
+    ALLOW_GLOBAL_CRED_FALLBACK=true \
     JIRA_URL="${JIRA_URL}" \
     JIRA_USERNAME="${JIRA_USERNAME}" \
     JIRA_API_TOKEN="${JIRA_API_TOKEN}" \


### PR DESCRIPTION
## Summary

- Newer `mcp-atlassian` versions added `UserTokenMiddleware` that rejects unauthenticated MCP requests by default (`ALLOW_GLOBAL_CRED_FALLBACK` is off)
- Preflight scripts connect to the MCP server without per-user identity headers → Jira preflight calls fail with `anyio` stream errors
- Bots with no active PRs (fleetshift) get stuck in an infinite skip loop and can never pick up new Jira work
- Fix: set `ALLOW_GLOBAL_CRED_FALLBACK=true` when starting `mcp-atlassian`

## Evidence

Proxy logs:
```
WARNING - mcp-atlassian.server.main - UserTokenMiddleware: rejecting unauthenticated MCP request
  (no user identity and ALLOW_GLOBAL_CRED_FALLBACK is off)
```

## Test plan

- [ ] Merge and wait for Konflux to build new proxy image
- [ ] Verify fleetshift bot picks up OME-202
- [ ] Verify framework bot Jira preflight stops erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)