### PR TITLE
fix(preflight): stop classifying investigation_posted tasks as interrupted

### DIFF
--- a/docs/git-auth-proxy.md
+++ b/docs/git-auth-proxy.md
@@ -191,20 +191,24 @@ In `setup_git()`, replace credential helper entries with `insteadOf` rewrites wh
 git_proxy_host = os.environ.get("GIT_AUTH_PROXY_HOST")  # e.g. "devbot-proxy"
 if git_proxy_host:
     # URL rewrite — token stays in proxy, never reaches bot pod
-    lines.extend([
-        f'[url "http://{git_proxy_host}:8447/github.com/"]',
-        '\tinsteadOf = https://github.com/',
-        f'[url "http://{git_proxy_host}:8447/gitlab.cee.redhat.com/"]',
-        '\tinsteadOf = https://gitlab.cee.redhat.com/',
-    ])
+    lines.extend(
+        [
+            f'[url "http://{git_proxy_host}:8447/github.com/"]',
+            "\tinsteadOf = https://github.com/",
+            f'[url "http://{git_proxy_host}:8447/gitlab.cee.redhat.com/"]',
+            "\tinsteadOf = https://gitlab.cee.redhat.com/",
+        ]
+    )
 else:
     # Fallback: credential helper (local dev, proxy not available)
-    lines.extend([
-        '[credential "https://github.com"]',
-        '\thelper = !/usr/local/bin/gh auth git-credential',
-        '[credential "https://gitlab.cee.redhat.com"]',
-        '\thelper = !/usr/local/bin/glab credential-helper',
-    ])
+    lines.extend(
+        [
+            '[credential "https://github.com"]',
+            "\thelper = !/usr/local/bin/gh auth git-credential",
+            '[credential "https://gitlab.cee.redhat.com"]',
+            "\thelper = !/usr/local/bin/glab credential-helper",
+        ]
+    )
 ```
 
 The env var is injected by the deployment template from `${PROXY_NAME}`. No code change needed when the proxy Service name changes.

--- a/docs/presets/custom-preflight.md
+++ b/docs/presets/custom-preflight.md
@@ -283,7 +283,9 @@ def fetch_data():
     try:
         proc = subprocess.run(
             [sys.executable, "path/to/fetch_script.py"],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
         if proc.returncode != 0 or not proc.stdout.strip():
             return None

--- a/docs/presets/custom-preflight.md
+++ b/docs/presets/custom-preflight.md
@@ -316,8 +316,7 @@ def main():
 
     if not has_issues:
         json.dump(
-            {"status": "skip",
-             "content": f"All {len(healthy)} items healthy. Skipping."},
+            {"status": "skip", "content": f"All {len(healthy)} items healthy. Skipping."},
             sys.stdout,
         )
         return

--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -303,11 +303,13 @@ def main():
             continue
         prs = get_task_prs(task)
         if prs:
-            review_needed.append({
-                "key": task.get("external_key", "?"),
-                "repo": task.get("repo", "?"),
-                "prs": prs,
-            })
+            review_needed.append(
+                {
+                    "key": task.get("external_key", "?"),
+                    "repo": task.get("repo", "?"),
+                    "prs": prs,
+                }
+            )
 
     if not review_needed:
         output_result("skip", f"{len(tasks)} tasks, none with PRs needing review.")

--- a/presets/shared/preflight/jira_kanban_preflight.py
+++ b/presets/shared/preflight/jira_kanban_preflight.py
@@ -275,7 +275,11 @@ def main():
                 jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
 
             is_interrupted = (
-                t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs") and not prs
+                t.get("status") == "in_progress"
+                and not t.get("pr_number")
+                and not meta.get("prs")
+                and not prs
+                and meta.get("last_step") != "investigation_posted"
             )
 
             if _has_new_jira_feedback(jira_comments, t.get("last_addressed", "")):

--- a/presets/shared/preflight/jira_sprint_preflight.py
+++ b/presets/shared/preflight/jira_sprint_preflight.py
@@ -277,7 +277,11 @@ def main():
                 jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
 
             is_interrupted = (
-                t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs") and not prs
+                t.get("status") == "in_progress"
+                and not t.get("pr_number")
+                and not meta.get("prs")
+                and not prs
+                and meta.get("last_step") != "investigation_posted"
             )
 
             if _has_new_jira_feedback(jira_comments, t.get("last_addressed", "")):


### PR DESCRIPTION
## Summary

- Investigation tasks with `last_step=investigation_posted` are intentionally parked awaiting human feedback
- Preflight was classifying them as INTERRUPTED (in_progress + no PR), triggering a full cycle every interval
- Fix excludes `investigation_posted` from the interrupted check in both kanban and sprint preflight
- Verified in container: all 3 preflight scripts now return `skip` for the LSC instance

Resolves: REHOR-57

## Test plan

- [x] Copied fix to `devbot-lightspeed-core` container
- [x] Ran `01-gh-pr-status.py` → `skip`
- [x] Ran `02-gl-mr-status.py` → `skip`
- [x] Ran `03-jira-kanban.py` → `skip` (LCORE-2685 now CLEAN, not INTERRUPTED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)