### PR TITLE
docs: add task tracking and repo discovery for custom workflows

### DIFF
--- a/docs/presets/custom-preflight.md
+++ b/docs/presets/custom-preflight.md
@@ -265,6 +265,58 @@ if __name__ == "__main__":
     main()
 ```
 
+## Repo Discovery
+
+Preflight scripts run from the **bot repo root** — no application repos are cloned at this point. You cannot use `gh repo view`, `git remote -v`, or any command that assumes CWD is inside a cloned repo.
+
+To discover which repos the instance works on, use `load_project_repos()` and `upstream_repo()` from `common.py`:
+
+```python
+from common import load_project_repos, upstream_repo, get_tasks, get_capacity, output_result
+
+TASK_KEY_PREFIX = "my-workflow:"
+
+def main():
+    tasks = get_tasks()
+    active_n, max_n = get_capacity()
+    active = [t for t in tasks if t.get("status") in ("in_progress", "pr_open", "pr_changes")]
+
+    if active_n >= max_n:
+        output_result("skip", f"At capacity ({active_n}/{max_n})")
+        return
+
+    repos = load_project_repos()
+    candidates = []
+
+    for repo_name, cfg in repos.items():
+        up, host = upstream_repo(repo_name)
+        if not up or host != "github":
+            continue
+
+        # Skip repos with an active task
+        task_key = f"{TASK_KEY_PREFIX}{up}"
+        if any(t.get("external_key") == task_key for t in active):
+            continue
+
+        # Query the upstream repo (e.g. for open PRs)
+        items = query_upstream(up)
+        if items:
+            candidates.append({"repo_name": repo_name, "upstream": up, "items": items})
+
+    if not candidates:
+        output_result("skip", "No repos with actionable items")
+        return
+
+    best = max(candidates, key=lambda c: len(c["items"]))
+    output_result("start", json.dumps(best))
+```
+
+Key points:
+- `load_project_repos()` reads `project-repos.json` from the instance config
+- `upstream_repo(repo_name)` resolves a repo entry to `("org/repo", "github"|"gitlab")`
+- The `gh pr list --repo <upstream>` command works without a local clone — it queries the GitHub API directly
+- Filter out repos that already have an active task to avoid duplicate work
+
 ## Real Example Pattern
 
 A common pattern for custom preflight scripts is fetching data from an external service, classifying it, and deciding whether to start a session. Here's the general structure:

--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -116,6 +116,25 @@ requires:
 
 ## instance.yaml Configuration
 
+**One instance = one workflow.** Each instance directory maps to its own OpenShift deployment (own pod, own schedule, own task queue). If you need a second workflow for the same repos, create a second instance directory:
+
+```
+instance/
+  rbac-config/              # Jira-driven workflow
+    agent/
+      instance.yaml         # workflow: jira-kanban
+      project-repos.json
+  rbac-config-konflux/      # Separate workflow for the same repos
+    agent/
+      instance.yaml         # workflow: ./workflows/konflux-pr-squash
+      project-repos.json    # Can reference the same repos
+      workflows/
+        konflux-pr-squash/
+          ...
+```
+
+Both instances share the memory server and can see each other's tasks, but run independently on their own schedules.
+
 Your instance config repo's `instance.yaml` controls which workflow runs and how:
 
 ```yaml
@@ -358,6 +377,92 @@ The preflight script for this pattern typically:
 3. Outputs `start` with only the actionable items, or `skip` if everything is healthy
 
 See [Writing Custom Preflight Scripts](custom-preflight.md) for the implementation details.
+
+## Task Tracking
+
+Custom workflows use the same memory server task system as built-in workflows. The agent creates and updates tasks via MCP tools (`task_add`, `task_update`, `task_get`, `task_remove`) — never via raw HTTP calls to the memory server API.
+
+### external_key conventions
+
+Every task has an `external_key` + `source_type` pair. The DB enforces `UNIQUE(external_key, source_type)`, so this combo is the task's identity.
+
+For **Jira-driven workflows**, the external_key is the Jira ticket key (`RHCLOUD-12345`) and source_type defaults to `"jira"`.
+
+For **non-Jira workflows**, you define your own key format. Use a deterministic, human-readable composite key:
+
+```
+<workflow-name>:<scope>
+```
+
+Examples:
+- `konflux-pr-squash:project-kessel/insights-rbac` — consolidation task scoped to a repo
+- `watchduty:jenkins-prod-pipeline` — monitoring task scoped to a service
+- `review-only:RedHatInsights/insights-chrome` — review task scoped to a repo
+
+If a workflow creates multiple tasks per scope (e.g. one consolidated PR per ecosystem), extend the key:
+- `konflux-pr-squash:project-kessel/insights-rbac:go`
+- `konflux-pr-squash:project-kessel/insights-rbac:python`
+
+### source_type
+
+The `task_add` MCP tool defaults `source_type` to `"jira"`. **Non-Jira workflows must pass it explicitly:**
+
+```
+task_add(
+    external_key="konflux-pr-squash:project-kessel/insights-rbac",
+    source_type="github",        # NOT the default "jira"
+    repo="insights-rbac",
+    branch="bot/consolidate-go-deps",
+    status="pr_open",
+    title="Consolidate 5 Go dependency updates",
+    metadata={
+        "prs": [{"repo": "project-kessel/insights-rbac", "number": 42, "host": "github"}],
+        "original_prs": [101, 102, 103],
+        "ecosystem": "go"
+    }
+)
+```
+
+Getting `source_type` wrong means `task_get` lookups fail (it queries by `external_key` + `source_type`), and preflight scripts that check for in-progress tasks won't find them.
+
+### Why MCP, not HTTP
+
+Your workflow CLAUDE.md should tell the agent to use `task_add`, not construct HTTP requests. The MCP tool:
+- Enforces the **capacity cap** (max 10 active tasks) — raw HTTP bypasses this
+- Publishes **events** to the SSE bus (dashboard updates, Slack notifications)
+- Builds **artifact links** automatically (Jira URLs, PR links)
+- Validates input and returns structured errors
+
+### Preflight integration
+
+Preflight scripts check the task system to avoid duplicate work. Your workflow's preflight should:
+
+1. Call `get_tasks()` to fetch active tasks
+2. Filter for tasks matching your workflow's `external_key` prefix
+3. Skip if a matching task is already in progress
+
+```python
+from common import get_tasks, get_capacity, output_result
+
+TASK_KEY_PREFIX = "my-workflow:"
+
+tasks = get_tasks()
+active = [t for t in tasks if t.get("status") in ("in_progress", "pr_open", "pr_changes")]
+
+# Already working on this?
+my_tasks = [t for t in active if t.get("external_key", "").startswith(TASK_KEY_PREFIX)]
+if my_tasks:
+    output_result("skip", f"Already in progress: {my_tasks[0]['external_key']}")
+    return
+
+# Respect capacity
+active_n, max_n = get_capacity()
+if active_n >= max_n:
+    output_result("skip", f"At capacity ({active_n}/{max_n})")
+    return
+```
+
+The built-in `gh_pr_status.py` preflight monitors all `pr_open` tasks automatically — no per-workflow polling needed. Create a task with `status="pr_open"` and PR metadata, and CI monitoring happens for free.
 
 ## Checklist: Shipping a Custom Workflow
 


### PR DESCRIPTION
## Summary

- Add **Task Tracking** section to `docs/presets/custom-workflows.md` — covers `external_key` conventions for non-Jira workflows, `source_type` requirement, why MCP over HTTP, and preflight integration
- Add **Repo Discovery** section to `docs/presets/custom-preflight.md` — explains that no repos are on disk during preflight, shows pattern using `load_project_repos()` + `upstream_repo()`
- Add **one instance = one workflow** callout with directory structure example

Based on review feedback from [fabric-access-ai-dev#34](https://github.com/RedHatInsights/fabric-access-ai-dev/pull/34) — common onboarding mistakes when building a custom workflow.

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-links between custom-workflows.md and custom-preflight.md still work
- [ ] Code examples in new sections are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)