### PR TITLE
fix(dashboard): handle paginated API responses across components

### DIFF
--- a/.github/workflows/dashboard-tests.yml
+++ b/.github/workflows/dashboard-tests.yml
@@ -1,0 +1,38 @@
+name: Dashboard Tests
+
+on:
+  pull_request:
+    paths:
+      - 'dashboard/**'
+      - '.github/workflows/dashboard-tests.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'dashboard/**'
+      - '.github/workflows/dashboard-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./dashboard
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run linter
+        run: npm run lint

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "lint": "tsc --noEmit",
     "test:ct": "npx playwright test",
     "test:ct:ui": "npx playwright test --ui",
     "generate-fixtures": "python3 tests/fixtures/generate_json.py"

--- a/dashboard/src/pages/Costs.test.tsx
+++ b/dashboard/src/pages/Costs.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Costs from './Costs';
+
+vi.mock('../api', () => ({
+  fetchCosts: vi.fn(),
+  fetchAnalytics: vi.fn(),
+}));
+
+vi.mock('../hooks/useWebSocket', () => ({
+  useWS: () => ({ connected: true, lastEvent: null, onEvent: () => () => {} }),
+}));
+
+import { fetchCosts, fetchAnalytics } from '../api';
+
+const mockFetchCosts = vi.mocked(fetchCosts);
+const mockFetchAnalytics = vi.mocked(fetchAnalytics);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Costs page', () => {
+  it('handles malformed analytics response', async () => {
+    // Mock API returns costs but analytics is missing fields
+    mockFetchCosts.mockResolvedValue({
+      items: [],
+      daily: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    });
+
+    // Analytics response missing all fields except summary
+    mockFetchAnalytics.mockResolvedValue({
+      // Missing summary, work_types, repos, tickets, feedback
+    });
+
+    render(
+      <MemoryRouter>
+        <Costs />
+      </MemoryRouter>
+    );
+
+    // Should render without crashing even with incomplete data
+    await waitFor(() => {
+      expect(screen.getByText(/Tickets Resolved/i)).toBeInTheDocument();
+    });
+  });
+
+  it('handles empty costs response correctly', async () => {
+    // Mock API returns paginated response with items array
+    mockFetchCosts.mockResolvedValue({
+      items: [],
+      daily: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    });
+
+    mockFetchAnalytics.mockResolvedValue({
+      summary: {
+        total_cycles: 0,
+        work_cycles: 0,
+        idle_cycles: 0,
+        error_cycles: 0,
+        unique_tickets: 0,
+        total_cost: 0,
+        avg_cost_per_work_cycle: 0,
+        avg_turns: 0,
+        avg_duration_ms: 0,
+        repos_touched: 0,
+        tickets_resolved: 0,
+      },
+      work_types: [],
+      repos: [],
+      tickets: [],
+      feedback: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <Costs />
+      </MemoryRouter>
+    );
+
+    // Should render without crashing
+    await waitFor(() => {
+      expect(screen.getByText(/Tickets Resolved/i)).toBeInTheDocument();
+    });
+  });
+
+  it('handles costs with data', async () => {
+    const mockCycles = [
+      {
+        id: 1,
+        cycle_number: 1,
+        external_key: 'RHCLOUD-001',
+        repo: 'test-repo',
+        work_type: 'bug_fix',
+        model: 'claude-opus-4',
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 200,
+        cost_usd: 0.05,
+        duration_ms: 30000,
+        started_at: '2026-07-24T10:00:00Z',
+      },
+    ];
+
+    const mockDaily = [
+      {
+        day: '2026-07-24',
+        cycles: 1,
+        total_cost: 0.05,
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read: 200,
+        cache_write: 0,
+        total_duration: 30000,
+        total_turns: 5,
+        idle_cycles: 0,
+        error_cycles: 0,
+      },
+    ];
+
+    mockFetchCosts.mockResolvedValue({
+      items: mockCycles,
+      daily: mockDaily,
+      total: 1,
+      limit: 200,
+      offset: 0,
+    });
+
+    mockFetchAnalytics.mockResolvedValue({
+      summary: {
+        total_cycles: 1,
+        work_cycles: 1,
+        idle_cycles: 0,
+        error_cycles: 0,
+        unique_tickets: 1,
+        total_cost: 0.05,
+        avg_cost_per_work_cycle: 0.05,
+        avg_turns: 5,
+        avg_duration_ms: 30000,
+        repos_touched: 1,
+        tickets_resolved: 1,
+      },
+      work_types: [{ category: 'other', cycles: 1, total_cost: 0.05, avg_cost: 0.05, avg_turns: 5, avg_duration_ms: 30000 }],
+      repos: [{ repo: 'test-repo', cycles: 1, total_cost: 0.05 }],
+      tickets: [{ external_key: 'RHCLOUD-001', cycles: 1, total_cost: 0.05 }],
+      feedback: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <Costs />
+      </MemoryRouter>
+    );
+
+    // Should render cost data
+    await waitFor(() => {
+      expect(screen.getByText('RHCLOUD-001')).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/src/pages/Costs.tsx
+++ b/dashboard/src/pages/Costs.tsx
@@ -214,7 +214,7 @@ export default function Costs() {
       fetchCosts(days, 500, from, to),
       fetchAnalytics(days, from, to),
     ]);
-    setData({ cycles: costsRes.items || [], daily: costsRes.daily || [] });
+    setData({ cycles: costsRes?.items || [], daily: costsRes?.daily || [] });
     setAnalytics(analyticsRes);
   }, [days, dateMode, dateFrom, dateTo]);
 
@@ -229,7 +229,25 @@ export default function Costs() {
   if (!data || !analytics) return <div className="empty-state">Loading...</div>;
 
   const { cycles, daily } = data;
-  const { summary, work_types, repos, tickets, feedback } = analytics;
+  const {
+    summary = {
+      total_cycles: 0,
+      work_cycles: 0,
+      idle_cycles: 0,
+      error_cycles: 0,
+      unique_tickets: 0,
+      total_cost: 0,
+      avg_cost_per_work_cycle: 0,
+      avg_turns: 0,
+      avg_duration_ms: 0,
+      repos_touched: 0,
+      tickets_resolved: 0,
+    },
+    work_types = [],
+    repos = [],
+    tickets = [],
+    feedback = { avg_review_rounds: 0, zero_review: 0, multi_review: 0 },
+  } = analytics;
 
   const totalDuration = cycles.reduce((s, c) => s + c.duration_ms, 0);
   const totalOutput = cycles.reduce((s, c) => s + c.output_tokens, 0);

--- a/dashboard/src/pages/CycleRuns.test.tsx
+++ b/dashboard/src/pages/CycleRuns.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import CycleRuns from './CycleRuns';
+
+vi.mock('../api', () => ({
+  fetchCycleRunsByTask: vi.fn(),
+  fetchCycleRuns: vi.fn(),
+  fetchCycleRunTranscript: vi.fn(),
+}));
+
+vi.mock('../hooks/useWebSocket', () => ({
+  useWS: () => ({ connected: true, lastEvent: null, onEvent: () => () => {} }),
+}));
+
+import { fetchCycleRunsByTask, fetchCycleRuns } from '../api';
+
+const mockFetchCycleRunsByTask = vi.mocked(fetchCycleRunsByTask);
+const mockFetchCycleRuns = vi.mocked(fetchCycleRuns);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CycleRuns page', () => {
+  it('handles empty cycle runs response correctly', async () => {
+    // Mock API returns paginated response with items array
+    mockFetchCycleRunsByTask.mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/instances/dev-bot/cycles']}>
+        <Routes>
+          <Route path="/instances/:instanceId/cycles" element={<CycleRuns />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Should render empty state without crashing
+    await waitFor(() => {
+      expect(screen.getByText('No cycle runs found')).toBeInTheDocument();
+    });
+  });
+
+  it('handles cycle runs with task groups', async () => {
+    const mockGroups = [
+      {
+        task_id: 1,
+        external_key: 'RHCLOUD-001',
+        summary: 'Fix login bug',
+        cycle_count: 3,
+        last_cycle_start: '2026-07-24T10:00:00Z',
+      },
+      {
+        task_id: 2,
+        external_key: 'RHCLOUD-002',
+        summary: 'Add dark mode',
+        cycle_count: 1,
+        last_cycle_start: '2026-07-24T09:00:00Z',
+      },
+    ];
+
+    mockFetchCycleRunsByTask.mockResolvedValue({
+      items: mockGroups,
+      total: 2,
+      limit: 20,
+      offset: 0,
+    });
+
+    mockFetchCycleRuns.mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/instances/dev-bot/cycles']}>
+        <Routes>
+          <Route path="/instances/:instanceId/cycles" element={<CycleRuns />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Should render both task groups
+    await waitFor(() => {
+      expect(screen.getByText('RHCLOUD-001')).toBeInTheDocument();
+      expect(screen.getByText('RHCLOUD-002')).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/src/pages/CycleRuns.tsx
+++ b/dashboard/src/pages/CycleRuns.tsx
@@ -547,7 +547,7 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
 
   const loadGroups = useCallback(async () => {
     const data = await fetchCycleRunsByTask({ instance_id: instanceId });
-    setGroups(data || []);
+    setGroups(data?.items || []);
   }, [instanceId]);
 
   const loadCyclesForTask = useCallback(async (taskId: number | null, orphan = false, showLoading = true) => {

--- a/dashboard/src/pages/EmbeddingMap.tsx
+++ b/dashboard/src/pages/EmbeddingMap.tsx
@@ -152,9 +152,10 @@ export default function EmbeddingMap() {
     resizeObserver.observe(container);
 
     // Load data
-    fetchEmbeddings().then((points: EmbeddingPoint[]) => {
+    fetchEmbeddings().then((data) => {
       if (disposed) return;
 
+      const points: EmbeddingPoint[] = data?.items || [];
       const geo = new THREE.SphereGeometry(0.04, 12, 12);
 
       points.forEach((pt) => {


### PR DESCRIPTION
Followup for patternfly migration pr, where I noticed some runtime errors


## Summary

Fixed crashes in CycleRuns, Costs, and EmbeddingMap components caused by incorrect handling of paginated API responses. All three APIs return `{items: [], total: 0}` structure, but components expected direct arrays.

## Changes

- **CycleRuns**: Extract `items` from paginated response to fix "groups.map is not a function"
- **Costs**: Add defensive coding with optional chaining and default values for incomplete API responses
- **EmbeddingMap**: Extract `items` from paginated response to fix "points.forEach is not a function"

## Test Coverage

- ✅ CycleRuns: Empty and populated cycle runs
- ✅ Costs: Malformed analytics, empty/populated data
- ⚠️ EmbeddingMap: No test (THREE.js WebGL requirement)

## Bugs Fixed

- CycleRuns crash introduced in aa95783
- Costs crashes introduced in 7a5eb70
- EmbeddingMap crash (same paginated API pattern)

---

**Base:** Built on top of `feat/dashboard-pf6-migration` branch

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>