### PR TITLE
fix(entrypoint): only run entrypoint.d scripts for installed envs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -177,9 +177,21 @@ if [ -n "${BOT_MEMORY_HEALTH_URL:-}" ]; then
     wait_for_http "memory-server" "$BOT_MEMORY_HEALTH_URL" "${BOT_MEMORY_HEALTH_TIMEOUT:-120}"
 fi
 
-# Run env preset entrypoint scripts (Chromium, dev-proxy, etc.)
+# Run env preset entrypoint scripts — only for installed envs
+INSTALLED_ENVS=""
+for cfg in instance/*/agent/instance.yaml; do
+    [ -f "$cfg" ] || continue
+    INSTALLED_ENVS="$INSTALLED_ENVS $(sed -n '/^envs:/,/^[^ ]/{ s/^  - //p }' "$cfg")"
+done
+INSTALLED_ENVS=$(echo "$INSTALLED_ENVS" | tr ' ' '\n' | sort -u | xargs)
 shopt -s nullglob
-for script in presets/envs/*/entrypoint.d/*.sh; do bash "$script"; done
+if [ -z "$INSTALLED_ENVS" ]; then
+    for script in presets/envs/*/entrypoint.d/*.sh; do bash "$script"; done
+else
+    for env in $INSTALLED_ENVS; do
+        for script in presets/envs/$env/entrypoint.d/*.sh; do bash "$script"; done
+    done
+fi
 shopt -u nullglob
 
 echo "Credentials configured. Starting bot with label: ${BOT_LABEL}"

--- a/presets/envs/browser/entrypoint.d/10-chromium.sh
+++ b/presets/envs/browser/entrypoint.d/10-chromium.sh
@@ -7,7 +7,11 @@ if curl -s http://127.0.0.1:9222/json/version > /dev/null 2>&1; then
     exit 0
 fi
 
-CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f | head -1)
+CHROME_BIN=$(find "${PLAYWRIGHT_BROWSERS_PATH:-/nonexistent}" -name chrome -type f 2>/dev/null | head -1)
+if [ -z "$CHROME_BIN" ]; then
+    echo "Chromium not installed, skipping"
+    exit 0
+fi
 "$CHROME_BIN" \
     --headless --no-sandbox --disable-gpu \
     --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 \


### PR DESCRIPTION
## Summary

- **Selective dispatch**: `entrypoint.sh` now reads `envs:` from all `instance/*/agent/instance.yaml` files (same logic as `install-envs.sh`) and only runs `entrypoint.d/*.sh` scripts for installed env presets. Falls back to running all scripts if no instance config is found (local dev / backward compat).
- **Defense-in-depth**: `10-chromium.sh` guards against missing Chromium binary before attempting to start it.

Fixes Chromium startup errors (`find: '': No such file or directory`, `command not found`) on instances like LSC that don't have the browser env installed but ship the preset files on disk.

## Test plan

- [x] `bash -n entrypoint.sh` — syntax OK
- [x] `bash -n presets/envs/browser/entrypoint.d/10-chromium.sh` — syntax OK
- [x] All 150 tests pass
- [ ] Deploy to LSC instance — verify no Chromium errors in logs
- [ ] Deploy to framework instance (has browser env) — verify Chromium starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)