### PR TITLE
feat: add kessel-sdk-browser to project repos

### DIFF
--- a/rehor-config/agent/project-repos.json
+++ b/rehor-config/agent/project-repos.json
@@ -176,5 +176,9 @@
   "scalprum/scaffolding": {
     "url": "https://github.com/platex-rehor-bot/scaffolding.git",
     "upstream": "https://github.com/scalprum/scaffolding.git"
+  },
+  "project-kessel/kessel-sdk-browser": {
+    "url": "https://github.com/platex-rehor-bot/kessel-sdk-browser.git",
+    "upstream": "https://github.com/project-kessel/kessel-sdk-browser.git"
   }
 }

--- a/rehor-config/agent/project-repos.json
+++ b/rehor-config/agent/project-repos.json
@@ -177,7 +177,7 @@
     "url": "https://github.com/platex-rehor-bot/scaffolding.git",
     "upstream": "https://github.com/scalprum/scaffolding.git"
   },
-  "project-kessel/kessel-sdk-browser": {
+  "kessel-sdk-browser": {
     "url": "https://github.com/platex-rehor-bot/kessel-sdk-browser.git",
     "upstream": "https://github.com/project-kessel/kessel-sdk-browser.git"
   }


### PR DESCRIPTION
## Summary
- Add `kessel-sdk-browser` (upstream: `project-kessel/kessel-sdk-browser`) to project-repos.json
- Jira label: `repo:kessel-sdk-browser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)