### PR TITLE
feat: add Konflux build log retrieval via KubeArchive API

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -44,6 +44,7 @@ objects:
 #      jira-email            — Jira username/email (unless JIRA_SECRET_NAME overrides)
 #      jira-token            — Jira API token (unless JIRA_SECRET_NAME overrides)
 #      upload-memory-password — (temporary) shared secret for bulk memory upload
+#      konflux-read-token    — (optional) KubeArchive SA token for Konflux build logs
 # 3. (Optional) Separate Jira secret (JIRA_SECRET_NAME) with keys:
 #      jira-email            — Jira username/email for this instance
 #      jira-token            — Jira API token for this instance
@@ -121,6 +122,12 @@ objects:
               secretKeyRef:
                 name: devbot-secrets
                 key: upload-memory-password
+                optional: true
+          - name: KUBEARCHIVE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: konflux-read-token
                 optional: true
           startupProbe:
             httpGet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       DATABASE_URL: postgresql://bot:bot@postgres:5432/bot_memory
       TRUSTED_BOT_ACCOUNTS: "${TRUSTED_BOT_ACCOUNTS:-}"
+      KUBEARCHIVE_TOKEN: "${KUBEARCHIVE_TOKEN:-}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/memory-server/bot_memory_server/server.py
+++ b/memory-server/bot_memory_server/server.py
@@ -41,12 +41,14 @@ from .tools.rag import register_rag_tools  # noqa: E402
 from .tools.slack import register_slack_tools  # noqa: E402
 from .tools.org_members import register_org_member_tools  # noqa: E402
 from .tools.cycles import register_cycle_tools  # noqa: E402
+from .tools.konflux import register_konflux_tools  # noqa: E402
 
 register_task_tools(mcp)
 register_rag_tools(mcp)
 register_slack_tools(mcp)
 register_org_member_tools(mcp)
 register_cycle_tools(mcp)
+register_konflux_tools(mcp)
 
 
 # Health check

--- a/memory-server/bot_memory_server/tools/konflux.py
+++ b/memory-server/bot_memory_server/tools/konflux.py
@@ -1,0 +1,171 @@
+"""MCP tools for fetching Konflux pipeline failure logs from KubeArchive."""
+
+import json
+import os
+import re
+import ssl
+import urllib.request
+from urllib.error import HTTPError, URLError
+
+KUBEARCHIVE_TOKEN = os.environ.get("KUBEARCHIVE_TOKEN", "")
+
+MAX_OUTPUT_CHARS = 8000
+DETAILS_URL_PATTERN = re.compile(r"https?://konflux-ui\.apps\.([^/]+)/ns/([^/]+)/pipelinerun/([^/]+)")
+KUBEARCHIVE_URL_TEMPLATE = "https://kubearchive-api-server-product-kubearchive.apps.{cluster}"
+
+
+def _api_get(path: str, base_url: str, timeout: int = 30) -> dict | str | None:
+    """GET request to KubeArchive API. Returns parsed JSON for JSON responses, raw text for logs."""
+    url = f"{base_url}{path}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {KUBEARCHIVE_TOKEN}"})
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            content_type = resp.headers.get("Content-Type", "")
+            raw = resp.read().decode("utf-8", errors="replace")
+            if "json" in content_type:
+                return json.loads(raw)
+            return raw
+    except HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")[:200] if e.fp else ""
+        return {"error": f"HTTP {e.code}", "message": body}
+    except (URLError, TimeoutError) as e:
+        return {"error": "connection_failed", "message": str(e)}
+
+
+def _parse_details_url(url: str) -> tuple[str, str, str] | None:
+    """Returns (cluster, namespace, pipelinerun_name) or None."""
+    m = DETAILS_URL_PATTERN.search(url)
+    if m:
+        return m.group(1), m.group(2), m.group(3)
+    return None
+
+
+def _is_failed(conditions: list[dict]) -> bool:
+    return any(c.get("type") == "Succeeded" and c.get("status") == "False" for c in conditions)
+
+
+def _failure_reason(conditions: list[dict]) -> str:
+    for c in conditions:
+        if c.get("type") == "Succeeded" and c.get("status") == "False":
+            return c.get("message", c.get("reason", "Unknown"))
+    return "Unknown"
+
+
+def _failed_steps(steps: list[dict]) -> list[dict]:
+    return [
+        {
+            "name": s["name"],
+            "exit_code": s.get("terminated", {}).get("exitCode", -1),
+        }
+        for s in steps
+        if s.get("terminated", {}).get("exitCode", 0) != 0
+    ]
+
+
+def _tail(text: str, n: int) -> str:
+    lines = text.rstrip("\n").split("\n")
+    if len(lines) <= n:
+        return text.rstrip("\n")
+    return f"... ({len(lines) - n} lines truncated) ...\n" + "\n".join(lines[-n:])
+
+
+def register_konflux_tools(mcp):
+    @mcp.tool()
+    async def konflux_get_build_logs(
+        details_url: str,
+        tail_lines: int = 100,
+    ) -> dict:
+        """Fetch Konflux CI pipeline failure logs from KubeArchive.
+
+        Use when a Konflux pipeline check fails on a PR. Provide the
+        details_url from the GitHub check's detailsUrl field (the Konflux UI URL).
+
+        Returns failed TaskRun details with step-level logs for diagnosis."""
+
+        if not KUBEARCHIVE_TOKEN:
+            return {"error": "KUBEARCHIVE_TOKEN not configured"}
+
+        if details_url:
+            parsed = _parse_details_url(details_url)
+            if parsed:
+                cluster, namespace, pipelinerun_name = parsed
+                base_url = KUBEARCHIVE_URL_TEMPLATE.format(cluster=cluster)
+            else:
+                return {"error": f"Could not parse namespace/pipelinerun from URL: {details_url}"}
+        else:
+            return {"error": "details_url is required"}
+
+        if not pipelinerun_name:
+            return {"error": "pipelinerun_name is required (or provide details_url)"}
+
+        label = urllib.request.quote(f"tekton.dev/pipelineRun={pipelinerun_name}", safe="")
+        data = _api_get(f"/apis/tekton.dev/v1/namespaces/{namespace}/taskruns?labelSelector={label}", base_url=base_url)
+
+        if isinstance(data, dict) and "error" in data:
+            return data
+
+        items = data.get("items", []) if isinstance(data, dict) else []
+        if not items:
+            return {
+                "pipelinerun": pipelinerun_name,
+                "namespace": namespace,
+                "error": "No TaskRuns found for this PipelineRun",
+            }
+
+        all_tasks = []
+        failed_tasks = []
+        for tr in items:
+            task_name = tr.get("metadata", {}).get("labels", {}).get("tekton.dev/pipelineTask", "unknown")
+            conditions = tr.get("status", {}).get("conditions", [])
+            failed = _is_failed(conditions)
+            all_tasks.append({"task": task_name, "failed": failed})
+            if not failed:
+                continue
+
+            pod_name = tr.get("status", {}).get("podName", "")
+            steps = tr.get("status", {}).get("steps", [])
+            bad_steps = _failed_steps(steps)
+
+            task_info = {
+                "task": task_name,
+                "pod": pod_name,
+                "reason": _failure_reason(conditions),
+                "steps": [],
+            }
+
+            for step in bad_steps:
+                step_info = {"name": step["name"], "exit_code": step["exit_code"], "logs": ""}
+                if pod_name:
+                    log_data = _api_get(
+                        f"/api/v1/namespaces/{namespace}/pods/{pod_name}/log?container=step-{step['name']}",
+                        base_url=base_url,
+                    )
+                    if isinstance(log_data, str):
+                        step_info["logs"] = _tail(log_data, tail_lines)
+                    elif isinstance(log_data, dict) and "error" in log_data:
+                        step_info["logs"] = f"[log fetch failed: {log_data.get('message', log_data['error'])}]"
+                task_info["steps"].append(step_info)
+
+            failed_tasks.append(task_info)
+
+        result = {
+            "pipelinerun": pipelinerun_name,
+            "namespace": namespace,
+            "total_tasks": len(all_tasks),
+            "failed_tasks": failed_tasks,
+            "summary": [f"{'FAIL' if t['failed'] else ' OK '} {t['task']}" for t in all_tasks],
+        }
+
+        output = json.dumps(result)
+        if len(output) > MAX_OUTPUT_CHARS:
+            for task in result["failed_tasks"]:
+                for step in task["steps"]:
+                    step["logs"] = _tail(step["logs"], tail_lines // 2)
+            output = json.dumps(result)
+            if len(output) > MAX_OUTPUT_CHARS:
+                for task in result["failed_tasks"]:
+                    for step in task["steps"]:
+                        step["logs"] = _tail(step["logs"], 30)
+
+        return result

--- a/memory-server/tests/test_konflux.py
+++ b/memory-server/tests/test_konflux.py
@@ -1,0 +1,130 @@
+"""Tests for Konflux build log retrieval tool."""
+
+import json
+from unittest.mock import patch, MagicMock
+import io
+
+import pytest
+
+from bot_memory_server.tools.konflux import (
+    _parse_details_url,
+    _is_failed,
+    _failure_reason,
+    _failed_steps,
+    _tail,
+)
+
+
+# --- _parse_details_url ---
+
+
+def test_parse_details_url_valid():
+    url = "https://konflux-ui.apps.cluster.example.com/ns/my-tenant/pipelinerun/my-app-on-pull-request-abc12"
+    result = _parse_details_url(url)
+    assert result == (
+        "cluster.example.com",
+        "my-tenant",
+        "my-app-on-pull-request-abc12",
+    )
+
+
+def test_parse_details_url_invalid():
+    assert _parse_details_url("https://example.com/not-a-konflux-url") is None
+
+
+# --- _is_failed ---
+
+
+def test_is_failed_true():
+    conditions = [{"type": "Succeeded", "status": "False", "reason": "Failed"}]
+    assert _is_failed(conditions) is True
+
+
+def test_is_failed_false():
+    assert _is_failed([{"type": "Succeeded", "status": "True"}]) is False
+    assert _is_failed([]) is False
+
+
+# --- _failure_reason ---
+
+
+def test_failure_reason_with_message():
+    conditions = [{"type": "Succeeded", "status": "False", "message": "step failed", "reason": "Failed"}]
+    assert _failure_reason(conditions) == "step failed"
+
+
+def test_failure_reason_no_failure():
+    assert _failure_reason([]) == "Unknown"
+
+
+# --- _failed_steps ---
+
+
+def test_failed_steps_one_failed():
+    steps = [
+        {"name": "build", "terminated": {"exitCode": 0}},
+        {"name": "push", "terminated": {"exitCode": 1}},
+    ]
+    result = _failed_steps(steps)
+    assert len(result) == 1
+    assert result[0] == {"name": "push", "exit_code": 1}
+
+
+def test_failed_steps_all_ok():
+    assert _failed_steps([{"name": "build", "terminated": {"exitCode": 0}}]) == []
+
+
+# --- _tail ---
+
+
+def test_tail_short_text():
+    assert _tail("line1\nline2\nline3", 10) == "line1\nline2\nline3"
+
+
+def test_tail_truncates():
+    text = "\n".join(f"line{i}" for i in range(10))
+    result = _tail(text, 3)
+    assert result.startswith("... (7 lines truncated) ...")
+    assert "line9" in result
+    assert "line0" not in result
+
+
+# --- classify_gh Konflux URL extraction ---
+
+
+def test_classify_gh_extracts_konflux_urls():
+    import sys
+    from pathlib import Path
+
+    shared_dir = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
+    sys.path.insert(0, str(shared_dir))
+    from gh_pr_status import classify_gh
+
+    checks = [
+        {
+            "name": "Red Hat Konflux / my-app-on-pull-request",
+            "conclusion": "FAILURE",
+            "detailsUrl": "https://konflux-ui.apps.cluster.example.com/ns/my-tenant/pipelinerun/my-app-on-pull-request-abc12",
+        }
+    ]
+    pr = {"state": "OPEN", "mergeable": "MERGEABLE", "reviews": [], "statusCheckRollup": checks}
+    state, issues = classify_gh(pr)
+    assert any(i.startswith("ci_fail:") for i in issues)
+    konflux = [i for i in issues if i.startswith("konflux_urls:")]
+    assert len(konflux) == 1
+    assert "my-app-on-pull-request-abc12" in konflux[0]
+
+
+def test_classify_gh_no_konflux_url_for_non_konflux_check():
+    import sys
+    from pathlib import Path
+
+    shared_dir = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
+    sys.path.insert(0, str(shared_dir))
+    from gh_pr_status import classify_gh
+
+    checks = [{"name": "lint", "conclusion": "FAILURE", "detailsUrl": "https://github.com/runs/123"}]
+    pr = {"state": "OPEN", "mergeable": "MERGEABLE", "reviews": [], "statusCheckRollup": checks}
+    state, issues = classify_gh(pr)
+    assert "ci_fail:lint" in issues
+    assert not any(i.startswith("konflux_urls:") for i in issues)

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -84,9 +84,13 @@ def classify_gh(pr, last_addressed=""):
     if pr.get("mergeable") == "CONFLICTING":
         issues.append("conflict")
     checks = pr.get("statusCheckRollup") or []
-    failed = [c.get("name", "?") for c in checks if c.get("conclusion") == "FAILURE"]
+    failed_checks = [c for c in checks if c.get("conclusion") == "FAILURE"]
+    failed = [c.get("name", "?") for c in failed_checks]
     if failed:
         issues.append(f"ci_fail:{','.join(failed)}")
+        konflux_urls = [c.get("detailsUrl", "") for c in failed_checks if "pipelinerun" in c.get("detailsUrl", "")]
+        if konflux_urls:
+            issues.append(f"konflux_urls:{';'.join(konflux_urls)}")
     if pr.get("reviewDecision") == "CHANGES_REQUESTED":
         issues.append("changes_requested")
     last_prefix = last_addressed[:16] if last_addressed else ""
@@ -179,6 +183,10 @@ def fmt_task(enriched):
     for p in enriched["prs"]:
         issue_str = ",".join(p["issues"]) if p["issues"] else "clean"
         lines.append(f"  PR {p['repo']}#{p['num']} (github) state={p['state']} [{issue_str}]")
+        for issue in p["issues"]:
+            if issue.startswith("konflux_urls:"):
+                for url in issue.split(":", 1)[1].split(";"):
+                    lines.append(f"    konflux_details: {url}")
     last_addr = enriched["task"].get("last_addressed")
     if enriched["pr_comments"]:
         lines.append(fmt_comments(enriched["pr_comments"], "pr_comments", since=last_addr))

--- a/presets/workflows/jira-kanban/CLAUDE.md
+++ b/presets/workflows/jira-kanban/CLAUDE.md
@@ -46,6 +46,7 @@ PR statuses in input. For each `pr_open`/`pr_changes`:
 4. Handle in order:
 
 **Failing CI**: `gh pr checks <n>` / `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`. Checkout → fix → commit → push. Jira comment. `task_update last_addressed`.
+- **Konflux pipelines** (experimental, not all namespaces supported): `konflux_details:` URL in preflight → call `konflux_get_build_logs(details_url=...)`. No URL but check name has "on-pull-request"/"on-push" → get `detailsUrl` from `gh pr checks`, pass to same tool. If 401/403 → skip, log the error, fix CI without logs.
 
 **Merge conflicts**: Rebase default branch → resolve → force push. Jira comment. `task_update last_addressed`.
 

--- a/presets/workflows/jira-sprint/CLAUDE.md
+++ b/presets/workflows/jira-sprint/CLAUDE.md
@@ -48,6 +48,7 @@ PR statuses provided in input. For each `pr_open`/`pr_changes` task:
 4. Handle in order:
 
 **Failing CI**: `gh pr checks <n>` / `glab api "projects/<path>/merge_requests/<n>/pipelines" --hostname gitlab.cee.redhat.com`. Checkout branch → fix → commit → push. Jira comment. `task_update` `last_addressed`.
+- **Konflux pipelines** (experimental, not all namespaces supported): `konflux_details:` URL in preflight → call `konflux_get_build_logs(details_url=...)`. No URL but check name has "on-pull-request"/"on-push" → get `detailsUrl` from `gh pr checks`, pass to same tool. If 401/403 → skip, log the error, fix CI without logs.
 
 **Merge conflicts**: Rebase on default branch → resolve → force push. Jira comment. `task_update` `last_addressed`.
 


### PR DESCRIPTION
### Description
When Konflux CI fails on a PR, the bot currently only sees "check failed" but can't read the actual build error. This adds a new `konflux_get_build_logs` MCP tool in the memory-server that queries the KubeArchive API to fetch failed TaskRun step-level logs.

  The cluster and namespace are derived **automatically** from the GitHub check's `detailsUrl`, so no per-repo configuration is needed — only a `KUBEARCHIVE_TOKEN` secret.

  Changes:
  - New MCP tool konflux_get_build_logs (memory-server/bot_memory_server/tools/konflux.py)
  - Preflight script extracts Konflux detailsUrl from failed checks
  - Bot instructions updated to call the tool when Konflux pipelines fail
  - Deploy template and docker-compose updated with token secret reference

[RHCLOUD-48548](https://redhat.atlassian.net/browse/RHCLOUD-48548)

---

### Blast radius
  - memory-server: New tool registered, no changes to existing tools
  - bot: Only behavioral — bot will now call the new MCP tool when it encounters Konflux CI failures. No code changes in the bot itself
  - deploy: Requires konflux-read-token key in devbot-secrets Vault secret (optional — tool gracefully returns an error if missing)
