### PR TITLE
feat(runner): remove legacy global setup, switch to selective preset loop

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -7,12 +7,6 @@
 #   setup.sh   — (required) custom build steps (dnf install, config, etc.)
 #   instance/  — (optional) extra files, COPYed to /home/botuser/app/instance/
 
-# Dev proxy — build custom Caddy from source on UBI
-FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:8d2d83261cbc8854b8c93b1237d7d4aa0069bdb93e2974d980bc7788db56f8f4 AS dev-proxy-builder
-COPY dev-bot/dev-proxy/ /tmp/dev-proxy/
-RUN cd /tmp/dev-proxy \
-    && go build -o /tmp/caddy .
-
 # Build executor thin client (gh/glab shim that forwards via UDS to proxy sidecar)
 FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:8d2d83261cbc8854b8c93b1237d7d4aa0069bdb93e2974d980bc7788db56f8f4 AS executor-client-builder
 WORKDIR /build
@@ -22,7 +16,7 @@ RUN go mod download \
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
-# System deps + Python 3.12 + Chromium runtime libraries
+# Core system deps + Python 3.12 (env-specific deps installed via presets)
 RUN dnf install -y --nodocs --allowerasing \
     python3.12 python3.12-pip python3.12-devel \
     git \
@@ -32,63 +26,11 @@ RUN dnf install -y --nodocs --allowerasing \
     gcc \
     make \
     sqlite-devel \
-    alsa-lib \
-    atk \
-    at-spi2-atk \
-    at-spi2-core \
-    cairo \
-    cups-libs \
-    dbus-libs \
-    libdrm \
-    mesa-libgbm \
-    glib2 \
-    nspr \
-    nss \
-    pango \
-    libX11 \
-    libxcb \
-    libXcomposite \
-    libXdamage \
-    libXext \
-    libXfixes \
-    libxkbcommon \
-    libXrandr \
     && dnf clean all
-
-# Node.js 22 (official binary tarball)
-RUN ARCH=$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://nodejs.org/dist/v22.15.0/node-v22.15.0-linux-${ARCH}.tar.gz" \
-    | tar -xz -C /usr/local --strip-components=1
-
-# Headless Chromium via Playwright (avoids EPEL/CentOS RPMs)
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-RUN npx playwright install chromium
 
 # Make python3.12 the default
 RUN ln -sf /usr/bin/python3.12 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.12 /usr/bin/python
-
-# Go — multiple versions via GOVERSIONS build arg
-ARG GOVERSIONS="1.24.2 1.25.7"
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && for v in $GOVERSIONS; do \
-         echo "Installing Go $v..." \
-         && curl -fsSL "https://go.dev/dl/go${v}.linux-${ARCH}.tar.gz" \
-            | tar -xz -C /usr/local \
-         && mv /usr/local/go /usr/local/go${v}; \
-       done \
-    && DEFAULT=$(echo $GOVERSIONS | awk '{print $1}') \
-    && ln -s /usr/local/go${DEFAULT} /usr/local/go
-ENV PATH="/usr/local/go/bin:$PATH"
-
-# use-go helper: eval "$(use-go 1.25.7)"
-RUN printf '#!/bin/bash\nV=${1:?Usage: use-go <version>}\nif [ ! -d "/usr/local/go${V}" ]; then echo "Go $V not installed. Available:" >&2; ls -d /usr/local/go[0-9]* | sed "s|/usr/local/go||" >&2; exit 1; fi\necho "export PATH=/usr/local/go${V}/bin:\${PATH#/usr/local/go*/bin:}"\n' > /usr/local/bin/use-go \
-    && chmod +x /usr/local/bin/use-go
-
-# golangci-lint
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-linux-${ARCH}.tar.gz" \
-    | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/golangci-lint'
 
 # Executor thin client — drop-in gh/glab replacement (forwards to proxy sidecar)
 COPY --from=executor-client-builder /tmp/executor-client /usr/local/bin/executor-client
@@ -108,28 +50,10 @@ RUN dnf install -y --nodocs libcap-devel \
     && pip3.12 uninstall -y meson ninja \
     && dnf clean all
 
-# Buildah (rootless container image builder — no daemon, works in OpenShift)
-RUN dnf install -y --nodocs buildah fuse-overlayfs \
-    && dnf clean all
-
 # tini — proper init process that reaps zombie children
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
     && curl -fsSL -o /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-${ARCH}" \
     && chmod +x /usr/local/bin/tini
-
-# grype (container image vulnerability scanner)
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.87.0_linux_${ARCH}.tar.gz" \
-    | tar -xz -C /usr/local/bin grype
-
-# Dev proxy (custom Caddy for local UI verification against stage)
-COPY --from=dev-proxy-builder /tmp/caddy /usr/local/bin/caddy
-COPY dev-bot/dev-proxy/Caddyfile /etc/caddy/Caddyfile
-COPY dev-bot/dev-proxy/start-proxy.sh /usr/local/bin/start-dev-proxy.sh
-RUN chmod +x /usr/local/bin/start-dev-proxy.sh
-
-# Pre-install MCP servers so they don't need network at runtime
-RUN npm install -g chrome-devtools-mcp@latest @redhat-cloud-services/hcc-pf-mcp
 
 # uv
 RUN pip3.12 install uv
@@ -146,22 +70,23 @@ ENV PATH="/home/botuser/app/.venv/bin:/home/botuser/go/bin:$PATH"
 ENV GOPATH="/home/botuser/go"
 ENV CLAUDE_CODE_USE_VERTEX=1
 ENV CLOUD_ML_REGION=global
-ENV BUILDAH_ISOLATION=chroot
 
 # Copy bot config files
 COPY dev-bot/config.json dev-bot/CLAUDE.md dev-bot/.mcp.json dev-bot/entrypoint.sh ./
 COPY dev-bot/.claude/ .claude/
+
+# Dev-proxy source (used by dev-proxy preset to build Caddy from source)
+COPY dev-bot/dev-proxy/ dev-proxy/
+
+# Instance files — COPY early so install-envs.sh can read instance.yaml
+COPY instance/ /home/botuser/app/instance/
+
+# Env presets — selective install based on instance.yaml envs list
 COPY dev-bot/presets/ presets/
-RUN bash -c 'shopt -s nullglob; for script in presets/envs/*/install.sh; do bash "$script"; done'
+RUN bash presets/install-envs.sh
 
 ENV HOME=/home/botuser
 USER botuser
-
-# Buildah rootless config — vfs driver (no kernel module needed, works everywhere)
-RUN mkdir -p /home/botuser/.config/containers /home/botuser/.local/share/containers \
-    && echo -e '[storage]\ndriver = "vfs"' > /home/botuser/.config/containers/storage.conf \
-    && echo -e '[registries.search]\nregistries = ["registry.access.redhat.com", "quay.io", "docker.io"]' \
-       > /home/botuser/.config/containers/registries.conf
 
 # === INSTANCE CUSTOMIZATION ===
 # Runner repos extend the base image here via setup.sh and instance/ files.
@@ -172,9 +97,6 @@ COPY setup.sh /tmp/instance-setup.sh
 RUN chmod +x /tmp/instance-setup.sh \
     && bash /tmp/instance-setup.sh \
     && rm /tmp/instance-setup.sh
-
-# Copy instance-specific files (optional — create empty instance/ dir if unused)
-COPY instance/ /home/botuser/app/instance/
 
 # Fix ownership — must run last
 RUN chown -R botuser:0 /home/botuser \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Bot container entrypoint — decode secrets, start Chromium, launch bot.
+# Bot container entrypoint — decode secrets, run env presets, launch bot.
 set -e
 
 # --- Verify required CLI tools ---
@@ -177,26 +177,10 @@ if [ -n "${BOT_MEMORY_HEALTH_URL:-}" ]; then
     wait_for_http "memory-server" "$BOT_MEMORY_HEALTH_URL" "${BOT_MEMORY_HEALTH_TIMEOUT:-120}"
 fi
 
-
-# Start headless Chromium in background (Playwright-installed binary)
-CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f | head -1)
-"$CHROME_BIN" \
-    --headless --no-sandbox --disable-gpu \
-    --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 \
-    --remote-allow-origins=* \
-    --ignore-certificate-errors \
-    --host-resolver-rules='MAP consent.trustarc.com 127.0.0.1' \
-    --proxy-server="${HTTPS_PROXY:-http://proxy:3128}" \
-    --proxy-bypass-list='*.foo.redhat.com;localhost;127.0.0.1' \
-    --no-first-run --disable-sync --disable-extensions --disable-popup-blocking &
-
-# Wait for Chromium to be ready
-until curl -s http://127.0.0.1:9222/json/version > /dev/null 2>&1; do sleep 1; done
-
-# Run env preset entrypoint scripts (no-op until presets are extracted)
+# Run env preset entrypoint scripts (Chromium, dev-proxy, etc.)
 shopt -s nullglob
 for script in presets/envs/*/entrypoint.d/*.sh; do bash "$script"; done
 shopt -u nullglob
 
-echo "Credentials configured. Chromium started. Starting bot with label: ${BOT_LABEL}"
+echo "Credentials configured. Starting bot with label: ${BOT_LABEL}"
 exec uv run dev-bot --label "$BOT_LABEL"

--- a/presets/envs/browser/install.sh
+++ b/presets/envs/browser/install.sh
@@ -2,10 +2,9 @@
 # Browser env preset — Chromium + Playwright + chrome-devtools MCP
 set -e
 
-# Skip if already installed (idempotent during transition period)
-if command -v chrome-devtools-mcp &>/dev/null && [ -d "${PLAYWRIGHT_BROWSERS_PATH:-/opt/pw-browsers}" ]; then
-    echo "browser preset: already installed, skipping"
-    exit 0
+if ! command -v npx &>/dev/null; then
+    echo "ERROR: browser preset requires node preset (npx not found)" >&2
+    exit 1
 fi
 
 # Chromium runtime libraries

--- a/presets/envs/container-scan/entrypoint.d/10-buildah-config.sh
+++ b/presets/envs/container-scan/entrypoint.d/10-buildah-config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Buildah rootless config — runs as botuser at container startup
+# vfs storage driver (no kernel module needed, works in OpenShift)
+command -v buildah &>/dev/null || exit 0
+
+export BUILDAH_ISOLATION=chroot
+
+CONTAINERS_DIR="$HOME/.config/containers"
+if [ ! -f "$CONTAINERS_DIR/storage.conf" ]; then
+    mkdir -p "$CONTAINERS_DIR" "$HOME/.local/share/containers"
+    printf '[storage]\ndriver = "vfs"\n' > "$CONTAINERS_DIR/storage.conf"
+    printf '[registries.search]\nregistries = ["registry.access.redhat.com", "quay.io", "docker.io"]\n' \
+        > "$CONTAINERS_DIR/registries.conf"
+fi

--- a/presets/envs/container-scan/install.sh
+++ b/presets/envs/container-scan/install.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
-# Container-scan env preset — grype + buildah
+# Container-scan env preset — grype + buildah + rootless config
 set -e
-
-# Skip if already installed (idempotent during transition period)
-if command -v grype &>/dev/null && command -v buildah &>/dev/null; then
-    echo "container-scan preset: already installed, skipping"
-    exit 0
-fi
 
 # Grype (vulnerability scanner)
 ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
@@ -15,3 +9,15 @@ curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.8
 
 # Buildah (rootless container builder)
 dnf install -y --nodocs buildah fuse-overlayfs && dnf clean all
+
+# Buildah rootless config — vfs driver (no kernel module needed, works everywhere)
+BOTUSER_HOME="${BOTUSER_HOME:-/home/botuser}"
+mkdir -p "$BOTUSER_HOME/.config/containers" "$BOTUSER_HOME/.local/share/containers"
+echo -e '[storage]\ndriver = "vfs"' > "$BOTUSER_HOME/.config/containers/storage.conf"
+echo -e '[registries.search]\nregistries = ["registry.access.redhat.com", "quay.io", "docker.io"]' \
+    > "$BOTUSER_HOME/.config/containers/registries.conf"
+
+# BUILDAH_ISOLATION for all shells
+cat > /etc/profile.d/buildah.sh << 'PROFILE'
+export BUILDAH_ISOLATION=chroot
+PROFILE

--- a/presets/envs/container-scan/install.sh
+++ b/presets/envs/container-scan/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Container-scan env preset — grype + buildah + rootless config
+# Container-scan env preset — grype + buildah
 set -e
 
 # Grype (vulnerability scanner)
@@ -9,13 +9,6 @@ curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.8
 
 # Buildah (rootless container builder)
 dnf install -y --nodocs buildah fuse-overlayfs && dnf clean all
-
-# Buildah rootless config — vfs driver (no kernel module needed, works everywhere)
-BOTUSER_HOME="${BOTUSER_HOME:-/home/botuser}"
-mkdir -p "$BOTUSER_HOME/.config/containers" "$BOTUSER_HOME/.local/share/containers"
-echo -e '[storage]\ndriver = "vfs"' > "$BOTUSER_HOME/.config/containers/storage.conf"
-echo -e '[registries.search]\nregistries = ["registry.access.redhat.com", "quay.io", "docker.io"]' \
-    > "$BOTUSER_HOME/.config/containers/registries.conf"
 
 # BUILDAH_ISOLATION for all shells
 cat > /etc/profile.d/buildah.sh << 'PROFILE'

--- a/presets/envs/dev-proxy/install.sh
+++ b/presets/envs/dev-proxy/install.sh
@@ -2,14 +2,12 @@
 # Dev-proxy env preset — custom Caddy for local UI verification against stage
 set -e
 
-# Skip if already installed (idempotent during transition period)
-# During transition, Caddy is built via multi-stage Dockerfile builder
-if command -v caddy &>/dev/null; then
-    echo "dev-proxy preset: caddy already installed, skipping"
-    exit 0
+if ! command -v go &>/dev/null; then
+    echo "ERROR: dev-proxy preset requires go preset (go not found)" >&2
+    exit 1
 fi
 
-# Build Caddy from source (for when multi-stage builder is removed)
+# Build Caddy from source
 if [ -d /home/botuser/app/dev-proxy ]; then
     cd /home/botuser/app/dev-proxy
     go build -o /usr/local/bin/caddy .

--- a/presets/envs/go/install.sh
+++ b/presets/envs/go/install.sh
@@ -3,13 +3,6 @@
 set -e
 
 export GOENV_ROOT="${GOENV_ROOT:-/usr/local/goenv}"
-
-# Skip if already installed (idempotent during transition period)
-if [ -d "$GOENV_ROOT" ] && command -v go &>/dev/null && command -v golangci-lint &>/dev/null; then
-    echo "go preset: already installed ($(go version)), skipping"
-    exit 0
-fi
-
 ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 
 # Install goenv

--- a/presets/envs/node/install.sh
+++ b/presets/envs/node/install.sh
@@ -4,12 +4,6 @@ set -e
 
 export NVM_DIR="${NVM_DIR:-/usr/local/nvm}"
 
-# Skip if already installed (idempotent during transition period)
-if [ -s "$NVM_DIR/nvm.sh" ] && command -v node &>/dev/null; then
-    echo "node preset: already installed ($(node --version)), skipping"
-    exit 0
-fi
-
 # Install nvm
 mkdir -p "$NVM_DIR"
 curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash

--- a/presets/envs/patternfly-mcp/install.sh
+++ b/presets/envs/patternfly-mcp/install.sh
@@ -2,12 +2,6 @@
 # PatternFly MCP env preset — hcc-pf-mcp server for PatternFly component guidance
 set -e
 
-# Skip if already installed (idempotent during transition period)
-if npm list -g @redhat-cloud-services/hcc-pf-mcp &>/dev/null 2>&1; then
-    echo "patternfly-mcp preset: already installed, skipping"
-    exit 0
-fi
-
 # Requires node preset (npm must be available)
 if ! command -v npm &>/dev/null; then
     echo "ERROR: patternfly-mcp preset requires node preset (npm not found)" >&2

--- a/presets/install-envs.sh
+++ b/presets/install-envs.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Selective env preset installer — reads instance.yaml envs lists and installs
+# only the presets each instance needs. Unions across all instance configs so the
+# single image can serve multiple instance configs (e.g. implementer + groomer).
+#
+# Falls back to installing ALL presets if no instance.yaml is found (local dev).
+set -e
+
+ENVS=""
+for cfg in instance/*/agent/instance.yaml; do
+    [ -f "$cfg" ] || continue
+    ENVS="$ENVS $(sed -n '/^envs:/,/^[^ ]/{ s/^  - //p }' "$cfg")"
+done
+ENVS=$(echo "$ENVS" | tr ' ' '\n' | sort -u | xargs)
+
+if [ -z "$ENVS" ]; then
+    echo "[install-envs] No instance.yaml envs found — installing all presets"
+    shopt -s nullglob
+    for script in presets/envs/*/install.sh; do
+        echo "[install-envs] Running $(basename "$(dirname "$script")")"
+        bash "$script"
+    done
+    exit 0
+fi
+
+echo "[install-envs] Selected envs: $ENVS"
+
+run_preset() {
+    local env="$1"
+    local script="presets/envs/$env/install.sh"
+    if [ -f "$script" ]; then
+        echo "[install-envs] Installing: $env"
+        bash "$script"
+    else
+        echo "[install-envs] $env has no install.sh — skipping"
+    fi
+}
+
+# Runtimes first, then tools that depend on them
+ORDER="node go browser container-scan dev-proxy patternfly-mcp slack"
+
+for env in $ORDER; do
+    echo "$ENVS" | tr ' ' '\n' | grep -qx "$env" || continue
+    run_preset "$env"
+done
+
+# Run any envs not in ORDER (future custom presets)
+for env in $ENVS; do
+    echo "$ORDER" | tr ' ' '\n' | grep -qx "$env" && continue
+    run_preset "$env"
+done


### PR DESCRIPTION
## Summary

- Remove all hardcoded env-specific installs from `Dockerfile.runner` — Node.js, Go, Chromium libs, Playwright, buildah, grype, Caddy multi-stage builder, and MCP server pre-installs. Only core system deps remain (python3.12, git, curl, jq, etc).
- Add `presets/install-envs.sh` — reads `envs:` from all `instance/*/agent/instance.yaml` files, deduplicates, and runs only selected preset `install.sh` scripts in dependency-safe order (runtimes first: node → go, then everything else). Falls back to all presets if no instance.yaml found.
- Restructure `Dockerfile.runner` to COPY `instance/` before the preset loop so `instance.yaml` is available at build time.
- Remove hardcoded Chromium startup from `entrypoint.sh` (14 lines) — the existing `browser/entrypoint.d/10-chromium.sh` handles it via the preset dispatch loop.
- Move buildah rootless config and `BUILDAH_ISOLATION=chroot` into `container-scan/install.sh`.
- Remove transition-period idempotency guards from all preset install scripts, add proper dependency checks (browser→node, dev-proxy→go, patternfly-mcp→node).

**Result**: An LSC instance with `envs: [slack, container-scan]` no longer ships Node/Go/Chromium — the image only contains what the instance actually needs.

## Test plan

- [x] All 147 Python tests pass
- [x] All shell scripts pass `bash -n` syntax check
- [x] Docker build with `test-preset-instance` (`envs: [node, go, patternfly-mcp]`) — only 3 presets installed
- [x] Verified: node/go/golangci-lint/hcc-pf-mcp present; chromium/grype/buildah/caddy absent
- [x] Docker build with full hcc-framework-agent-dev instance (all envs)
- [x] Docker build with lsc-bot-instance (slack + container-scan only)
- [ ] Runtime validation: Chromium starts via entrypoint.d, buildah has vfs config

Resolves RHCLOUD-48705
