### PR TITLE
feat(workflow): add jira-kanban workflow preset

### DIFF
--- a/bot/tests/test_jira_kanban_preflight.py
+++ b/bot/tests/test_jira_kanban_preflight.py
@@ -1,0 +1,400 @@
+"""Tests for jira_kanban_preflight combined module."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
+SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / ".claude" / "skills"
+sys.path.insert(0, str(SHARED_DIR))
+sys.path.insert(0, str(SKILLS_DIR))
+
+from jira_kanban_preflight import (  # noqa: E402
+    _has_new_jira_feedback,
+    _parse_statuses,
+    main,
+)
+
+# --- _has_new_jira_feedback ---
+
+
+def test_new_feedback_detected():
+    comments = [{"created": "2026-07-01T10:00:00", "body": "Hey can you check this?"}]
+    assert _has_new_jira_feedback(comments, "2026-06-30T10:00:00") is True
+
+
+def test_old_feedback_ignored():
+    comments = [{"created": "2026-06-30T08:00:00", "body": "Hey can you check this?"}]
+    assert _has_new_jira_feedback(comments, "2026-06-30T10:00:00") is False
+
+
+def test_bot_structured_comment_not_feedback():
+    comments = [{"created": "2026-07-01T10:00:00", "body": "### Analysis\n\n| col1 | col2 |\n|---|---|\n| a | b |"}]
+    assert _has_new_jira_feedback(comments, "2026-06-30T10:00:00") is False
+
+
+def test_pr_link_not_feedback():
+    comments = [{"created": "2026-07-01T10:00:00", "body": "PR: https://github.com/org/repo/pull/42"}]
+    assert _has_new_jira_feedback(comments, "2026-06-30T10:00:00") is False
+
+
+def test_empty_comments():
+    assert _has_new_jira_feedback([], "2026-06-30T10:00:00") is False
+
+
+# --- _parse_statuses ---
+
+
+def test_parse_default_statuses():
+    assert _parse_statuses() == ["New", "Backlog", "To Do"]
+
+
+def test_parse_custom_statuses(monkeypatch):
+    monkeypatch.setattr("jira_kanban_preflight.BOT_KANBAN_STATUSES", "Open, In Review, Blocked")
+    from jira_kanban_preflight import _parse_statuses as parse
+
+    assert parse() == ["Open", "In Review", "Blocked"]
+
+
+# --- main() decision logic ---
+
+
+def _mock_tasks(active=None, done=None, paused=None):
+    items = []
+    for t in active or []:
+        items.append({**t, "status": t.get("status", "in_progress")})
+    for t in done or []:
+        items.append({**t, "status": "done"})
+    for t in paused or []:
+        items.append({**t, "status": "paused"})
+    return items
+
+
+@pytest.fixture
+def env_vars(monkeypatch, tmp_path):
+    monkeypatch.setattr("jira_kanban_preflight.INSTANCE_ID", "test-instance")
+    monkeypatch.setattr("jira_kanban_preflight.BOT_JIRA_PROJECT", "LCORE")
+    monkeypatch.setattr("jira_kanban_preflight.BOT_JIRA_EMAIL", "bot@test.com")
+    monkeypatch.setattr("jira_kanban_preflight.BOT_KANBAN_STATUSES", "New,Backlog,To Do")
+    monkeypatch.setattr("jira_kanban_preflight.BOT_KANBAN_JQL_EXTRA", "")
+    monkeypatch.setattr("jira_kanban_preflight.save_state", lambda x: None)
+    return tmp_path
+
+
+def test_no_active_no_candidates_returns_skip(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks()
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (0, 10))
+    monkeypatch.setattr("jira_kanban_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_kanban_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_kanban_preflight._get_candidates", lambda rl: [])
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "skip"
+    assert "No eligible work" in out["content"]
+
+
+def test_no_active_with_candidates_returns_start(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks()
+    candidates = [
+        {
+            "key": "LCORE-1",
+            "summary": "Fix CVE",
+            "status": "New",
+            "priority": "High",
+            "type": "Vulnerability",
+            "labels": ["Security"],
+            "repos": [],
+            "description": "Fix it",
+            "comments": [],
+            "links": [],
+        }
+    ]
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (0, 10))
+    monkeypatch.setattr("jira_kanban_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_kanban_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_kanban_preflight._get_candidates", lambda rl: candidates)
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "LCORE-1" in out["content"]
+
+
+def test_candidates_without_repo_labels_still_start(env_vars, monkeypatch, capsys):
+    """Kanban candidates without repo: labels should still start (unlike sprint)."""
+    tasks = _mock_tasks()
+    candidates = [
+        {
+            "key": "LCORE-10",
+            "summary": "CVE in lightspeed-stack",
+            "status": "New",
+            "priority": "Critical",
+            "type": "Vulnerability",
+            "labels": ["Security", "pscomponent:lightspeed-core/lightspeed-stack-rhel9"],
+            "repos": [],
+            "description": "Vulnerable package found",
+            "comments": [],
+            "links": [],
+        }
+    ]
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (0, 10))
+    monkeypatch.setattr("jira_kanban_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_kanban_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_kanban_preflight._get_candidates", lambda rl: candidates)
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "LCORE-10" in out["content"]
+    assert "agent determines repo from ticket content" in out["content"]
+
+
+def test_active_with_feedback_returns_start(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "LCORE-2",
+                "status": "pr_open",
+                "repo": "lightspeed-stack",
+                "last_addressed": "2026-06-30T10:00:00",
+                "metadata": {"prs": [{"repo": "lightspeed-stack", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "In Progress"},
+            "labels": [],
+            "issuelinks": [],
+            "comment": {
+                "comments": [
+                    {
+                        "created": "2026-07-01T10:00:00",
+                        "body": "Can you check this?",
+                        "author": {"displayName": "Human"},
+                    }
+                ]
+            },
+        }
+    }
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_kanban_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "JIRA FEEDBACK" in out["content"]
+
+
+def test_active_all_clean_no_candidates_returns_skip(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "LCORE-3",
+                "status": "pr_open",
+                "repo": "lightspeed-stack",
+                "last_addressed": "2026-07-01T12:00:00",
+                "metadata": {"prs": [{"repo": "lightspeed-stack", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "Code Review"},
+            "labels": [],
+            "issuelinks": [],
+            "comment": {"comments": []},
+        }
+    }
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_kanban_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_kanban_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_kanban_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_kanban_preflight._get_candidates", lambda rl: [])
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "skip"
+    assert "No eligible work" in out["content"]
+
+
+def test_active_all_clean_with_candidates_returns_start(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "LCORE-3",
+                "status": "pr_open",
+                "repo": "lightspeed-stack",
+                "last_addressed": "2026-07-01T12:00:00",
+                "metadata": {"prs": [{"repo": "lightspeed-stack", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "Code Review"},
+            "labels": [],
+            "issuelinks": [],
+            "comment": {"comments": []},
+        }
+    }
+    candidates = [
+        {
+            "key": "LCORE-99",
+            "summary": "New CVE",
+            "status": "New",
+            "priority": "High",
+            "type": "Vulnerability",
+            "labels": ["Security"],
+            "repos": [],
+            "description": "Build it",
+            "comments": [],
+            "links": [],
+        }
+    ]
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_kanban_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_kanban_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_kanban_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_kanban_preflight._get_candidates", lambda rl: candidates)
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "LCORE-99" in out["content"]
+
+
+def test_at_capacity_investigation_only(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks()
+    inv_candidates = [
+        {
+            "key": "LCORE-4",
+            "summary": "Investigate outage",
+            "status": "New",
+            "priority": "High",
+            "type": "Task",
+            "labels": ["needs-investigation"],
+            "repos": [],
+            "description": "Look into it",
+            "comments": [],
+            "links": [],
+        }
+    ]
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (10, 10))
+    monkeypatch.setattr("jira_kanban_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_kanban_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_kanban_preflight._get_investigation_candidates", lambda rl: inv_candidates)
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "Investigation" in out["content"]
+
+
+def test_at_capacity_no_investigations_returns_skip(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks()
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (10, 10))
+    monkeypatch.setattr("jira_kanban_preflight.load_project_repos", lambda: {})
+    monkeypatch.setattr("jira_kanban_preflight.build_repo_lookup", lambda x: {})
+    monkeypatch.setattr("jira_kanban_preflight._get_investigation_candidates", lambda rl: [])
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "skip"
+    assert "capacity" in out["content"].lower()
+
+
+def test_missing_instance_id_returns_error(monkeypatch, capsys):
+    monkeypatch.setattr("jira_kanban_preflight.INSTANCE_ID", "")
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "error"
+
+
+def test_interrupted_task_returns_start(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "LCORE-5",
+                "status": "in_progress",
+                "repo": "lightspeed-stack",
+                "metadata": {"last_step": "implemented"},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "In Progress"},
+            "labels": [],
+            "issuelinks": [],
+            "comment": {"comments": []},
+        }
+    }
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_kanban_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "INTERRUPTED" in out["content"]
+
+
+def test_extra_jql_appended(env_vars, monkeypatch):
+    """BOT_KANBAN_JQL_EXTRA is included in candidate queries."""
+    monkeypatch.setattr("jira_kanban_preflight.BOT_KANBAN_JQL_EXTRA", "type = Vulnerability")
+    captured_jqls = []
+
+    def mock_search(jql, limit=10):
+        captured_jqls.append(jql)
+        return []
+
+    monkeypatch.setattr("jira_kanban_preflight._jira_search", mock_search)
+
+    from jira_kanban_preflight import _get_candidates
+
+    _get_candidates({})
+
+    assert len(captured_jqls) >= 1
+    assert "type = Vulnerability" in captured_jqls[0]
+
+
+def test_custom_statuses_in_query(env_vars, monkeypatch):
+    """Custom BOT_KANBAN_STATUSES appear in JQL."""
+    monkeypatch.setattr("jira_kanban_preflight.BOT_KANBAN_STATUSES", "Open,Ready")
+    captured_jqls = []
+
+    def mock_search(jql, limit=10):
+        captured_jqls.append(jql)
+        return []
+
+    monkeypatch.setattr("jira_kanban_preflight._jira_search", mock_search)
+
+    from jira_kanban_preflight import _get_candidates
+
+    _get_candidates({})
+
+    assert len(captured_jqls) >= 1
+    assert '"Open"' in captured_jqls[0]
+    assert '"Ready"' in captured_jqls[0]

--- a/presets/shared/preflight/jira_kanban_preflight.py
+++ b/presets/shared/preflight/jira_kanban_preflight.py
@@ -1,0 +1,369 @@
+"""Jira kanban preflight — triage active tasks + find new work candidates.
+
+Project-based candidate finder for kanban boards. Replaces sprint-based
+queries with configurable project + status filters.
+Returns start only when there's genuinely actionable work:
+  - Active tasks with Jira feedback or interrupted work → start
+  - Active tasks all clean + capacity + new candidates → start
+  - No active tasks + new candidates found → start
+  - No active tasks + no candidates → skip
+  - Active tasks, all Jira-clean, no capacity or no candidates → skip
+"""
+
+import os
+import sys
+
+from common import (
+    INSTANCE_ID,
+    build_repo_lookup,
+    fmt_comments,
+    fmt_task_header,
+    get_capacity,
+    get_task_prs,
+    get_tasks,
+    load_project_repos,
+    output_result,
+    save_state,
+)
+from jira_mcp import jira_call, jira_cleanup
+
+BOT_JIRA_PROJECT = os.environ.get("BOT_JIRA_PROJECT", "")
+BOT_JIRA_EMAIL = os.environ.get("BOT_JIRA_EMAIL", "")
+BOT_KANBAN_STATUSES = os.environ.get("BOT_KANBAN_STATUSES", "New,Backlog,To Do")
+BOT_KANBAN_JQL_EXTRA = os.environ.get("BOT_KANBAN_JQL_EXTRA", "")
+
+
+# ---------------------------------------------------------------------------
+# Triage helpers (same logic as jira_sprint_preflight)
+# ---------------------------------------------------------------------------
+
+
+def _jira_issue(key):
+    return jira_call(
+        "jira_get_issue",
+        {
+            "issue_key": key,
+            "fields": "summary,status,assignee,labels,issuelinks",
+            "comment_limit": 10,
+        },
+    )
+
+
+def _has_new_jira_feedback(jira_comments, last_addressed):
+    for c in jira_comments:
+        ct = c.get("created", "")[:16]
+        if last_addressed and ct > last_addressed[:16]:
+            body = c.get("body", "")
+            if not ("### " in body or "| " in body or "PR:" in body):
+                return True
+    return False
+
+
+def _fmt_jira(task, jira_data, jira_comments):
+    lines = fmt_task_header(task)
+    if jira_data:
+        fields = jira_data.get("fields", {})
+        lines.append(f"  jira_status: {fields.get('status', {}).get('name', '?')}")
+        labels = fields.get("labels", [])
+        if labels:
+            lines.append(f"  labels: {','.join(labels)}")
+        for lk in fields.get("issuelinks", [])[:5]:
+            lt = lk.get("type", {}).get("name", "?")
+            linked = lk.get("inwardIssue") or lk.get("outwardIssue", {})
+            if linked:
+                status = linked.get("fields", {}).get("status", {}).get("name", "?")
+                lines.append(f"  link: {lt} {linked.get('key', '?')} [{status}]")
+        last_addr = task.get("last_addressed")
+        jc = [
+            {
+                "author": c.get("author", {}).get("displayName", "?"),
+                "t": c.get("created", "")[:16],
+                "b": c.get("body", ""),
+            }
+            for c in jira_comments
+        ]
+        lines.append(fmt_comments(jc, "jira_comments", since=last_addr))
+    else:
+        lines.append("  [jira unavailable — use jira_get_issue]")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Find-work helpers
+# ---------------------------------------------------------------------------
+
+
+def _jira_search(jql, limit=10):
+    data = jira_call(
+        "jira_search",
+        {
+            "jql": jql,
+            "limit": limit,
+            "fields": "summary,status,labels,assignee,priority,description,comment,issuelinks,issuetype",
+        },
+    )
+    if not data:
+        return []
+    return data if isinstance(data, list) else data.get("issues", [])
+
+
+def _match_repo_labels(labels, repo_lookup):
+    repo_labels = [label.replace("repo:", "") for label in labels if label.startswith("repo:")]
+    if not repo_labels:
+        return []
+    matched = [repo_lookup[r] for r in repo_labels if r in repo_lookup]
+    return matched if len(matched) == len(repo_labels) else []
+
+
+def _format_candidates(issues, repo_lookup):
+    results = []
+    for issue in issues:
+        fields = issue.get("fields") or issue
+        labels = fields.get("labels", [])
+        repos = _match_repo_labels(labels, repo_lookup)
+        comment_data = fields.get("comment", {})
+        comments = (comment_data.get("comments") or [])[-5:] if isinstance(comment_data, dict) else []
+        status = fields.get("status", {})
+        priority = fields.get("priority", {})
+        issue_type = fields.get("issuetype") or fields.get("issue_type") or {}
+
+        results.append(
+            {
+                "key": issue["key"],
+                "summary": fields.get("summary") or issue.get("summary", ""),
+                "status": status.get("name", "?") if isinstance(status, dict) else str(status),
+                "priority": priority.get("name", "?") if isinstance(priority, dict) else str(priority),
+                "type": issue_type.get("name", "?") if isinstance(issue_type, dict) else str(issue_type),
+                "labels": labels,
+                "repos": repos,
+                "description": fields.get("description") or "",
+                "comments": comments,
+                "links": fields.get("issuelinks", []),
+            }
+        )
+    return results
+
+
+def _parse_statuses():
+    return [s.strip() for s in BOT_KANBAN_STATUSES.split(",") if s.strip()]
+
+
+def _get_candidates(repo_lookup):
+    if not BOT_JIRA_PROJECT:
+        print("ERR: BOT_JIRA_PROJECT not set", file=sys.stderr)
+        return []
+
+    statuses = _parse_statuses()
+    status_list = ", ".join(f'"{s}"' for s in statuses)
+    extra = f" AND {BOT_KANBAN_JQL_EXTRA}" if BOT_KANBAN_JQL_EXTRA.strip() else ""
+    candidates = []
+    seen_keys = set()
+
+    def collect(jql, tag):
+        added = 0
+        for c in _jira_search(jql, limit=10):
+            if c["key"] not in seen_keys:
+                seen_keys.add(c["key"])
+                candidates.append(c)
+                added += 1
+                if len(candidates) >= 10:
+                    break
+        print(f"  {tag}: +{added} (total {len(candidates)})", file=sys.stderr)
+
+    collect(
+        f"project = {BOT_JIRA_PROJECT} AND status IN ({status_list}) "
+        f"AND assignee is EMPTY{extra} "
+        f"ORDER BY priority DESC, created ASC",
+        "kanban/unassigned",
+    )
+
+    if len(candidates) < 10 and BOT_JIRA_EMAIL:
+        collect(
+            f"project = {BOT_JIRA_PROJECT} AND status IN ({status_list}) "
+            f'AND assignee = "{BOT_JIRA_EMAIL}"{extra} '
+            f"ORDER BY priority DESC, created ASC",
+            "kanban/bot-assigned",
+        )
+
+    return _format_candidates(candidates, repo_lookup)
+
+
+def _get_investigation_candidates(repo_lookup):
+    if not BOT_JIRA_PROJECT:
+        return []
+    statuses = _parse_statuses()
+    status_list = ", ".join(f'"{s}"' for s in statuses)
+    extra = f" AND {BOT_KANBAN_JQL_EXTRA}" if BOT_KANBAN_JQL_EXTRA.strip() else ""
+    issues = _jira_search(
+        f"project = {BOT_JIRA_PROJECT} AND labels = needs-investigation "
+        f"AND assignee is EMPTY AND status IN ({status_list}){extra} "
+        f"ORDER BY priority DESC, created ASC",
+        limit=5,
+    )
+    return _format_candidates(issues, repo_lookup)
+
+
+def _fmt_candidate(c):
+    lines = [f"{c['key']} [{c['status']}] priority={c['priority']} type={c['type']}"]
+    lines.append(f"  title: {c['summary']}")
+    if c["repos"]:
+        lines.append(f"  repos: {','.join(c['repos'])}")
+    else:
+        repo_labels = [label for label in c["labels"] if label.startswith("repo:")]
+        if repo_labels:
+            lines.append(f"  repo_labels: {','.join(repo_labels)} (NO MATCH in project-repos.json)")
+        else:
+            lines.append("  repos: (no repo: label — agent determines repo from ticket content)")
+    other_labels = [label for label in c["labels"] if not label.startswith("repo:")]
+    if other_labels:
+        lines.append(f"  labels: {','.join(other_labels)}")
+    for lk in c["links"][:5]:
+        lt = lk.get("type", {}).get("name", "?")
+        linked = lk.get("inwardIssue") or lk.get("outwardIssue", {})
+        if linked:
+            lk_status = linked.get("fields", {}).get("status", {}).get("name", "?")
+            lines.append(f"  link: {lt} {linked.get('key', '?')} [{lk_status}]")
+    if c["description"]:
+        lines.append("  description:")
+        for dl in c["description"].strip().split("\n"):
+            lines.append(f"    {dl}")
+    if c["comments"]:
+        lines.append(f"  comments ({len(c['comments'])}):")
+        for cm in c["comments"]:
+            author = cm.get("author", {}).get("displayName", "?")
+            t = cm.get("created", "")[:16]
+            body = cm.get("body", "")
+            lines.append(f"    [{t}] {author}:")
+            for bl in body.strip().split("\n"):
+                lines.append(f"      {bl}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    if not INSTANCE_ID:
+        output_result("error", "BOT_INSTANCE_ID not set")
+        return
+
+    tasks = get_tasks()
+    active_n, max_n = get_capacity()
+    active = [t for t in tasks if t.get("status") in ("in_progress", "pr_open", "pr_changes")]
+    paused = [t for t in tasks if t.get("status") == "paused"]
+    done = [t for t in tasks if t.get("status") == "done"]
+
+    lines = [f"## Jira Kanban Preflight (capacity {active_n}/{max_n})"]
+    lines.append("")
+
+    # Phase 1: Triage active tasks for Jira feedback / interruptions
+    if active:
+        feedback_tasks = []
+        interrupted_tasks = []
+        clean_tasks = []
+
+        for t in active:
+            key = t.get("external_key", "")
+            meta = t.get("metadata") or {}
+            prs = get_task_prs(t)
+
+            jira = _jira_issue(key) if key else None
+            jira_comments = []
+            if jira:
+                jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
+
+            is_interrupted = (
+                t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs") and not prs
+            )
+
+            if _has_new_jira_feedback(jira_comments, t.get("last_addressed", "")):
+                feedback_tasks.append((t, jira, jira_comments))
+            elif is_interrupted:
+                interrupted_tasks.append((t, jira, jira_comments))
+            else:
+                clean_tasks.append((t, jira, jira_comments))
+
+        actionable = len(feedback_tasks) + len(interrupted_tasks)
+
+        if feedback_tasks:
+            lines.append(f"### JIRA FEEDBACK ({len(feedback_tasks)})")
+            for t, jira, jc in feedback_tasks:
+                lines.append(_fmt_jira(t, jira, jc))
+                lines.append("")
+
+        if interrupted_tasks:
+            lines.append(f"### INTERRUPTED ({len(interrupted_tasks)})")
+            for t, jira, jc in interrupted_tasks:
+                lines.append(_fmt_jira(t, jira, jc))
+                lines.append("")
+
+        if clean_tasks:
+            lines.append(f"### CLEAN ({len(clean_tasks)})")
+            for t, _, _ in clean_tasks:
+                lines.append(f"  {t.get('external_key', '?')} [{t.get('status', '?')}] {t.get('repo', '?')}")
+            lines.append("")
+
+        if actionable > 0:
+            save_state({"jira": {"feedback": len(feedback_tasks), "interrupted": len(interrupted_tasks)}})
+            output_result("start", "\n".join(lines))
+            jira_cleanup()
+            return
+
+    # Phase 2: Search for new work candidates (capacity permitting)
+    if not active:
+        lines.append("No active tasks")
+    if done:
+        lines.append(f"done pending archival: {','.join(t.get('external_key', '?') for t in done)}")
+    if paused:
+        parts = (t.get("external_key", "?") + ":" + str(t.get("paused_reason", "")) for t in paused)
+        lines.append(f"paused: {' | '.join(parts)}")
+    lines.append("")
+
+    repos_dict = load_project_repos()
+    repo_lookup = build_repo_lookup(repos_dict)
+
+    if active_n >= max_n:
+        candidates = _get_investigation_candidates(repo_lookup)
+        jira_cleanup()
+        if not candidates:
+            lines.append(f"At capacity ({active_n}/{max_n}), no investigation tickets")
+            save_state({"jira": {"feedback": 0, "interrupted": 0}})
+            output_result("skip", "\n".join(lines))
+            return
+        lines.append(f"### Investigation Candidates (at capacity {active_n}/{max_n})")
+        lines.append("")
+        for c in candidates:
+            lines.append(_fmt_candidate(c))
+            lines.append("")
+        save_state({"jira": {"feedback": 0, "interrupted": 0}})
+        output_result("start", "\n".join(lines))
+        return
+
+    candidates = _get_candidates(repo_lookup)
+    jira_cleanup()
+
+    if not candidates:
+        lines.append("No eligible work candidates in kanban backlog")
+        save_state({"jira": {"feedback": 0, "interrupted": 0}})
+        output_result("skip", "\n".join(lines))
+        return
+
+    lines.append(f"### New Work Candidates ({len(candidates)})")
+    lines.append("")
+    for c in candidates:
+        lines.append(_fmt_candidate(c))
+        lines.append("")
+
+    lines.append(f"-> {len(candidates)} candidate(s) found")
+    lines.append(f"-> Top pick: {candidates[0]['key']}")
+    if candidates[0]["repos"]:
+        lines.append(f"   repos={','.join(candidates[0]['repos'])}")
+
+    save_state({"jira": {"feedback": 0, "interrupted": 0}})
+    output_result("start", "\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/presets/workflows/jira-kanban/CLAUDE.md
+++ b/presets/workflows/jira-kanban/CLAUDE.md
@@ -1,0 +1,270 @@
+Autonomous dev bot. Pick Jira tickets → impl → open PRs.
+
+## Workflow Loop
+
+ONE item/cycle. Priority order:
+
+**Status updates** via `bot_status_update`:
+- Cycle start: `working`, "Starting cycle — triaging tasks..."
+- Pick task: include `external_key` + `repo`
+- Cycle end: `idle`, "Cycle complete. Sleeping..." or "No work found. Sleeping..."
+- Error: `error`, "<what went wrong>"
+
+**Sleep signaling**: Skills write `data/cycle-sleep.json` telling runner sleep duration. Agent does NOT manage — automatic:
+- No signal file = standard 300s sleep (work done)
+- Runner reads + deletes file after each cycle
+
+### Input Data
+
+Task statuses, PR/MR states, Jira comments, PR comments, capacity — provided in input prompt. Do NOT re-fetch data already in input. Ticket shows `[jira unavailable]` → use `jira_get_issue` MCP tool for those only.
+
+### Priority 0: Resume + Respond to Feedback
+
+Use input data to identify tasks w/ unaddressed feedback. Do NOT re-fetch data already in input.
+
+**CRITICAL — Shared Jira identity**: Bot shares Jira creds w/ human operator → same author. CANNOT filter by author. Identify bot comments by **content patterns**: structured reports (### headers), grype scan tables, PR links, status updates, duplicate notices. Short conversational comments ("Hello bot, can you verify...", "Can you check...") = human. **When in doubt → treat as human feedback.**
+
+Investigation tasks (`last_step = "investigation_posted"`) especially important — humans reply days later.
+
+Action buckets (first match wins):
+
+1. **Unaddressed feedback** — PR reviews, Jira comments, failing CI, merge conflicts. Highest priority. Includes investigation follow-ups. **Before acting**: reload `personas/<name>/prompt.md` for repo. Has CI fix patterns + sequencing rules.
+2. **Interrupted work** — `in_progress` w/ `last_step` set, no PR yet. Reload persona → resume.
+3. **Investigations without report** — `in_progress` + `needs-investigation`, no analysis posted.
+4. **CVE investigations missing grype scan** — `last_step = "investigation_posted"`, no grype scan done. Build Dockerfile + scan per CVE persona.
+5. **Failed retryable tasks** — `last_step` = `clone_failed`/`push_failed`/`ci_failed`. **Start fresh**: close existing PR (if any), delete remote branch, delete local branch, re-create from default branch. Same err twice → `paused_reason`, move on.
+
+None apply → Priority 1.
+
+### Priority 1: Maintain Existing PRs
+
+PR statuses provided in input. For each `pr_open`/`pr_changes` task:
+
+0. **Reload persona**: Read `personas/<name>/prompt.md` for repo tech stack (same logic as step 6). Has CI fix patterns + sequencing rules.
+1. `cd` repo dir. `git fetch origin`. Fork? Also `git fetch upstream`.
+2. Check `host` in `project-repos.json` → `gh` (GitHub) or `glab` (GitLab). **ALL `glab` commands MUST include `--hostname gitlab.cee.redhat.com`** — without it, glab defaults to `gitlab.com` which is blocked. Fork repos: `glab mr` needs `--repo <upstream-project-path>`.
+3. **Review reminder**: No Slack notification sent → ALWAYS invoke `/slack-notify` w/ `review_reminder` (first notification, regardless of PR age). After first, cooldown handles repeats every 48h. **Bot reviews don't count** — only human reviews satisfy "reviewed". PR w/ only bot reviews = still needs human review → send reminder. **Bot review feedback IS actionable** — address coderabbitai/sourcery-ai suggestions as real feedback. Fix valid issues, dismiss false positives w/ reply.
+
+4. Handle in order:
+
+**Failing CI**: `gh pr checks <n>` / `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`. Checkout branch → fix → commit → push. Jira comment. `task_update` `last_addressed`.
+
+**Merge conflicts**: Rebase on default branch → resolve → force push. Jira comment. `task_update` `last_addressed`.
+
+**PR/MR review feedback**:
+- GH: MUST check BOTH:
+  1. Inline: `gh api repos/{owner}/{repo}/pulls/{n}/comments`
+  2. General: `gh api repos/{owner}/{repo}/issues/{n}/comments`
+- GL: `glab api "projects/<url-encoded-project>/merge_requests/<n>/notes?per_page=50&sort=asc" --hostname gitlab.cee.redhat.com` — parse JSON for author + body. `glab mr view --comments` truncates, use API for full text. CI errs appear in devtools-bot notes — grep for `ERROR` / `failed`.
+- **Read FULL conversation** — don't rely on `last_addressed` as cutoff. For each comment, check if addressed: bot replied? subsequent commit fixed? thread resolved? approval vs actionable req? `last_addressed` = soft hint only.
+- Read ALL comments including bot's own (GH: identify by `user.login`). Bot's own comments = ctx for what's addressed, NOT new feedback. **Exception**: bot's own comments describing pending action (e.g. "commits are unsigned", "needs rebase", "will fix in next cycle") ARE open tasks — treat as self-assigned work items. Human comments w/o bot reply or subsequent fix = outstanding. Address outstanding feedback → commit → push.
+
+**Unsigned commits**: PR has unsigned commits (bot previously noted, or `git log --show-signature` shows unsigned) → checkout branch, `git rebase --force-rebase HEAD~N` (N = unsigned commit count) to re-sign, force push. Priority 0 fix — unsigned commits block merge.
+- Screenshots requested → follow persona's "Verification for UI changes". Dev server + chrome-devtools MCP. **Never commit screenshots.** Upload via `/gh-release-upload` skill: `python3 .claude/skills/gh-release-upload/upload.py /tmp/screenshots/foo.png owner/repo`. Never use `gh release upload` directly (fails through thin client). Reference returned URLs in PR comment.
+- Reply to reviews via `gh` / `glab api "projects/<url-encoded-project>/merge_requests/<n>/notes" -X POST -f "body=<text>" --hostname gitlab.cee.redhat.com`. `task_update` `last_addressed`. `memory_store` notable feedback as `review_feedback`. Jira comment.
+
+**Jira comments**:
+- `jira_get_issue` → read ALL comments. Identify bot comments by **content patterns only** (structured reports, tables, PR links). Short conversational = human. **Do NOT filter by author** (shared identity). When in doubt → human feedback.
+- Question → reply via `jira_add_comment`
+- Change req → impl, commit, push, reply
+- Ctx/requirements → incorporate
+- `task_update` `last_addressed`
+
+**PR merged**: Invoke `/wrap-up` w/ Jira key. Script handles: task archival, Jira transition → "Release Pending", Jira comment, Slack notification, remote + local branch deletion (tolerates already-deleted branches). After wrap-up:
+- **Update linked issues**: duplicates → comment fix merged. Related → link PR. Blocked → blocker resolved.
+- **Store learnings**: `memory_store` as `learning` + `codebase_pattern`. Set `repo` + `tags`.
+
+**Unresolvable**: Jira comment explaining blocker. `task_update` `paused_reason`. Invoke `/slack-notify` w/ `needs_help`: "{KEY} blocked — {reason}". Task stays tracked.
+
+Handle one PR issue → stop. Next cycle picks up next.
+
+### Priority 1.5: Check Assigned Tickets
+
+Use input data to identify:
+1. **Merged PRs?** Input shows `state=MERGED` → invoke `/wrap-up <KEY>`. Then `memory_store` learnings.
+2. **New Jira comments?** Visible in input. Handle: questions → reply, requirements → incorporate, close reqs → respect.
+3. PR still open, no comments → skip (Priority 1 handles).
+
+One ticket/cycle → stop.
+
+### Priority 2: New Jira Work
+
+ALL tasks clean — no pending feedback/interrupted work/unfinished investigations, PRs passing CI, no unaddressed reviews.
+
+**Check capacity**: `task_check_capacity`. No capacity → only investigation tickets (`needs-investigation`). At limit for impl tickets.
+
+New work candidates provided in input prompt (sourced from kanban board by project + status).
+
+Pick first candidate. At capacity → only `needs-investigation`. No candidates → memory housekeeping → "NO_WORK_FOUND" → stop.
+
+**`[FIRING]` / ALERT tickets ARE real work.** `ALERT{hash}` labels + `[FIRING]` prefixes = automated alerts needing fixes (e.g. RDSEOL = RDS end-of-life upgrades). NOT monitoring noise. Treat like any ticket — match persona, impl. Priority often higher — signals something broken/expiring.
+
+**Before skipping "too complex" ticket**: check `personas/` for matching persona (e.g. `rds-upgrade` for RDS/blue-green). Read persona prompt — may have multi-cycle workflow. Persona exists → attempt. No persona + genuinely blocked → Jira comment w/ reason, leave unassigned, next candidate. Never silently skip.
+
+**During candidate scanning**: Ticket is duplicate or already addressed by another ticket/PR → do NOT silently skip. MUST: `jira_add_comment` explaining which ticket/PR addresses it → `jira_transition_issue` "Release Pending" → `jira_create_issue_link` (duplicates). Then next candidate. Keeps Jira clean, avoids re-scanning.
+
+#### Memory Housekeeping (idle)
+
+≤3-5 memories/cycle. `memory_list` limit=10 → `memory_search` each for duplicates (>80% similarity) → consolidate → `memory_store` merged + `memory_delete` originals.
+
+#### Investigation Tickets
+
+`needs-investigation` label → do NOT impl. Instead:
+
+1. Claim ticket (assign self, "In Progress")
+2. `task_add` w/ `in_progress`. Investigations don't count toward 10-task cap.
+3. `memory_search` for repo + problem area
+4. Read all `repo:` repos — `git fetch origin && git pull` → explore relevant code
+5. Investigate: trace issue, identify root causes, files, repos
+6. `jira_add_comment` — detailed report: root cause, affected repos/files, suggested fix, blockers
+7. `memory_store` as `learning` + `codebase_pattern`
+8. `task_update` summary + `last_step = "investigation_posted"`. Do NOT archive. Stays `in_progress` until human confirms:
+   - Human confirms/closes → archive
+   - Human asks follow-up → treat as feedback, do work, reply, update `last_addressed`
+9. Do NOT close Jira ticket. Remove `needs-investigation` label only.
+
+#### Check Linked Issues
+
+Before starting work, `jira_get_issue` → check issue links:
+
+1. **Duplicates**: Other ticket done/merged → comment, transition "Release Pending", skip. Other in progress → comment, link, skip.
+2. **Blocked by**: Blocker unresolved → comment, stop.
+3. **Related**: Note. PR opened → comment on related w/ PR link.
+4. **Parent/Epic**: Note. Done → check if all siblings done → mention.
+
+#### Implement
+
+1. **Claim**: `$BOT_JIRA_EMAIL` for assignee (never `jira_get_user_profile`). `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress". No sprint management — kanban board tracks status automatically.
+
+2. **Track**: `task_add` w/ `external_key, repo, branch (bot/<KEY>), in_progress, title, summary, metadata`:
+   ```json
+   {"last_step": "branch_created", "next_step": "implement", "repos": ["pdf-generator", "app-interface"]}
+   ```
+
+3. **Details**: `jira_get_issue` — title, description, acceptance criteria.
+
+4. **Search memory** (multiple queries):
+   - By ticket description/title
+   - By repo (`repo` filter) → repo-specific patterns
+   - By category: `review_feedback` + repo, `codebase_pattern` + repo, `learning`
+   - By tags: `css`, `testing`, `patternfly`, `ci`, `dependency-upgrade`
+   - Apply ALL insights. Avoid past reviewer corrections. Follow learned conventions.
+
+5. **Prepare repos**: `repo:` labels → match `project-repos.json`. Bare (`repo:insights-chrome`) or org-prefixed (`repo:RedHatInsights/insights-chrome`) — org/repo resolved via upstream URLs. Fork workflow default:
+   - `url` = bot's fork, `upstream` = original repo (PR target), `host` = "gitlab" if GL, `readonly` = read only
+
+   Dir = `./repos/<repo-name>/` (from upstream URL basename, no `.git`).
+
+   **Clone on demand**: Not exists → `git clone --depth 1 --single-branch <url> ./repos/<name>/`. Has upstream → `git remote add upstream <upstream-url>`. More history needed → `git fetch --deepen=50` or `git fetch --unshallow`. Clone fails → Jira comment, stop.
+
+   **Verify remotes**: Exists → `git remote -v`. Origin must match `url`. Upstream remote must match `upstream` field. Fix w/ `set-url`/`add` as needed.
+
+   Non-readonly repos:
+   - Fork: `git fetch upstream` → `git checkout master && git reset --hard upstream/master`. Push fails → sync fork first: `gh repo sync <fork> --source <upstream> --force`
+   - Direct: `git fetch origin` → checkout default branch → pull
+   - Branch: `bot/<TICKET-KEY>`
+
+   **Retry → start clean**:
+   1. Close existing PR if open: GH `gh pr close <n> --repo <upstream>` / GL `glab mr close <n> --hostname gitlab.cee.redhat.com`
+   2. Delete remote branch: GH `gh api repos/{owner}/{repo}/git/refs/heads/bot/{KEY} -X DELETE` / GL `glab api projects/:id/repository/branches/bot%2F{KEY} -X DELETE --hostname gitlab.cee.redhat.com`
+   3. Delete local branch: `git branch -D bot/<KEY>`
+   4. Re-create branch from updated default branch, re-impl
+
+   **Git identity**: Global config set by `run.py` at startup (name, email, GPG signing). Do NOT run `git config --local` for identity/signing — handled globally. Do NOT check `GPG_SIGNING_KEY` env var (sanitized at startup).
+
+   Readonly: `git fetch origin` + pull. Read only.
+
+   **Repo CLAUDE.md**: Exists → read in full. References other files (e.g. `@AGENTS.md`) → read those too. Repo instructions override persona guidelines.
+
+6. **Load personas**: Dynamic by tech stack:
+   - `package.json` w/ React/PF → `frontend`
+   - `go.mod` → `backend`/`operator`
+   - `Pipfile`/`requirements.txt` w/ Django → `backend`/`rbac`
+   - Dockerfiles/scripts/Caddyfiles → `tooling`
+   - Config/YAML repo → `config`
+   - CVE ticket → also `cve` (layered on base)
+   - RDS EOL / blue-green upgrade ticket → also `rds-upgrade` (layered on `config`)
+   - Read `personas/<name>/prompt.md`. Multi-repo → load ALL.
+   - Persona scoping: frontend rules only in frontend repos, etc.
+   - Cross-repo: plan holistically, dep order (upstream first), reference in commits/PR.
+
+7. **Implement**: Read ticket carefully. Follow repo conventions.
+   - Use LSP: `get_diagnostics`, `get_hover`, `go_to_definition`, `find_references`. Diagnostics before commit.
+   - **npm scripts only**: `npm test` not `npx jest`. `npm run lint` not `npx eslint`. Never call CLIs directly.
+   - **Testing mandatory**: Run existing tests. Find related tests. No coverage → write new tests. Run + verify pass.
+   - Lint via npm scripts.
+   - **Memory before commit**: `memory_search` "commit message"/"commit convention"/"PR title" + `review_feedback` + repo filter. Apply ALL feedback across all repos.
+   - Conventional commits: `type(scope): short description` (≤50 chars title). Ticket key in body.
+   ```
+   fix(chatbot): move VA to top of dropdown
+
+   RHCLOUD-46011
+   Reorder addHook calls so VA is registered first.
+   ```
+
+8. **Update progress**: `task_update` summary + metadata `{"last_step": "tests_passing", "next_step": "push_and_pr", "files_changed": [...]}`.
+
+9. **Visual verification**: UI changes → persona's "Verification" section. Dev server + chrome-devtools. Never commit screenshots. Upload via `/gh-release-upload` skill → reference returned URLs in PR. Never use `gh release upload` directly. Skip = rejection.
+
+10. **Push + PR**: `git push origin bot/<KEY>`
+
+    **IMPORTANT**: Do NOT use `gh pr create` / `glab mr create` — don't work in this env. Use API calls:
+
+    GH (fork): `gh api repos/<upstream-owner>/<repo>/pulls -X POST -f title="..." -f body="..." -f head="<fork-owner>:bot/<KEY>" -f base="<default-branch>"`
+    GH (direct): `gh api repos/<owner>/<repo>/pulls -X POST -f title="..." -f body="..." -f head="bot/<KEY>" -f base="<default-branch>"`
+    Push fails → `last_step = "push_failed"`, Jira comment, keep `in_progress` for retry.
+
+    GL (fork): `glab api projects/<upstream-url-encoded>/merge_requests -X POST -f source_branch="bot/<KEY>" -f target_branch="<default-branch>" -f title="..." -f description="$(cat <<'EOF' ... EOF)" --hostname gitlab.cee.redhat.com`
+    GL (direct): same but project path = own repo.
+
+    **CRITICAL**: glab URL-encodes newlines if description passed inline. ALWAYS use heredoc `$(cat <<'EOF' ... EOF)` for multiline descriptions.
+
+    Parse PR/MR number + URL from JSON res. Title ≤50 chars.
+    **PR body**: Use `/push-and-pr` skill's `--find-template` to discover repo's PR template. Found → fill each section (see SKILL.md). Not found → freeform: ticket key + changes summary.
+    Readonly repos: include config changes in Jira comment.
+
+11. **Track PRs**: `task_update` status `pr_open`, `summary`, `last_addressed`. PRs tracked via `metadata.prs`. Multi-repo: `metadata.prs`:
+    ```json
+    {"last_step": "pr_opened", "files_changed": [...], "commits": [...],
+     "prs": [{"repo": "...", "number": 42, "url": "...", "host": "github"}]}
+    ```
+
+12. **Report on Jira**: `jira_transition_issue` → "Code Review". `jira_add_comment`: what done, PR links, concerns. Update linked issues w/ PR links (one comment per, only on PR open or completion).
+
+13. **Notify Slack**: Invoke `/slack-notify` w/ `pr_created`: "{KEY}: {title} — PR: {url}". Also `needs_help` if investigation or blocked.
+
+## Progress Tracking
+
+Keep task record updated throughout (not just end). `task_update` w/ `summary` + `metadata` at each milestone:
+
+- `last_step`: `branch_created`/`implemented`/`tests_passing`/`push_failed`/`pr_opened`/`review_addressed`/`investigation_posted`/`archived`
+- `files_changed`, `commits`, `next_step`, `notes`, `repos`, `prs`
+
+### Cycle Progress (progress_load / progress_store)
+
+Persists structured progress across cycles. Separate from `task_update` — creates **history**, not just current state.
+
+**On resume** (existing task, not new):
+1. `task_get(external_key)` → note `id` field = `task_id`
+2. `progress_load(task_id=<id>)` → last 5 cycle summaries
+3. Use returned progress → understand prior decisions, files, blockers, where left off
+
+**Before cycle ends** (after work on task):
+1. `progress_store(task_id=<id>, instance_id=<instance>, cycle_type="task_work", progress={...})`
+2. Progress keys: `last_step`, `next_step`, `files_changed`, `commits`, `key_decisions`, `blockers`, `notes`
+3. In addition to `task_update` — call both
+
+Idle/err cycles: `run.py` handles automatically. No agent action.
+
+**On startup — interrupted work**: `in_progress` w/ `last_step` set? → `progress_load(task_id)` for cycle history + `memory_search` repo + problem → resume from `next_step`. Cycle progress = per-cycle history. Task metadata = current state. RAG memory = cross-ticket learnings.
+
+## Rules
+
+- ONE item/cycle
+- PR maintenance > new tickets
+- Blocked/ambiguous → Jira comment + stop
+- Stay in ticket scope
+- **No Jira spam**: Read existing comments first. Same info already posted → don't repeat
+- **Store learnings**: After completion/notable feedback → `memory_store` w/ specific category + `repo` + `tags`
+- **Search before starting**: Multiple `memory_search` queries (step 4). Avoid repeating mistakes.
+- **Use runtime-provided env vars**: Skills MUST use existing runtime env vars (see deploy/template.yaml). Never introduce custom `BOT_*` vars if runtime already provides equivalent. Examples: use `GH_USER_NAME` (not `BOT_GITHUB_USERNAME`), `BOT_JIRA_EMAIL` (not `JIRA_USER`), `BOT_CONFIG_PATH` (already exists). Check deployment config before adding new env var requirements.

--- a/presets/workflows/jira-kanban/CLAUDE.md
+++ b/presets/workflows/jira-kanban/CLAUDE.md
@@ -7,194 +7,179 @@ ONE item/cycle. Priority order:
 **Status updates** via `bot_status_update`:
 - Cycle start: `working`, "Starting cycle — triaging tasks..."
 - Pick task: include `external_key` + `repo`
-- Cycle end: `idle`, "Cycle complete. Sleeping..." or "No work found. Sleeping..."
+- Cycle end: `idle`, "Cycle complete. Sleeping..." / "No work found. Sleeping..."
 - Error: `error`, "<what went wrong>"
 
-**Sleep signaling**: Skills write `data/cycle-sleep.json` telling runner sleep duration. Agent does NOT manage — automatic:
-- No signal file = standard 300s sleep (work done)
-- Runner reads + deletes file after each cycle
+**Sleep signaling**: Skills write `data/cycle-sleep.json` w/ sleep duration. Agent does NOT manage — automatic. No signal file = 300s default. Runner reads + deletes after cycle.
 
 ### Input Data
 
-Task statuses, PR/MR states, Jira comments, PR comments, capacity — provided in input prompt. Do NOT re-fetch data already in input. Ticket shows `[jira unavailable]` → use `jira_get_issue` MCP tool for those only.
+Task statuses, PR/MR states, Jira comments, PR comments, capacity — in input prompt. Do NOT re-fetch. `[jira unavailable]` → `jira_get_issue` MCP for those only.
 
 ### Priority 0: Resume + Respond to Feedback
 
-Use input data to identify tasks w/ unaddressed feedback. Do NOT re-fetch data already in input.
+Use input data for tasks w/ unaddressed feedback. Do NOT re-fetch.
 
-**CRITICAL — Shared Jira identity**: Bot shares Jira creds w/ human operator → same author. CANNOT filter by author. Identify bot comments by **content patterns**: structured reports (### headers), grype scan tables, PR links, status updates, duplicate notices. Short conversational comments ("Hello bot, can you verify...", "Can you check...") = human. **When in doubt → treat as human feedback.**
+**CRITICAL — Shared Jira identity**: Bot shares creds w/ human → same author. CANNOT filter by author. Bot comments = **content patterns**: structured reports (### headers), grype scan tables, PR links, status updates, dup notices. Short conversational = human. **When in doubt → human feedback.**
 
-Investigation tasks (`last_step = "investigation_posted"`) especially important — humans reply days later.
+Investigation tasks (`last_step = "investigation_posted"`) — humans reply days later.
 
 Action buckets (first match wins):
 
-1. **Unaddressed feedback** — PR reviews, Jira comments, failing CI, merge conflicts. Highest priority. Includes investigation follow-ups. **Before acting**: reload `personas/<name>/prompt.md` for repo. Has CI fix patterns + sequencing rules.
-2. **Interrupted work** — `in_progress` w/ `last_step` set, no PR yet. Reload persona → resume.
-3. **Investigations without report** — `in_progress` + `needs-investigation`, no analysis posted.
-4. **CVE investigations missing grype scan** — `last_step = "investigation_posted"`, no grype scan done. Build Dockerfile + scan per CVE persona.
-5. **Failed retryable tasks** — `last_step` = `clone_failed`/`push_failed`/`ci_failed`. **Start fresh**: close existing PR (if any), delete remote branch, delete local branch, re-create from default branch. Same err twice → `paused_reason`, move on.
+1. **Unaddressed feedback** — PR reviews, Jira comments, failing CI, merge conflicts. Highest pri. Includes investigation follow-ups. Reload `personas/<name>/prompt.md` first.
+2. **Interrupted work** — `in_progress` w/ `last_step`, no PR. Reload persona → resume.
+3. **Investigations w/o report** — `in_progress` + `needs-investigation`, no analysis posted.
+4. **CVE investigations missing grype scan** — `last_step = "investigation_posted"`, no grype. Build Dockerfile + scan per CVE persona.
+5. **Failed retryable** — `last_step` = `clone_failed`/`push_failed`/`ci_failed`. Start fresh: close PR, delete remote+local branch, re-create from default. Same err twice → `paused_reason`, move on.
 
-None apply → Priority 1.
+None → Priority 1.
 
 ### Priority 1: Maintain Existing PRs
 
-PR statuses provided in input. For each `pr_open`/`pr_changes` task:
+PR statuses in input. For each `pr_open`/`pr_changes`:
 
-0. **Reload persona**: Read `personas/<name>/prompt.md` for repo tech stack (same logic as step 6). Has CI fix patterns + sequencing rules.
-1. `cd` repo dir. `git fetch origin`. Fork? Also `git fetch upstream`.
-2. Check `host` in `project-repos.json` → `gh` (GitHub) or `glab` (GitLab). **ALL `glab` commands MUST include `--hostname gitlab.cee.redhat.com`** — without it, glab defaults to `gitlab.com` which is blocked. Fork repos: `glab mr` needs `--repo <upstream-project-path>`.
-3. **Review reminder**: No Slack notification sent → ALWAYS invoke `/slack-notify` w/ `review_reminder` (first notification, regardless of PR age). After first, cooldown handles repeats every 48h. **Bot reviews don't count** — only human reviews satisfy "reviewed". PR w/ only bot reviews = still needs human review → send reminder. **Bot review feedback IS actionable** — address coderabbitai/sourcery-ai suggestions as real feedback. Fix valid issues, dismiss false positives w/ reply.
+0. Reload persona for repo tech stack. Has CI fix patterns.
+1. `cd` repo. `git fetch origin`. Fork → also `git fetch upstream`.
+2. `host` in `project-repos.json` → `gh` (GH) / `glab` (GL). **ALL `glab` MUST include `--hostname gitlab.cee.redhat.com`**. Fork: `glab mr` needs `--repo <upstream-project-path>`.
+3. **Review reminder**: No Slack notif sent → ALWAYS `/slack-notify` w/ `review_reminder`. After first, cooldown 48h. Bot reviews don't count — only human reviews. Bot review feedback IS actionable — address coderabbitai/sourcery-ai suggestions.
 
 4. Handle in order:
 
-**Failing CI**: `gh pr checks <n>` / `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`. Checkout branch → fix → commit → push. Jira comment. `task_update` `last_addressed`.
+**Failing CI**: `gh pr checks <n>` / `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`. Checkout → fix → commit → push. Jira comment. `task_update last_addressed`.
 
-**Merge conflicts**: Rebase on default branch → resolve → force push. Jira comment. `task_update` `last_addressed`.
+**Merge conflicts**: Rebase default branch → resolve → force push. Jira comment. `task_update last_addressed`.
 
 **PR/MR review feedback**:
-- GH: MUST check BOTH:
-  1. Inline: `gh api repos/{owner}/{repo}/pulls/{n}/comments`
-  2. General: `gh api repos/{owner}/{repo}/issues/{n}/comments`
-- GL: `glab api "projects/<url-encoded-project>/merge_requests/<n>/notes?per_page=50&sort=asc" --hostname gitlab.cee.redhat.com` — parse JSON for author + body. `glab mr view --comments` truncates, use API for full text. CI errs appear in devtools-bot notes — grep for `ERROR` / `failed`.
-- **Read FULL conversation** — don't rely on `last_addressed` as cutoff. For each comment, check if addressed: bot replied? subsequent commit fixed? thread resolved? approval vs actionable req? `last_addressed` = soft hint only.
-- Read ALL comments including bot's own (GH: identify by `user.login`). Bot's own comments = ctx for what's addressed, NOT new feedback. **Exception**: bot's own comments describing pending action (e.g. "commits are unsigned", "needs rebase", "will fix in next cycle") ARE open tasks — treat as self-assigned work items. Human comments w/o bot reply or subsequent fix = outstanding. Address outstanding feedback → commit → push.
+- GH: check BOTH: inline `gh api repos/{o}/{r}/pulls/{n}/comments` + general `gh api repos/{o}/{r}/issues/{n}/comments`
+- GL: `glab api "projects/<enc>/merge_requests/<n>/notes?per_page=50&sort=asc" --hostname gitlab.cee.redhat.com` — parse JSON. `glab mr view --comments` truncates, use API.
+- Read FULL conversation. `last_addressed` = soft hint only. Each comment: addressed? Bot replied? Commit fixed? Thread resolved?
+- Read ALL comments incl bot's own (GH: `user.login`). Bot's own = ctx, NOT feedback. **Exception**: bot's pending action comments ("unsigned", "needs rebase") = self-assigned work. Human w/o reply/fix = outstanding → address → commit → push.
 
-**Unsigned commits**: PR has unsigned commits (bot previously noted, or `git log --show-signature` shows unsigned) → checkout branch, `git rebase --force-rebase HEAD~N` (N = unsigned commit count) to re-sign, force push. Priority 0 fix — unsigned commits block merge.
-- Screenshots requested → follow persona's "Verification for UI changes". Dev server + chrome-devtools MCP. **Never commit screenshots.** Upload via `/gh-release-upload` skill: `python3 .claude/skills/gh-release-upload/upload.py /tmp/screenshots/foo.png owner/repo`. Never use `gh release upload` directly (fails through thin client). Reference returned URLs in PR comment.
-- Reply to reviews via `gh` / `glab api "projects/<url-encoded-project>/merge_requests/<n>/notes" -X POST -f "body=<text>" --hostname gitlab.cee.redhat.com`. `task_update` `last_addressed`. `memory_store` notable feedback as `review_feedback`. Jira comment.
+**Unsigned commits**: `git log --show-signature` shows unsigned → `git rebase --force-rebase HEAD~N` → force push. Pri 0 fix — blocks merge.
+- Screenshots → persona "Verification". Dev server + chrome-devtools. **Never commit screenshots.** Upload via `/gh-release-upload`: `python3 .claude/skills/gh-release-upload/upload.py /tmp/screenshots/foo.png owner/repo`. Never `gh release upload` directly. Ref URLs in PR comment.
+- Reply via `gh` / `glab api`. `task_update last_addressed`. `memory_store` notable as `review_feedback`. Jira comment.
 
 **Jira comments**:
-- `jira_get_issue` → read ALL comments. Identify bot comments by **content patterns only** (structured reports, tables, PR links). Short conversational = human. **Do NOT filter by author** (shared identity). When in doubt → human feedback.
-- Question → reply via `jira_add_comment`
-- Change req → impl, commit, push, reply
-- Ctx/requirements → incorporate
-- `task_update` `last_addressed`
+- `jira_get_issue` → ALL comments. Bot = content patterns only. Short conversational = human. Shared identity → don't filter author.
+- Question → reply. Change req → impl+commit+push+reply. Ctx → incorporate. `task_update last_addressed`.
 
-**PR merged**: Invoke `/wrap-up` w/ Jira key. Script handles: task archival, Jira transition → "Release Pending", Jira comment, Slack notification, remote + local branch deletion (tolerates already-deleted branches). After wrap-up:
-- **Update linked issues**: duplicates → comment fix merged. Related → link PR. Blocked → blocker resolved.
-- **Store learnings**: `memory_store` as `learning` + `codebase_pattern`. Set `repo` + `tags`.
+**PR merged**: `/wrap-up` w/ Jira key. Handles: archival, Jira → "Release Pending", Slack, branch cleanup. After:
+- Update linked: dups → comment fix merged. Related → link PR. Blocked → resolved.
+- `memory_store` as `learning` + `codebase_pattern`. Set `repo` + `tags`.
 
-**Unresolvable**: Jira comment explaining blocker. `task_update` `paused_reason`. Invoke `/slack-notify` w/ `needs_help`: "{KEY} blocked — {reason}". Task stays tracked.
+**Unresolvable**: Jira comment w/ blocker. `task_update paused_reason`. `/slack-notify` `needs_help`.
 
-Handle one PR issue → stop. Next cycle picks up next.
+One PR issue → stop. Next cycle picks next.
 
 ### Priority 1.5: Check Assigned Tickets
 
-Use input data to identify:
-1. **Merged PRs?** Input shows `state=MERGED` → invoke `/wrap-up <KEY>`. Then `memory_store` learnings.
-2. **New Jira comments?** Visible in input. Handle: questions → reply, requirements → incorporate, close reqs → respect.
-3. PR still open, no comments → skip (Priority 1 handles).
+From input data:
+1. **Merged?** `state=MERGED` → `/wrap-up <KEY>`. `memory_store` learnings.
+2. **New Jira comments?** Handle: questions → reply, reqs → incorporate, close → respect.
+3. PR open, no comments → skip (Pri 1 handles).
 
 One ticket/cycle → stop.
 
 ### Priority 2: New Jira Work
 
-ALL tasks clean — no pending feedback/interrupted work/unfinished investigations, PRs passing CI, no unaddressed reviews.
+ALL tasks clean — no feedback/interrupted/unfinished, PRs passing CI, no unaddressed reviews.
 
-**Check capacity**: `task_check_capacity`. No capacity → only investigation tickets (`needs-investigation`). At limit for impl tickets.
+**Capacity**: `task_check_capacity`. No capacity → investigation only (`needs-investigation`).
 
-New work candidates provided in input prompt (sourced from kanban board by project + status).
+Candidates in input prompt (sourced from kanban board by project + status).
 
-Pick first candidate. At capacity → only `needs-investigation`. No candidates → memory housekeeping → "NO_WORK_FOUND" → stop.
+Pick first candidate. At capacity → `needs-investigation` only. No candidates → memory housekeeping → "NO_WORK_FOUND" → stop.
 
-**`[FIRING]` / ALERT tickets ARE real work.** `ALERT{hash}` labels + `[FIRING]` prefixes = automated alerts needing fixes (e.g. RDSEOL = RDS end-of-life upgrades). NOT monitoring noise. Treat like any ticket — match persona, impl. Priority often higher — signals something broken/expiring.
+**`[FIRING]`/ALERT = real work.** `ALERT{hash}` labels + `[FIRING]` = automated alerts needing fixes. NOT noise. Match persona, impl. Often higher pri.
 
-**Before skipping "too complex" ticket**: check `personas/` for matching persona (e.g. `rds-upgrade` for RDS/blue-green). Read persona prompt — may have multi-cycle workflow. Persona exists → attempt. No persona + genuinely blocked → Jira comment w/ reason, leave unassigned, next candidate. Never silently skip.
+**Before skipping "complex"**: check `personas/` for match (e.g. `rds-upgrade`). Read prompt — may have multi-cycle workflow. Persona exists → attempt. No persona + blocked → Jira comment, leave unassigned, next. Never silently skip.
 
-**During candidate scanning**: Ticket is duplicate or already addressed by another ticket/PR → do NOT silently skip. MUST: `jira_add_comment` explaining which ticket/PR addresses it → `jira_transition_issue` "Release Pending" → `jira_create_issue_link` (duplicates). Then next candidate. Keeps Jira clean, avoids re-scanning.
+**Dup scanning**: Ticket = dup / already addressed → `jira_add_comment` explaining → `jira_transition_issue` "Release Pending" → `jira_create_issue_link` (duplicates). Next candidate.
 
 #### Memory Housekeeping (idle)
 
-≤3-5 memories/cycle. `memory_list` limit=10 → `memory_search` each for duplicates (>80% similarity) → consolidate → `memory_store` merged + `memory_delete` originals.
+≤3-5/cycle. `memory_list` limit=10 → `memory_search` each for dups (>80%) → consolidate → `memory_store` merged + `memory_delete` originals.
 
 #### Investigation Tickets
 
-`needs-investigation` label → do NOT impl. Instead:
+`needs-investigation` → do NOT impl:
 
-1. Claim ticket (assign self, "In Progress")
-2. `task_add` w/ `in_progress`. Investigations don't count toward 10-task cap.
-3. `memory_search` for repo + problem area
-4. Read all `repo:` repos — `git fetch origin && git pull` → explore relevant code
-5. Investigate: trace issue, identify root causes, files, repos
-6. `jira_add_comment` — detailed report: root cause, affected repos/files, suggested fix, blockers
-7. `memory_store` as `learning` + `codebase_pattern`
-8. `task_update` summary + `last_step = "investigation_posted"`. Do NOT archive. Stays `in_progress` until human confirms:
-   - Human confirms/closes → archive
-   - Human asks follow-up → treat as feedback, do work, reply, update `last_addressed`
-9. Do NOT close Jira ticket. Remove `needs-investigation` label only.
+1. Claim (assign self, "In Progress")
+2. `task_add` `in_progress`. Don't count toward 10-cap.
+3. `memory_search` repo + problem area
+4. Read `repo:` repos — `git fetch origin && git pull` → explore
+5. Investigate: trace, root causes, files, repos
+6. `jira_add_comment` — report: root cause, affected, suggested fix, blockers
+7. `memory_store` `learning` + `codebase_pattern`
+8. `task_update` summary + `last_step = "investigation_posted"`. Do NOT archive. Stays `in_progress` til human confirms. Follow-up → feedback loop.
+9. Do NOT close Jira. Remove `needs-investigation` label only.
 
 #### Check Linked Issues
 
-Before starting work, `jira_get_issue` → check issue links:
+Before work, `jira_get_issue` → check links:
 
-1. **Duplicates**: Other ticket done/merged → comment, transition "Release Pending", skip. Other in progress → comment, link, skip.
-2. **Blocked by**: Blocker unresolved → comment, stop.
-3. **Related**: Note. PR opened → comment on related w/ PR link.
-4. **Parent/Epic**: Note. Done → check if all siblings done → mention.
+1. **Dups**: Done/merged → comment, "Release Pending", skip. In progress → comment, link, skip.
+2. **Blocked by**: Unresolved → comment, stop.
+3. **Related**: Note. PR → comment on related w/ link.
+4. **Parent/Epic**: Note. All siblings done → mention.
 
 #### Implement
 
-1. **Claim**: `$BOT_JIRA_EMAIL` for assignee (never `jira_get_user_profile`). `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress". No sprint management — kanban board tracks status automatically.
+1. **Claim**: `$BOT_JIRA_EMAIL` for assignee (never `jira_get_user_profile`). `jira_update_issue` assignee → `jira_get_transitions` → `jira_transition_issue` "In Progress". No sprint mgmt — kanban tracks status automatically.
 
 2. **Track**: `task_add` w/ `external_key, repo, branch (bot/<KEY>), in_progress, title, summary, metadata`:
    ```json
    {"last_step": "branch_created", "next_step": "implement", "repos": ["pdf-generator", "app-interface"]}
    ```
 
-3. **Details**: `jira_get_issue` — title, description, acceptance criteria.
+3. **Details**: `jira_get_issue` — title, desc, acceptance criteria.
 
 4. **Search memory** (multiple queries):
-   - By ticket description/title
+   - Ticket desc/title
    - By repo (`repo` filter) → repo-specific patterns
    - By category: `review_feedback` + repo, `codebase_pattern` + repo, `learning`
    - By tags: `css`, `testing`, `patternfly`, `ci`, `dependency-upgrade`
-   - Apply ALL insights. Avoid past reviewer corrections. Follow learned conventions.
+   - Apply ALL. Avoid past corrections. Follow conventions.
 
-5. **Prepare repos**: `repo:` labels → match `project-repos.json`. Bare (`repo:insights-chrome`) or org-prefixed (`repo:RedHatInsights/insights-chrome`) — org/repo resolved via upstream URLs. Fork workflow default:
-   - `url` = bot's fork, `upstream` = original repo (PR target), `host` = "gitlab" if GL, `readonly` = read only
+5. **Prepare repos**: `repo:` labels → match `project-repos.json`. Bare (`repo:insights-chrome`) or org-prefixed — resolved via upstream URLs. Fork workflow default: `url` = fork, `upstream` = original (PR target), `host` = "gitlab" if GL, `readonly` = read only.
 
-   Dir = `./repos/<repo-name>/` (from upstream URL basename, no `.git`).
+   Dir = `./repos/<repo-name>/` (upstream URL basename, no `.git`).
 
-   **Clone on demand**: Not exists → `git clone --depth 1 --single-branch <url> ./repos/<name>/`. Has upstream → `git remote add upstream <upstream-url>`. More history needed → `git fetch --deepen=50` or `git fetch --unshallow`. Clone fails → Jira comment, stop.
+   **Clone**: Not exists → `git clone --depth 1 --single-branch <url> ./repos/<name>/`. Has upstream → `git remote add upstream <upstream-url>`. More history → `git fetch --deepen=50` / `--unshallow`. Fail → Jira comment, stop.
 
-   **Verify remotes**: Exists → `git remote -v`. Origin must match `url`. Upstream remote must match `upstream` field. Fix w/ `set-url`/`add` as needed.
+   **Verify remotes**: Exists → `git remote -v`. Origin must match `url`. Upstream must match. Fix w/ `set-url`/`add`.
 
-   Non-readonly repos:
-   - Fork: `git fetch upstream` → `git checkout master && git reset --hard upstream/master`. Push fails → sync fork first: `gh repo sync <fork> --source <upstream> --force`
-   - Direct: `git fetch origin` → checkout default branch → pull
+   Non-readonly:
+   - Fork: `git fetch upstream` → `git checkout master && git reset --hard upstream/master`. Push fail → `gh repo sync <fork> --source <upstream> --force`
+   - Direct: `git fetch origin` → checkout default → pull
    - Branch: `bot/<TICKET-KEY>`
 
-   **Retry → start clean**:
-   1. Close existing PR if open: GH `gh pr close <n> --repo <upstream>` / GL `glab mr close <n> --hostname gitlab.cee.redhat.com`
-   2. Delete remote branch: GH `gh api repos/{owner}/{repo}/git/refs/heads/bot/{KEY} -X DELETE` / GL `glab api projects/:id/repository/branches/bot%2F{KEY} -X DELETE --hostname gitlab.cee.redhat.com`
-   3. Delete local branch: `git branch -D bot/<KEY>`
-   4. Re-create branch from updated default branch, re-impl
+   **Retry → start clean**: close PR → delete remote branch → delete local → re-create from default, re-impl.
 
-   **Git identity**: Global config set by `run.py` at startup (name, email, GPG signing). Do NOT run `git config --local` for identity/signing — handled globally. Do NOT check `GPG_SIGNING_KEY` env var (sanitized at startup).
+   **Git identity**: Global config by `run.py`. Do NOT `git config --local` for identity/signing. Do NOT check `GPG_SIGNING_KEY` env.
 
    Readonly: `git fetch origin` + pull. Read only.
 
-   **Repo CLAUDE.md**: Exists → read in full. References other files (e.g. `@AGENTS.md`) → read those too. Repo instructions override persona guidelines.
+   **Repo CLAUDE.md**: Exists → read full. References other files → read those. Repo instructions override persona.
 
 6. **Load personas**: Dynamic by tech stack:
    - `package.json` w/ React/PF → `frontend`
    - `go.mod` → `backend`/`operator`
    - `Pipfile`/`requirements.txt` w/ Django → `backend`/`rbac`
    - Dockerfiles/scripts/Caddyfiles → `tooling`
-   - Config/YAML repo → `config`
-   - CVE ticket → also `cve` (layered on base)
-   - RDS EOL / blue-green upgrade ticket → also `rds-upgrade` (layered on `config`)
+   - Config/YAML → `config`
+   - CVE → also `cve` (layered)
+   - RDS EOL → also `rds-upgrade` (layered on `config`)
    - Read `personas/<name>/prompt.md`. Multi-repo → load ALL.
-   - Persona scoping: frontend rules only in frontend repos, etc.
-   - Cross-repo: plan holistically, dep order (upstream first), reference in commits/PR.
+   - Scope: frontend rules in frontend repos only, etc.
+   - Cross-repo: plan holistically, dep order, reference in commits/PR.
 
-7. **Implement**: Read ticket carefully. Follow repo conventions.
-   - Use LSP: `get_diagnostics`, `get_hover`, `go_to_definition`, `find_references`. Diagnostics before commit.
-   - **npm scripts only**: `npm test` not `npx jest`. `npm run lint` not `npx eslint`. Never call CLIs directly.
-   - **Testing mandatory**: Run existing tests. Find related tests. No coverage → write new tests. Run + verify pass.
-   - Lint via npm scripts.
-   - **Memory before commit**: `memory_search` "commit message"/"commit convention"/"PR title" + `review_feedback` + repo filter. Apply ALL feedback across all repos.
-   - Conventional commits: `type(scope): short description` (≤50 chars title). Ticket key in body.
+7. **Impl**: Read ticket. Follow repo conventions.
+   - LSP: `get_diagnostics`, `get_hover`, `go_to_definition`, `find_references`. Diagnostics before commit.
+   - **npm scripts only**: `npm test` not `npx jest`. `npm run lint` not `npx eslint`.
+   - **Tests mandatory**: Run existing. Find related. No coverage → write new. Verify pass.
+   - **Memory before commit**: `memory_search` "commit message"/"commit convention" + `review_feedback` + repo. Apply ALL.
+   - Conventional commits: `type(scope): desc` (≤50 chars). Ticket key in body.
    ```
    fix(chatbot): move VA to top of dropdown
 
@@ -202,61 +187,55 @@ Before starting work, `jira_get_issue` → check issue links:
    Reorder addHook calls so VA is registered first.
    ```
 
-8. **Update progress**: `task_update` summary + metadata `{"last_step": "tests_passing", "next_step": "push_and_pr", "files_changed": [...]}`.
+8. **Progress**: `task_update` summary + metadata `{"last_step": "tests_passing", "next_step": "push_and_pr", "files_changed": [...]}`.
 
-9. **Visual verification**: UI changes → persona's "Verification" section. Dev server + chrome-devtools. Never commit screenshots. Upload via `/gh-release-upload` skill → reference returned URLs in PR. Never use `gh release upload` directly. Skip = rejection.
+9. **Visual verification**: UI changes → persona "Verification". Dev server + chrome-devtools. Never commit screenshots. Upload via `/gh-release-upload` → ref URLs in PR. Skip = rejection.
 
 10. **Push + PR**: `git push origin bot/<KEY>`
 
-    **IMPORTANT**: Do NOT use `gh pr create` / `glab mr create` — don't work in this env. Use API calls:
+    Do NOT use `gh pr create`/`glab mr create`. Use API:
 
-    GH (fork): `gh api repos/<upstream-owner>/<repo>/pulls -X POST -f title="..." -f body="..." -f head="<fork-owner>:bot/<KEY>" -f base="<default-branch>"`
-    GH (direct): `gh api repos/<owner>/<repo>/pulls -X POST -f title="..." -f body="..." -f head="bot/<KEY>" -f base="<default-branch>"`
-    Push fails → `last_step = "push_failed"`, Jira comment, keep `in_progress` for retry.
+    GH fork: `gh api repos/<upstream-o>/<r>/pulls -X POST -f title="..." -f body="..." -f head="<fork-o>:bot/<KEY>" -f base="<default>"`
+    GH direct: `gh api repos/<o>/<r>/pulls -X POST -f title="..." -f body="..." -f head="bot/<KEY>" -f base="<default>"`
+    Push fail → `last_step = "push_failed"`, Jira comment, keep `in_progress`.
 
-    GL (fork): `glab api projects/<upstream-url-encoded>/merge_requests -X POST -f source_branch="bot/<KEY>" -f target_branch="<default-branch>" -f title="..." -f description="$(cat <<'EOF' ... EOF)" --hostname gitlab.cee.redhat.com`
-    GL (direct): same but project path = own repo.
+    GL fork: `glab api projects/<upstream-enc>/merge_requests -X POST -f source_branch="bot/<KEY>" -f target_branch="<default>" -f title="..." -f description="$(cat <<'EOF' ... EOF)" --hostname gitlab.cee.redhat.com`
+    GL direct: same, own project path.
 
-    **CRITICAL**: glab URL-encodes newlines if description passed inline. ALWAYS use heredoc `$(cat <<'EOF' ... EOF)` for multiline descriptions.
+    **CRITICAL**: glab URL-encodes newlines inline. ALWAYS heredoc for multiline desc.
 
-    Parse PR/MR number + URL from JSON res. Title ≤50 chars.
-    **PR body**: Use `/push-and-pr` skill's `--find-template` to discover repo's PR template. Found → fill each section (see SKILL.md). Not found → freeform: ticket key + changes summary.
-    Readonly repos: include config changes in Jira comment.
+    Parse PR/MR number + URL from JSON. Title ≤50 chars.
+    **PR body**: `/push-and-pr` `--find-template` for repo PR template. Found → fill sections. Not found → freeform: ticket key + changes.
+    Readonly → config changes in Jira comment.
 
-11. **Track PRs**: `task_update` status `pr_open`, `summary`, `last_addressed`. PRs tracked via `metadata.prs`. Multi-repo: `metadata.prs`:
+11. **Track PRs**: `task_update` `pr_open`, summary, `last_addressed`. Multi-repo `metadata.prs`:
     ```json
     {"last_step": "pr_opened", "files_changed": [...], "commits": [...],
      "prs": [{"repo": "...", "number": 42, "url": "...", "host": "github"}]}
     ```
 
-12. **Report on Jira**: `jira_transition_issue` → "Code Review". `jira_add_comment`: what done, PR links, concerns. Update linked issues w/ PR links (one comment per, only on PR open or completion).
+12. **Jira**: `jira_transition_issue` → "Code Review". `jira_add_comment`: what done, PR links, concerns. Update linked w/ PR links.
 
-13. **Notify Slack**: Invoke `/slack-notify` w/ `pr_created`: "{KEY}: {title} — PR: {url}". Also `needs_help` if investigation or blocked.
+13. **Slack**: `/slack-notify` `pr_created`: "{KEY}: {title} — PR: {url}". Also `needs_help` if blocked.
 
 ## Progress Tracking
 
-Keep task record updated throughout (not just end). `task_update` w/ `summary` + `metadata` at each milestone:
+`task_update` w/ `summary` + `metadata` at each milestone:
 
 - `last_step`: `branch_created`/`implemented`/`tests_passing`/`push_failed`/`pr_opened`/`review_addressed`/`investigation_posted`/`archived`
 - `files_changed`, `commits`, `next_step`, `notes`, `repos`, `prs`
 
 ### Cycle Progress (progress_load / progress_store)
 
-Persists structured progress across cycles. Separate from `task_update` — creates **history**, not just current state.
+Persists progress across cycles. Separate from `task_update` — creates **history**.
 
-**On resume** (existing task, not new):
-1. `task_get(external_key)` → note `id` field = `task_id`
-2. `progress_load(task_id=<id>)` → last 5 cycle summaries
-3. Use returned progress → understand prior decisions, files, blockers, where left off
+**On resume**: `task_get(external_key)` → `progress_load(task_id=<id>)` → last 5 cycles → understand prior decisions, where left off.
 
-**Before cycle ends** (after work on task):
-1. `progress_store(task_id=<id>, instance_id=<instance>, cycle_type="task_work", progress={...})`
-2. Progress keys: `last_step`, `next_step`, `files_changed`, `commits`, `key_decisions`, `blockers`, `notes`
-3. In addition to `task_update` — call both
+**Before cycle ends**: `progress_store(task_id=<id>, instance_id=<inst>, cycle_type="task_work", progress={...})`. Keys: `last_step`, `next_step`, `files_changed`, `commits`, `key_decisions`, `blockers`, `notes`. Call both `progress_store` + `task_update`.
 
-Idle/err cycles: `run.py` handles automatically. No agent action.
+Idle/err: `run.py` handles. No agent action.
 
-**On startup — interrupted work**: `in_progress` w/ `last_step` set? → `progress_load(task_id)` for cycle history + `memory_search` repo + problem → resume from `next_step`. Cycle progress = per-cycle history. Task metadata = current state. RAG memory = cross-ticket learnings.
+**Interrupted work**: `in_progress` w/ `last_step`? → `progress_load` + `memory_search` repo → resume from `next_step`.
 
 ## Rules
 
@@ -264,7 +243,7 @@ Idle/err cycles: `run.py` handles automatically. No agent action.
 - PR maintenance > new tickets
 - Blocked/ambiguous → Jira comment + stop
 - Stay in ticket scope
-- **No Jira spam**: Read existing comments first. Same info already posted → don't repeat
-- **Store learnings**: After completion/notable feedback → `memory_store` w/ specific category + `repo` + `tags`
-- **Search before starting**: Multiple `memory_search` queries (step 4). Avoid repeating mistakes.
-- **Use runtime-provided env vars**: Skills MUST use existing runtime env vars (see deploy/template.yaml). Never introduce custom `BOT_*` vars if runtime already provides equivalent. Examples: use `GH_USER_NAME` (not `BOT_GITHUB_USERNAME`), `BOT_JIRA_EMAIL` (not `JIRA_USER`), `BOT_CONFIG_PATH` (already exists). Check deployment config before adding new env var requirements.
+- **No Jira spam**: Read existing first. Same info posted → don't repeat
+- **Store learnings**: After completion/feedback → `memory_store` w/ category + `repo` + `tags`
+- **Search before starting**: Multiple `memory_search` (step 4). Avoid repeating mistakes.
+- **Use runtime env vars**: Never add custom `BOT_*` if runtime provides equivalent. Use `GH_USER_NAME`/`BOT_JIRA_EMAIL`/`BOT_CONFIG_PATH`. Check deploy config first.

--- a/presets/workflows/jira-kanban/manifest.yaml
+++ b/presets/workflows/jira-kanban/manifest.yaml
@@ -1,0 +1,35 @@
+name: jira-kanban
+type: workflow
+description: Jira kanban workflow — project-based pull, no sprint management
+
+preflight:
+  - 01-gh-pr-status.py
+  - 02-gl-mr-status.py
+  - 03-jira-kanban.py
+
+shared_skills:
+  - push-and-pr
+  - post-pr
+  - auto-fork
+
+provides:
+  claude_md: CLAUDE.md
+  skills:
+    - triage
+    - new-work
+    - claim-ticket
+    - wrap-up
+
+requires:
+  mcp_servers:
+    - bot-memory
+    - mcp-atlassian
+  env_vars:
+    - BOT_JIRA_PROJECT
+    - BOT_INSTANCE_ID
+    - BOT_JIRA_EMAIL
+  optional_env_vars:
+    - BOT_CONFIG_REPO
+    - BOT_KANBAN_STATUSES
+    - BOT_KANBAN_JQL_EXTRA
+    - SLACK_WEBHOOK_URL

--- a/presets/workflows/jira-kanban/preflight/01-gh-pr-status.py
+++ b/presets/workflows/jira-kanban/preflight/01-gh-pr-status.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from gh_pr_status import main
+
+main()

--- a/presets/workflows/jira-kanban/preflight/02-gl-mr-status.py
+++ b/presets/workflows/jira-kanban/preflight/02-gl-mr-status.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from gl_mr_status import main
+
+main()

--- a/presets/workflows/jira-kanban/preflight/03-jira-kanban.py
+++ b/presets/workflows/jira-kanban/preflight/03-jira-kanban.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from jira_kanban_preflight import main
+
+main()


### PR DESCRIPTION
## Summary

- New `jira-kanban` workflow preset for teams using kanban boards (no sprint management)
- Shared preflight module `jira_kanban_preflight.py` with project-based candidate sourcing
- Configurable via `BOT_JIRA_PROJECT`, `BOT_KANBAN_STATUSES`, `BOT_KANBAN_JQL_EXTRA` env vars
- Generic workflow — CVE/vulnerability behavior belongs in personas, not the workflow

## Details

RHCLOUD-48698

### Key differences from `jira-sprint`:
- **No `BOT_LABEL` requirement** — filters by project + status instead
- **No sprint assignment** — kanban board tracks status automatically
- **Configurable statuses** — `BOT_KANBAN_STATUSES` defaults to `New,Backlog,To Do`
- **Extra JQL** — `BOT_KANBAN_JQL_EXTRA` for instance-specific filters (e.g. `AND type = Vulnerability`)
- **Candidates without `repo:` labels still surface** — agent determines repo from ticket content

### Files
| File | Purpose |
|------|---------|
| `presets/shared/preflight/jira_kanban_preflight.py` | Shared kanban preflight module |
| `presets/workflows/jira-kanban/manifest.yaml` | Workflow manifest |
| `presets/workflows/jira-kanban/CLAUDE.md` | Workflow instructions (fork of jira-sprint, sprint refs removed) |
| `presets/workflows/jira-kanban/preflight/0[1-3]-*.py` | Thin wrappers |
| `bot/tests/test_jira_kanban_preflight.py` | 19 tests mirroring sprint preflight test patterns |

### Verified against LCORE
Tested JQL queries against real LCORE board — correctly finds unassigned Vulnerability tickets with `pscomponent:` labels in "New" status.

## Test plan
- [x] 19 new kanban preflight tests pass
- [x] 14 existing sprint preflight tests still pass  
- [x] Full test suite (126 tests) passes
- [x] Ruff check clean
- [x] Manifest loads correctly
- [x] JQL queries validated against LCORE Jira board (read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)