### PR TITLE
fix: improve cost tracking logging and resolve field name mismatches

### DIFF
--- a/.claude/skills/jira_mcp.py
+++ b/.claude/skills/jira_mcp.py
@@ -32,8 +32,8 @@ async def _ensure_session():
     if not JIRA_MCP_URL:
         raise RuntimeError("JIRA_MCP_URL not set")
 
-    from mcp.client.streamable_http import streamablehttp_client
     from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
 
     _cm_transport = streamablehttp_client(JIRA_MCP_URL)
     _read, _write, _ = await _cm_transport.__aenter__()

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -26,6 +26,10 @@ TURN_CRITICAL_THRESHOLD = 0.90  # urgent at 90%
 
 DASHBOARD_URL = os.environ.get("BOT_DASHBOARD_URL", "http://localhost:8080/api/bot-status")
 
+# Track consecutive status push failures for warning after N misses
+_status_fail_count = 0
+_STATUS_FAIL_WARNING_THRESHOLD = 5
+
 
 @dataclass
 class CycleContext:
@@ -46,19 +50,28 @@ async def _push_status(
     repo: str | None = None,
 ) -> None:
     """Push a status update to the dashboard banner via HTTP."""
+    global _status_fail_count
     try:
         await client.post(
             DASHBOARD_URL,
             json={
                 "state": state,
                 "message": message,
-                "jira_key": jira_key,
+                "external_key": jira_key,
                 "repo": repo,
             },
             timeout=2.0,
         )
-    except Exception:
-        pass  # Dashboard may be down — don't break the bot
+        _status_fail_count = 0
+    except Exception as e:
+        _status_fail_count += 1
+        logger.debug("Dashboard push failed: %s", e)
+        if _status_fail_count >= _STATUS_FAIL_WARNING_THRESHOLD:
+            logger.warning(
+                "Dashboard unreachable (%d+ consecutive failures)",
+                _STATUS_FAIL_WARNING_THRESHOLD,
+            )
+            _status_fail_count = 0
 
 
 def _describe_tool_use(block) -> str:

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -66,12 +66,11 @@ async def _push_status(
     except Exception as e:
         _status_fail_count += 1
         logger.debug("Dashboard push failed: %s", e)
-        if _status_fail_count >= _STATUS_FAIL_WARNING_THRESHOLD:
+        if _status_fail_count == _STATUS_FAIL_WARNING_THRESHOLD:
             logger.warning(
-                "Dashboard unreachable (%d+ consecutive failures)",
+                "Dashboard unreachable (%d consecutive failures, silencing)",
                 _STATUS_FAIL_WARNING_THRESHOLD,
             )
-            _status_fail_count = 0
 
 
 def _describe_tool_use(block) -> str:

--- a/bot/costs.py
+++ b/bot/costs.py
@@ -59,12 +59,13 @@ def _build_entry(label: str, result, ctx: CycleContext | None = None) -> dict:
         "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
         "cache_write_tokens": usage.get("cache_creation_input_tokens", 0),
         "model": model,
+        "model_usage": model_usage if model_usage else {},
         "is_error": getattr(result, "subtype", "") != "success",
         "no_work": _is_no_work(result_text),
     }
 
     if ctx:
-        entry["jira_key"] = ctx.jira_key
+        entry["external_key"] = ctx.jira_key
         entry["repo"] = ctx.repo
         entry["work_type"] = ctx.work_type
         entry["summary"] = ctx.summary
@@ -86,8 +87,16 @@ def record_cost(costs_file: Path, label: str, result, ctx: CycleContext | None =
 
     # Push to dashboard API
     try:
-        httpx.post(COSTS_API, json=entry, timeout=3.0)
-    except Exception:
-        logger.debug("Failed to push cost to dashboard API (dashboard may be down)")
+        resp = httpx.post(COSTS_API, json=entry, timeout=3.0)
+        if not resp.is_success:
+            logger.warning(
+                "Cost push failed: HTTP %d: %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+    except httpx.TimeoutException:
+        logger.warning("Cost push timed out after 3s")
+    except Exception as e:
+        logger.warning("Cost push failed: %s", e)
 
     return entry["no_work"]

--- a/bot/run.py
+++ b/bot/run.py
@@ -372,6 +372,17 @@ def cleanup_between_cycles(script_dir: Path) -> None:
         pass
 
 
+def handle_cycle_timeout(timeout_seconds: int) -> tuple[None, None]:
+    """Log timeout and warn about lost cost data. Returns (None, None) for result, ctx."""
+    logger = logging.getLogger(__name__)
+    logger.error(
+        "Cycle timed out after %ds — skipping to next cycle",
+        timeout_seconds,
+    )
+    logger.warning("Cost data for timed-out cycle lost (SDK does not expose partial usage)")
+    return None, None
+
+
 def main() -> None:
     # Load .env before anything else so MCP servers get the credentials
     load_dotenv(SCRIPT_DIR / ".env")
@@ -523,12 +534,7 @@ def main() -> None:
                     )
                 )
             except asyncio.TimeoutError:
-                logger.error(
-                    "Cycle timed out after %ds — skipping to next cycle",
-                    config.cycle_timeout,
-                )
-                logger.warning("Cost data for timed-out cycle lost (SDK does not expose partial usage)")
-                result, ctx = None, None
+                result, ctx = handle_cycle_timeout(config.cycle_timeout)
 
             if result is not None:
                 record_cost(

--- a/bot/run.py
+++ b/bot/run.py
@@ -103,8 +103,12 @@ def setup_git(script_dir: Path) -> None:
 
 
 def setup_logging() -> None:
-    """Configure logging to stdout and data/bot.log."""
+    """Configure logging to stdout and data/bot.log.
+
+    Set DEBUG=true env var to enable DEBUG-level logging.
+    """
     DATA_DIR.mkdir(exist_ok=True)
+    level = logging.DEBUG if os.environ.get("DEBUG") == "true" else logging.INFO
     fmt = "[%(asctime)s] %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
 
@@ -114,7 +118,7 @@ def setup_logging() -> None:
     ]
 
     logging.basicConfig(
-        level=logging.INFO,
+        level=level,
         format=fmt,
         datefmt=datefmt,
         handlers=handlers,
@@ -523,6 +527,7 @@ def main() -> None:
                     "Cycle timed out after %ds — skipping to next cycle",
                     config.cycle_timeout,
                 )
+                logger.warning("Cost data for timed-out cycle lost (SDK does not expose partial usage)")
                 result, ctx = None, None
 
             if result is not None:

--- a/bot/tests/test_gh_pr_status.py
+++ b/bot/tests/test_gh_pr_status.py
@@ -3,13 +3,10 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
 sys.path.insert(0, str(SHARED_DIR))
 
 from gh_pr_status import classify_gh  # noqa: E402
-
 
 # --- classify_gh ---
 

--- a/bot/tests/test_preflight_shared.py
+++ b/bot/tests/test_preflight_shared.py
@@ -1,11 +1,8 @@
 """Tests for preflight shared modules (presets/shared/preflight/)."""
 
-import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
 sys.path.insert(0, str(SHARED_DIR))
@@ -19,7 +16,6 @@ from common import (  # noqa: E402
 from gh_pr_status import classify_gh, has_new_feedback  # noqa: E402
 from gl_mr_status import classify_gl  # noqa: E402
 from gl_mr_status import has_new_feedback as gl_has_new_feedback  # noqa: E402
-
 
 # --- upstream_repo ---
 

--- a/impact-data/collect-impact-data.py
+++ b/impact-data/collect-impact-data.py
@@ -16,26 +16,27 @@ Environment variables (optional):
   JIRA_EMAIL     — Jira email for Basic auth; if set, uses Basic auth
                    (email:token). If unset, uses Bearer token auth.
   JIRA_FILTER_ID — Jira saved filter ID   (default: 107017)
-  GH_BOT_USER    — GitHub bot username     (default: platex-rehor-bot)
-  OUTPUT_FILE    — Output CSV path         (default: tickets-with-prs.csv)
+  GH_BOT_USER       — GitHub bot username          (default: platex-rehor-bot)
+  BOT_LABEL_PREFIX  — Label prefix for bot labels  (default: hcc-ai-)
+  OUTPUT_FILE       — Output CSV path              (default: tickets-with-prs.csv)
 
 Usage:
   export JIRA_TOKEN="..."
   python3 collect-impact-data.py
 """
 
-import os
-import sys
-import json
 import csv
+import json
+import os
 import re
-import time
 import subprocess
-import urllib.request
-import urllib.parse
+import sys
+import time
 import urllib.error
+import urllib.parse
+import urllib.request
 from base64 import b64encode
-from datetime import datetime, date
+from datetime import date, datetime
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -47,6 +48,7 @@ JIRA_EMAIL = os.environ.get("JIRA_EMAIL", "")
 JIRA_FILTER_ID = os.environ.get("JIRA_FILTER_ID", "107017")
 
 GH_BOT_USER = os.environ.get("GH_BOT_USER", "platex-rehor-bot")
+BOT_LABEL_PREFIX = os.environ.get("BOT_LABEL_PREFIX", "hcc-ai-")
 
 OUTPUT_FILE = os.environ.get("OUTPUT_FILE", "tickets-with-prs.csv")
 
@@ -386,13 +388,13 @@ def match_prs_to_tickets(prs):
 
 
 def get_repo_labels(labels):
-    return [l[5:] for l in labels if l.startswith("repo:")]
+    return [label[5:] for label in labels if label.startswith("repo:")]
 
 
 def get_bot_label(labels):
-    for l in labels:
-        if l.startswith("hcc-ai-"):
-            return l
+    for label in labels:
+        if label.startswith(BOT_LABEL_PREFIX):
+            return label
     return ""
 
 
@@ -623,7 +625,7 @@ def compute_stats(tickets, pr_map, comment_links, gh_prs, with_prs, with_mrs):
     ticket_types = sorted(type_counts.items(), key=lambda x: -x[1])
 
     # --- Bot labels ---
-    bot_labels = sorted({l for t in tickets for l in t["labels"] if l.startswith("hcc-ai-")})
+    bot_labels = sorted({lb for t in tickets for lb in t["labels"] if lb.startswith(BOT_LABEL_PREFIX)})
 
     # --- Timeline ---
     first_pr_date = None

--- a/impact-data/extract-pr-links.py
+++ b/impact-data/extract-pr-links.py
@@ -12,14 +12,11 @@ Output:
     impact-data/tickets-with-prs.csv
 """
 
-import json
-import glob
-import re
 import csv
-import subprocess
-import sys
+import glob
+import json
 import os
-import time
+import re
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -99,7 +96,8 @@ def main():
             data = json.load(f)
             comment_links.update(data)
     print(
-        f"Loaded comment links for {len(comment_links)} tickets from {len(glob.glob(os.path.join(SCRIPT_DIR, 'comments-links-page*.json')))} files"
+        f"Loaded comment links for {len(comment_links)} tickets from"
+        f" {len(glob.glob(os.path.join(SCRIPT_DIR, 'comments-links-page*.json')))} files"
     )
 
     # Build CSV

--- a/impact-data/generate-report.py
+++ b/impact-data/generate-report.py
@@ -6,7 +6,8 @@ Zero dependencies — uses only Python stdlib.
 
 Usage:
     python3 generate-report.py
-    python3 generate-report.py --stats stats.json --template impact-assessment.md.template --output ../rehor-impact-assessment.md
+    python3 generate-report.py --stats stats.json --template impact-assessment.md.template
+        --output ../rehor-impact-assessment.md
 """
 
 import argparse
@@ -14,7 +15,7 @@ import json
 import os
 import re
 import sys
-from datetime import datetime, date
+from datetime import date, datetime
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/test_cost_tracking_logging.py
+++ b/tests/test_cost_tracking_logging.py
@@ -16,8 +16,17 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
+import bot.agent
 from bot.agent import _push_status
 from bot.costs import record_cost
+
+
+@pytest.fixture(autouse=True)
+def _reset_status_fail_count():
+    """Reset module-level failure counter between tests."""
+    bot.agent._status_fail_count = 0
+    yield
+    bot.agent._status_fail_count = 0
 
 
 @pytest.fixture
@@ -101,7 +110,7 @@ def test_cost_push_http_error_now_detected(tmp_costs_file, mock_result, caplog):
 
 @pytest.mark.asyncio
 async def test_status_push_failure_now_logged(caplog):
-    """FIXED: _push_status now logs failures at DEBUG, WARNING after 5 consecutive."""
+    """FIXED: _push_status logs DEBUG per failure, WARNING once at threshold, then silent."""
     caplog.set_level(logging.DEBUG)
 
     mock_client = AsyncMock()
@@ -113,45 +122,43 @@ async def test_status_push_failure_now_logged(caplog):
     assert caplog.records[0].levelname == "DEBUG"
     assert "Dashboard push failed" in caplog.text
 
-    # After 5 consecutive failures: WARNING
+    # Failures 2-4: still DEBUG only
     caplog.clear()
-    caplog.set_level(logging.INFO)
-    for _ in range(4):
+    for _ in range(3):
         await _push_status(mock_client, "working", "Test")
-
-    await _push_status(mock_client, "working", "Test")
-    # Check that WARNING was logged (don't clear between calls)
     warning_logs = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert len(warning_logs) > 0
+    assert len(warning_logs) == 0
+
+    # 5th failure: WARNING fires exactly once
+    caplog.clear()
+    await _push_status(mock_client, "working", "Test")
+    warning_logs = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warning_logs) == 1
     assert "Dashboard unreachable" in caplog.text
+
+    # 6th+ failures: no more warnings (silenced)
+    caplog.clear()
+    for _ in range(5):
+        await _push_status(mock_client, "working", "Test")
+    warning_logs = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warning_logs) == 0
 
 
 # --- Test 3: Timeout loses all cost data ---
 
 
-@pytest.mark.asyncio
-async def test_timeout_loses_cost_data(tmp_path, caplog):
-    """Prove: When cycle times out, no cost is recorded (result=None)."""
-    from bot.costs import record_cost
+def test_timeout_logs_cost_data_loss_warning(caplog):
+    """FIXED: Timeout path now warns that cost data is lost."""
+    from bot.run import handle_cycle_timeout
 
-    caplog.set_level(logging.INFO)
-    costs_file = tmp_path / "costs.jsonl"
+    caplog.set_level(logging.WARNING)
 
-    # Simulate the timeout path in run.py:477-499
-    result = None  # Set to None on timeout
+    result, ctx = handle_cycle_timeout(timeout_seconds=600)
 
-    # This is what run.py does after timeout
-    if result is not None:
-        record_cost(costs_file, "test-label", result)
-    else:
-        # No cost recorded
-        pass
-
-    # Verify no cost was written
-    assert not costs_file.exists() or costs_file.read_text() == ""
-
-    # Verify no warning about lost cost data
-    assert "cost data" not in caplog.text.lower()
+    assert result is None
+    assert ctx is None
+    assert any("Cost data for timed-out cycle lost" in r.message for r in caplog.records)
+    assert any(r.levelname == "WARNING" for r in caplog.records)
 
 
 # --- Test 4: Local file write is resilient ---

--- a/tests/test_cost_tracking_logging.py
+++ b/tests/test_cost_tracking_logging.py
@@ -1,0 +1,225 @@
+"""Tests proving cost tracking failures and verifying fixes.
+
+These tests demonstrate the issues identified in the cost-tracking-fix-plan:
+1. Timeout loses cost data
+2. HTTP push failures are silent
+3. Status push failures are completely silent
+
+Tests marked with _BEFORE_ prove the original issue exists.
+Tests marked with _FIXED_ verify the fix works.
+"""
+
+import json
+import logging
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from bot.agent import _push_status
+from bot.costs import record_cost
+
+
+@pytest.fixture
+def mock_result():
+    """Mock SDK ResultMessage with typical usage data."""
+    result = Mock()
+    result.usage = {
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "cache_read_input_tokens": 200,
+        "cache_creation_input_tokens": 100,
+    }
+    result.model_usage = {"claude-opus-4": {"input_tokens": 1000, "output_tokens": 500}}
+    result.session_id = "test-session-123"
+    result.num_turns = 5
+    result.duration_ms = 30000
+    result.total_cost_usd = 0.25
+    result.result = "Task completed successfully"
+    result.subtype = "success"
+    return result
+
+
+@pytest.fixture
+def tmp_costs_file(tmp_path):
+    """Temporary costs.jsonl file."""
+    return tmp_path / "costs.jsonl"
+
+
+@pytest.fixture
+def mock_ctx():
+    """Mock CycleContext."""
+    from bot.agent import CycleContext
+
+    ctx = CycleContext()
+    ctx.jira_key = "RHCLOUD-1234"
+    ctx.repo = "test-repo"
+    ctx.work_type = "new_ticket"
+    ctx.summary = "Fix button color"
+    return ctx
+
+
+# --- Test 1: HTTP push failures are logged at DEBUG (invisible in prod) ---
+
+
+def test_cost_push_failure_now_visible_at_warning(tmp_costs_file, mock_result, caplog):
+    """FIXED: HTTP push failures now logged at WARNING level, visible in production."""
+    caplog.set_level(logging.INFO)
+
+    with patch("bot.costs.httpx.post") as mock_post:
+        mock_post.side_effect = httpx.ConnectError("Connection refused")
+
+        record_cost(tmp_costs_file, "test-label", mock_result)
+
+    # Now visible at INFO level
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "Cost push failed" in caplog.text
+
+
+def test_cost_push_http_error_now_detected(tmp_costs_file, mock_result, caplog):
+    """FIXED: HTTP 500 responses now detected and logged."""
+    caplog.set_level(logging.INFO)
+
+    with patch("bot.costs.httpx.post") as mock_post:
+        mock_resp = Mock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Server Error"
+        mock_resp.is_success = False
+        mock_post.return_value = mock_resp
+
+        record_cost(tmp_costs_file, "test-label", mock_result)
+
+    # Now logged
+    assert len(caplog.records) == 1
+    assert "HTTP 500" in caplog.text
+    assert "Internal Server Error" in caplog.text
+
+
+# --- Test 2: Status push failures are completely silent ---
+
+
+@pytest.mark.asyncio
+async def test_status_push_failure_now_logged(caplog):
+    """FIXED: _push_status now logs failures at DEBUG, WARNING after 5 consecutive."""
+    caplog.set_level(logging.DEBUG)
+
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+
+    # First failure: DEBUG only
+    await _push_status(mock_client, "working", "Processing RHCLOUD-1234")
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "DEBUG"
+    assert "Dashboard push failed" in caplog.text
+
+    # After 5 consecutive failures: WARNING
+    caplog.clear()
+    caplog.set_level(logging.INFO)
+    for _ in range(4):
+        await _push_status(mock_client, "working", "Test")
+
+    await _push_status(mock_client, "working", "Test")
+    # Check that WARNING was logged (don't clear between calls)
+    warning_logs = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warning_logs) > 0
+    assert "Dashboard unreachable" in caplog.text
+
+
+# --- Test 3: Timeout loses all cost data ---
+
+
+@pytest.mark.asyncio
+async def test_timeout_loses_cost_data(tmp_path, caplog):
+    """Prove: When cycle times out, no cost is recorded (result=None)."""
+    from bot.costs import record_cost
+
+    caplog.set_level(logging.INFO)
+    costs_file = tmp_path / "costs.jsonl"
+
+    # Simulate the timeout path in run.py:477-499
+    result = None  # Set to None on timeout
+
+    # This is what run.py does after timeout
+    if result is not None:
+        record_cost(costs_file, "test-label", result)
+    else:
+        # No cost recorded
+        pass
+
+    # Verify no cost was written
+    assert not costs_file.exists() or costs_file.read_text() == ""
+
+    # Verify no warning about lost cost data
+    assert "cost data" not in caplog.text.lower()
+
+
+# --- Test 4: Local file write is resilient ---
+
+
+def test_cost_local_write_happens_before_http(tmp_costs_file, mock_result):
+    """Verify: Local jsonl write happens even if HTTP push fails."""
+    with patch("bot.costs.httpx.post") as mock_post:
+        mock_post.side_effect = Exception("Network error")
+
+        record_cost(tmp_costs_file, "test-label", mock_result)
+
+    # Local file still written
+    assert tmp_costs_file.exists()
+    entries = [json.loads(line) for line in tmp_costs_file.read_text().strip().split("\n")]
+    assert len(entries) == 1
+    assert entries[0]["session_id"] == "test-session-123"
+
+
+# --- Test 5: Field name mismatch (jira_key vs external_key) ---
+
+
+def test_cost_entry_now_uses_external_key_field(tmp_costs_file, mock_result, mock_ctx):
+    """FIXED: Cost entries now use 'external_key' matching dashboard expectation."""
+    with patch("bot.costs.httpx.post") as mock_post:
+        mock_resp = Mock()
+        mock_resp.is_success = True
+        mock_post.return_value = mock_resp
+
+        record_cost(tmp_costs_file, "test-label", mock_result, ctx=mock_ctx)
+
+    # Check what was sent to API
+    call_args = mock_post.call_args
+    sent_data = call_args.kwargs["json"]
+
+    # Now sends external_key (correct)
+    assert "external_key" in sent_data
+    assert sent_data["external_key"] == "RHCLOUD-1234"
+
+    # Old jira_key field removed
+    assert "jira_key" not in sent_data
+
+
+# --- Test 6: Model usage only captures first model ---
+
+
+def test_model_usage_now_captures_all_models(tmp_costs_file, mock_result):
+    """FIXED: Full model_usage dict now stored alongside scalar model field."""
+    # Simulate multi-model usage (e.g., subagents with different models)
+    mock_result.model_usage = {
+        "claude-opus-4": {"input_tokens": 1000, "output_tokens": 500},
+        "claude-sonnet-4": {"input_tokens": 2000, "output_tokens": 1000},
+    }
+
+    with patch("bot.costs.httpx.post") as mock_post:
+        mock_resp = Mock()
+        mock_resp.is_success = True
+        mock_post.return_value = mock_resp
+
+        record_cost(tmp_costs_file, "test-label", mock_result)
+
+    entries = [json.loads(line) for line in tmp_costs_file.read_text().strip().split("\n")]
+    entry = entries[0]
+
+    # Scalar model field still present (backward compat)
+    assert entry["model"] == "claude-opus-4"
+
+    # Full model_usage dict now stored
+    assert "model_usage" in entry
+    assert entry["model_usage"]["claude-opus-4"]["input_tokens"] == 1000
+    assert entry["model_usage"]["claude-sonnet-4"]["input_tokens"] == 2000

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -3,7 +3,6 @@
 import json
 import stat
 
-
 from bot.merge import (
     PROTECTED_HOOKS,
     MergeReport,

--- a/tests/test_new_work.py
+++ b/tests/test_new_work.py
@@ -7,7 +7,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".claude" / "ski
 
 from new_work import build_repo_lookup, match_repo_labels
 
-
 SAMPLE_REPOS = {
     "insights-chrome": {
         "url": "https://github.com/platex-rehor-bot/insights-chrome.git",

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
-
 # Mock claude_agent_sdk before importing bot modules
 _mock_sdk = ModuleType("claude_agent_sdk")
 for name in [
@@ -30,7 +29,6 @@ from bot.transcripts import (  # noqa: E402
     _resolve_cycle_type,
     record_transcript,
 )
-
 
 # --- _get_cycle_runs_url ---
 


### PR DESCRIPTION
### Description

[REHOR-24](https://issues.redhat.com/browse/REHOR-24)

Fix cost tracking logging visibility and field name mismatches that caused dashboard data to appear under wrong keys.

**Logging improvements:**
- Cost push failures now logged at WARNING (visible in production)
- HTTP error responses (4xx/5xx) detected and logged
- Status push failures logged at DEBUG, WARNING after 5 consecutive
- Timeout cost loss explicitly warned
- Add DEBUG=true env var support for verbose logging

**Field name fixes:**
- Change `jira_key` → `external_key` (matches dashboard expectation)
- Applies to both cost entries and status updates

**Data completeness:**
- Store full `model_usage` dict alongside scalar `model` field

**Tests:**
- 7 new tests covering original issues and verifying fixes

---

### Blast radius
Only affects `bot/agent.py`, `bot/costs.py`, `bot/run.py`. Cost tracking data consumers (dashboard) benefit from corrected field names. No breaking changes to bot behavior.

---

### Rollback plan
Git revert is sufficient — changes are isolated to cost tracking and logging paths.

---

### Checklist
- [x] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
Assisted by: Claude Code