### PR TITLE
fix(preflight): stop classifying addressed PRs as actionable

### DIFF
--- a/bot/agent.py
+++ b/bot/agent.py
@@ -360,8 +360,8 @@ def _extract_task_id_from_result(block: ToolResultBlock, ctx: CycleContext) -> N
         data = json.loads(text)
         if not isinstance(data, dict):
             return
-        # Task objects: {id: int, jira_key: ...}
-        if isinstance(data.get("id"), int) and "jira_key" in data:
+        # Task objects: {id: int, external_key: ...}
+        if isinstance(data.get("id"), int) and ("external_key" in data or "jira_key" in data):
             ctx.task_id = data["id"]
         # Cycle run objects from progress_store: {task_id: int, cycle_type: ...}
         elif isinstance(data.get("task_id"), int) and data["task_id"] > 0:

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -220,7 +220,7 @@ def main():
         elif "closed" in issues:
             closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
-            ci_only = all(i.startswith("ci_fail") for i in issues)
+            ci_only = all(i.startswith(("ci_fail", "konflux_urls", "changes_requested")) for i in issues)
             if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):
                 clean.append(e)
             else:
@@ -228,7 +228,10 @@ def main():
         elif "conflict" in issues:
             conflict.append(e)
         elif any(i in ("changes_requested",) or i.startswith("review:") for i in issues):
-            feedback.append(e)
+            if has_new_feedback(e) or not e["task"].get("last_addressed"):
+                feedback.append(e)
+            else:
+                clean.append(e)
         elif has_new_feedback(e):
             feedback.append(e)
         else:


### PR DESCRIPTION
## Summary
- Fix `ci_only` check in `gh_pr_status.py` to treat `konflux_urls` as CI-related metadata (not a separate issue type that breaks the `all()` check)
- Fix `changes_requested` classification to check `has_new_feedback` before marking as actionable — stale GitHub review decisions no longer trigger Claude sessions
- Fix `agent.py` task_id extraction to recognize `external_key` (current) alongside legacy `jira_key`

## Test plan
- [x] Deploy to pod, observe preflight cycles with CI-failing + changes_requested PRs
- [x] Verify preflight returns `skip` when all PRs are already addressed
- [x] Verify preflight still returns `start` when genuine new feedback exists

Resolves: [REHOR-49](https://redhat.atlassian.net/browse/REHOR-49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)