### PR TITLE
fix: eliminate loading flash in cycles and add fade-in animations

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -313,6 +313,7 @@ header {
 
 .instance-grid > * {
   height: 100%;
+  animation: fadeSlideIn 0.5s ease-out;
 }
 
 .pf-v6-c-nav.pf-m-horizontal {
@@ -630,6 +631,10 @@ select:focus,
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.card-grid > * {
+  animation: fadeSlideIn 0.5s ease-out;
 }
 
 /* Task card */
@@ -1708,6 +1713,7 @@ select:focus,
 
 /* Task group cards (cycle runs grouped by task) */
 .task-group-list { display: flex; flex-direction: column; gap: 4px; }
+.task-group-list > * { animation: fadeSlideIn 0.5s ease-out; }
 .task-group-card {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -1808,6 +1814,21 @@ select:focus,
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.task-group-cycles > * {
+  animation: fadeSlideIn 0.5s ease-out;
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Empty state */

--- a/dashboard/src/pages/CycleRuns.tsx
+++ b/dashboard/src/pages/CycleRuns.tsx
@@ -550,8 +550,8 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
     setGroups(data || []);
   }, [instanceId]);
 
-  const loadCyclesForTask = useCallback(async (taskId: number | null, orphan = false) => {
-    setLoadingRuns(true);
+  const loadCyclesForTask = useCallback(async (taskId: number | null, orphan = false, showLoading = true) => {
+    if (showLoading) setLoadingRuns(true);
     try {
       const params: { task_id?: number | 'none'; instance_id?: string; limit: number } = { limit: 50 };
       if (taskId != null) params.task_id = taskId;
@@ -561,7 +561,7 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
       setRuns(res.items || []);
       return res.items || [];
     } finally {
-      setLoadingRuns(false);
+      if (showLoading) setLoadingRuns(false);
     }
   }, [instanceId]);
 
@@ -572,25 +572,32 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
   useEffect(() => {
     const cycleParam = searchParams.get('cycle');
     const taskParam = searchParams.get('task_id');
-    if (cycleParam && groups.length > 0) {
+    if (cycleParam && groups.length > 0 && !selectedRun) {
       const cycleId = parseInt(cycleParam);
       const tid = taskParam ? parseInt(taskParam) : null;
       const match = groups.find((g) => g.task_id === tid);
       setExpandedGroupKey(match ? groupKey(match) : tid != null ? `t:${tid}` : 'orphan');
-      loadCyclesForTask(tid, tid == null).then((items) => {
+      loadCyclesForTask(tid, tid == null, false).then((items) => {
         const found = items.find((r: CycleRun) => r.id === cycleId);
         if (found) setSelectedRun(found);
       });
     }
-  }, [searchParams, groups, loadCyclesForTask]);
+  }, [groups, loadCyclesForTask]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return onEvent((event) => {
       if (event.type === 'cycle_run_added') {
         loadGroups();
+        if (expandedGroupKey) {
+          const expanded = groups.find((g) => groupKey(g) === expandedGroupKey);
+          if (expanded) {
+            const isOrphan = expanded.task_id == null && !expanded.external_key;
+            loadCyclesForTask(expanded.task_id, isOrphan, false);
+          }
+        }
       }
     });
-  }, [onEvent, loadGroups]);
+  }, [onEvent, loadGroups, expandedGroupKey, groups, loadCyclesForTask]);
 
   const handleGroupClick = async (g: TaskCycleGroup) => {
     const key = groupKey(g);


### PR DESCRIPTION
## Summary
- Fixed cycles page flashing Loading cycles... on every WebSocket event and when clicking cycle details
- Silently refreshes expanded cycle list when new cycles arrive (no flash)
- Added smooth 0.5s fade-in animation for cards across all pages

## Test plan
- [ ] Open Cycles page, expand a group — should show Loading only on first expand
- [ ] Click a cycle to see details — no Loading flash
- [ ] Wait for new cycle to arrive — appears with smooth animation
- [ ] Check Tasks, Memories, Instances pages — cards fade in smoothly

Made with [Cursor](https://cursor.com)