### PR TITLE
fix(preflight): add BOT_LABEL filtering to kanban queries

### DIFF
--- a/bot/tests/test_jira_kanban_preflight.py
+++ b/bot/tests/test_jira_kanban_preflight.py
@@ -75,6 +75,7 @@ def _mock_tasks(active=None, done=None, paused=None):
 @pytest.fixture
 def env_vars(monkeypatch, tmp_path):
     monkeypatch.setattr("jira_kanban_preflight.INSTANCE_ID", "test-instance")
+    monkeypatch.setattr("jira_kanban_preflight.BOT_LABEL", "hcc-ai-lightspeed-core")
     monkeypatch.setattr("jira_kanban_preflight.BOT_JIRA_PROJECT", "LCORE")
     monkeypatch.setattr("jira_kanban_preflight.BOT_JIRA_EMAIL", "bot@test.com")
     monkeypatch.setattr("jira_kanban_preflight.BOT_KANBAN_STATUSES", "New,Backlog,To Do")
@@ -398,3 +399,59 @@ def test_custom_statuses_in_query(env_vars, monkeypatch):
     assert len(captured_jqls) >= 1
     assert '"Open"' in captured_jqls[0]
     assert '"Ready"' in captured_jqls[0]
+
+
+def test_bot_label_in_candidate_query(env_vars, monkeypatch):
+    """BOT_LABEL is used to filter candidates in JQL."""
+    captured_jqls = []
+
+    def mock_search(jql, limit=10):
+        captured_jqls.append(jql)
+        return []
+
+    monkeypatch.setattr("jira_kanban_preflight._jira_search", mock_search)
+
+    from jira_kanban_preflight import _get_candidates
+
+    _get_candidates({})
+
+    assert len(captured_jqls) >= 1
+    assert "labels = hcc-ai-lightspeed-core" in captured_jqls[0]
+
+
+def test_missing_bot_label_returns_empty(env_vars, monkeypatch):
+    """No BOT_LABEL → _get_candidates returns empty, no JQL fired."""
+    monkeypatch.setattr("jira_kanban_preflight.BOT_LABEL", "")
+    captured_jqls = []
+
+    def mock_search(jql, limit=10):
+        captured_jqls.append(jql)
+        return []
+
+    monkeypatch.setattr("jira_kanban_preflight._jira_search", mock_search)
+
+    from jira_kanban_preflight import _get_candidates
+
+    result = _get_candidates({})
+
+    assert result == []
+    assert len(captured_jqls) == 0
+
+
+def test_bot_label_in_investigation_query(env_vars, monkeypatch):
+    """BOT_LABEL is used to filter investigation candidates."""
+    captured_jqls = []
+
+    def mock_search(jql, limit=10):
+        captured_jqls.append(jql)
+        return []
+
+    monkeypatch.setattr("jira_kanban_preflight._jira_search", mock_search)
+
+    from jira_kanban_preflight import _get_investigation_candidates
+
+    _get_investigation_candidates({})
+
+    assert len(captured_jqls) == 1
+    assert "labels = hcc-ai-lightspeed-core" in captured_jqls[0]
+    assert "labels = needs-investigation" in captured_jqls[0]

--- a/presets/shared/preflight/jira_kanban_preflight.py
+++ b/presets/shared/preflight/jira_kanban_preflight.py
@@ -27,6 +27,7 @@ from common import (
 )
 from jira_mcp import jira_call, jira_cleanup
 
+BOT_LABEL = os.environ.get("BOT_LABEL", "")
 BOT_JIRA_PROJECT = os.environ.get("BOT_JIRA_PROJECT", "")
 BOT_JIRA_EMAIL = os.environ.get("BOT_JIRA_EMAIL", "")
 BOT_KANBAN_STATUSES = os.environ.get("BOT_KANBAN_STATUSES", "New,Backlog,To Do")
@@ -152,10 +153,14 @@ def _get_candidates(repo_lookup):
     if not BOT_JIRA_PROJECT:
         print("ERR: BOT_JIRA_PROJECT not set", file=sys.stderr)
         return []
+    if not BOT_LABEL:
+        print("ERR: BOT_LABEL not set — cannot filter candidates", file=sys.stderr)
+        return []
 
     statuses = _parse_statuses()
     status_list = ", ".join(f'"{s}"' for s in statuses)
     extra = f" AND {BOT_KANBAN_JQL_EXTRA}" if BOT_KANBAN_JQL_EXTRA.strip() else ""
+    label_filter = f"AND labels = {BOT_LABEL} "
     candidates = []
     seen_keys = set()
 
@@ -172,7 +177,7 @@ def _get_candidates(repo_lookup):
 
     collect(
         f"project = {BOT_JIRA_PROJECT} AND status IN ({status_list}) "
-        f"AND assignee is EMPTY{extra} "
+        f"{label_filter}AND assignee is EMPTY{extra} "
         f"ORDER BY priority DESC, created ASC",
         "kanban/unassigned",
     )
@@ -180,7 +185,7 @@ def _get_candidates(repo_lookup):
     if len(candidates) < 10 and BOT_JIRA_EMAIL:
         collect(
             f"project = {BOT_JIRA_PROJECT} AND status IN ({status_list}) "
-            f'AND assignee = "{BOT_JIRA_EMAIL}"{extra} '
+            f'{label_filter}AND assignee = "{BOT_JIRA_EMAIL}"{extra} '
             f"ORDER BY priority DESC, created ASC",
             "kanban/bot-assigned",
         )
@@ -189,13 +194,14 @@ def _get_candidates(repo_lookup):
 
 
 def _get_investigation_candidates(repo_lookup):
-    if not BOT_JIRA_PROJECT:
+    if not BOT_JIRA_PROJECT or not BOT_LABEL:
         return []
     statuses = _parse_statuses()
     status_list = ", ".join(f'"{s}"' for s in statuses)
     extra = f" AND {BOT_KANBAN_JQL_EXTRA}" if BOT_KANBAN_JQL_EXTRA.strip() else ""
     issues = _jira_search(
-        f"project = {BOT_JIRA_PROJECT} AND labels = needs-investigation "
+        f"project = {BOT_JIRA_PROJECT} AND labels = {BOT_LABEL} "
+        f"AND labels = needs-investigation "
         f"AND assignee is EMPTY AND status IN ({status_list}){extra} "
         f"ORDER BY priority DESC, created ASC",
         limit=5,
@@ -214,7 +220,7 @@ def _fmt_candidate(c):
             lines.append(f"  repo_labels: {','.join(repo_labels)} (NO MATCH in project-repos.json)")
         else:
             lines.append("  repos: (no repo: label — agent determines repo from ticket content)")
-    other_labels = [label for label in c["labels"] if not label.startswith("repo:")]
+    other_labels = [label for label in c["labels"] if not label.startswith("repo:") and label != BOT_LABEL]
     if other_labels:
         lines.append(f"  labels: {','.join(other_labels)}")
     for lk in c["links"][:5]:


### PR DESCRIPTION
## Summary

- Add `BOT_LABEL` filtering to kanban preflight candidate JQL queries, matching the sprint preflight behavior
- Without this, the kanban preflight picks up **any** unassigned ticket in the project — the LSC instance grabbed LCORE-1851 which was not labeled for the bot
- `_get_candidates` and `_get_investigation_candidates` now require `BOT_LABEL` and return empty if unset
- Filter out `BOT_LABEL` from displayed labels in `_fmt_candidate` (cosmetic, matches sprint)
- Added 3 new tests: label in candidate query, missing label guard, label in investigation query

## Test plan

- [x] All 22 kanban preflight tests pass (including 3 new ones)
- [x] Patched live in LSC pod — preflight correctly returns `start` only for active/interrupted tasks, not new unlabeled candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)