### PR TITLE
Make digest opt-in, move script to bot/, add memory_mcp module, and d…

### DIFF
--- a/bot/slack_digest.py
+++ b/bot/slack_digest.py
@@ -42,7 +42,11 @@ def cmd_digest():
         print(json.dumps({"sent": False, "reason": "Weekend — digest skipped"}))
         return
 
-    digest_hour = int(os.environ.get("SLACK_DIGEST_HOUR", "9"))
+    digest_hour_raw = os.environ.get("SLACK_DIGEST_HOUR")
+    if not digest_hour_raw:
+        return
+
+    digest_hour = int(digest_hour_raw)
     if now.hour < digest_hour:
         print(json.dumps({"sent": False, "reason": f"Before digest hour (current: {now.hour}, target: {digest_hour})"}))
         return

--- a/bot/tests/test_gh_pr_status.py
+++ b/bot/tests/test_gh_pr_status.py
@@ -3,13 +3,10 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
 sys.path.insert(0, str(SHARED_DIR))
 
 from gh_pr_status import classify_gh  # noqa: E402
-
 
 # --- classify_gh ---
 

--- a/bot/tests/test_install_skills.py
+++ b/bot/tests/test_install_skills.py
@@ -1,6 +1,5 @@
 """Tests for install_skills() — shared/workflow/env skill installation."""
 
-import shutil
 from pathlib import Path
 
 import pytest

--- a/bot/tests/test_multi_profile.py
+++ b/bot/tests/test_multi_profile.py
@@ -8,12 +8,9 @@ import sync_config_repo and assemble_claude_md via importlib with the
 heavy dependency mocked out.
 """
 
-import importlib
 import json
 import os
 import sys
-from pathlib import Path
-from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/bot/tests/test_preflight_shared.py
+++ b/bot/tests/test_preflight_shared.py
@@ -1,11 +1,8 @@
 """Tests for preflight shared modules (presets/shared/preflight/)."""
 
-import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
 sys.path.insert(0, str(SHARED_DIR))
@@ -19,7 +16,6 @@ from common import (  # noqa: E402
 from gh_pr_status import classify_gh, has_new_feedback  # noqa: E402
 from gl_mr_status import classify_gl  # noqa: E402
 from gl_mr_status import has_new_feedback as gl_has_new_feedback  # noqa: E402
-
 
 # --- upstream_repo ---
 

--- a/bot/tests/test_slack_digest_cmd.py
+++ b/bot/tests/test_slack_digest_cmd.py
@@ -80,21 +80,18 @@ class TestDigestHourCheck:
         output = json.loads(capsys.readouterr().out.strip())
         assert output["sent"] is True
 
-    def test_default_hour_is_9(self, monkeypatch, capsys):
+    def test_skips_when_digest_hour_not_set(self, monkeypatch, capsys):
+        """Opt-in: no SLACK_DIGEST_HOUR means digest is disabled."""
         monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/test")
         monkeypatch.delenv("SLACK_DIGEST_HOUR", raising=False)
         wednesday_9 = datetime(2026, 7, 15, 9, 0, tzinfo=timezone.utc)
 
-        with (
-            patch.object(slack_digest, "datetime") as mock_dt,
-            patch.object(slack_digest, "memory_call", return_value={"sent": False, "count": 0}),
-            patch.object(slack_digest, "memory_cleanup"),
-        ):
+        with patch.object(slack_digest, "datetime") as mock_dt:
             mock_dt.now.return_value = wednesday_9
             slack_digest.cmd_digest()
 
-        output = json.loads(capsys.readouterr().out.strip())
-        assert "Before digest hour" not in output.get("reason", "")
+        output = capsys.readouterr().out.strip()
+        assert output == ""
 
 
 class TestDigestNoWebhook:

--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -506,6 +506,8 @@ After deploying, verify in order:
 | `BOT_SPRINT_PREFIX` | no | Sprint name prefix filter (for sprint assignment only) |
 | `BOT_INCLUDE_BACKLOG` | no | `'true'` to include backlog tickets |
 | `SLACK_WEBHOOK_URL` | no | Slack webhook — Incoming (`/services/`, recommended) or Workflow Builder (`/triggers/`) |
+| `SLACK_NOTIFY_MODE` | no | `immediate` (default) or `daily_digest`. In digest mode, notifications queue instead of sending immediately. Requires `SLACK_DIGEST_HOUR` to be set. |
+| `SLACK_DIGEST_HOUR` | no | UTC hour (0-23) when daily digest is sent. Opt-in — digest is disabled unless this is set. |
 | `PROXY_IMAGE` | no | Proxy container image (only needed if `PROXY_REPLICAS=1`) |
 | `PROXY_IMAGE_TAG` | no | Proxy image tag (default: `latest`) |
 | `PROXY_REPLICAS` | no | `'0'` = use shared proxy (default), `'1'` = deploy own proxy |

--- a/docs/presets/envs.md
+++ b/docs/presets/envs.md
@@ -164,6 +164,12 @@ Adds the Slack notification skill. The bot sends alerts when PRs are created, ti
 
 The payload key is auto-detected from the URL: `{"text": ...}` for Incoming Webhooks, `{"msg": ...}` for Workflow Builder.
 
+**Optional env vars**:
+- `SLACK_NOTIFY_MODE` — `immediate` (default) or `daily_digest`. In immediate mode, each event sends a separate Slack message with 48h cooldown. In daily digest mode, events queue and are sent as a single summary message at the configured hour.
+- `SLACK_DIGEST_HOUR` — UTC hour (0-23) when the daily digest is sent. Opt-in: digest is disabled unless this is set. The bot runner triggers it automatically after each cycle — zero LLM tokens spent.
+
+Both `SLACK_NOTIFY_MODE=daily_digest` and `SLACK_DIGEST_HOUR` must be set to enable digest mode. Without `SLACK_DIGEST_HOUR`, notifications fall back to immediate mode.
+
 **Depends on**: nothing
 
 ---

--- a/memory-server/bot_memory_server/tools/slack.py
+++ b/memory-server/bot_memory_server/tools/slack.py
@@ -53,7 +53,7 @@ def register_slack_tools(mcp: FastMCP):
 
         notify_mode = os.environ.get("SLACK_NOTIFY_MODE", "immediate")
 
-        if notify_mode == "daily_digest":
+        if notify_mode == "daily_digest" and os.environ.get("SLACK_DIGEST_HOUR"):
             existing = await pool.fetchrow(
                 """
                 SELECT id FROM slack_digest_queue

--- a/memory-server/tests/test_slack_digest.py
+++ b/memory-server/tests/test_slack_digest.py
@@ -179,7 +179,7 @@ class TestSlackNotifyDigest:
 
         with (
             patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest"}),
+            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest", "SLACK_DIGEST_HOUR": "9"}),
         ):
             result = await slack_notify(
                 external_key="RHCLOUD-200",
@@ -212,7 +212,7 @@ class TestSlackNotifyDigest:
 
         with (
             patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest"}),
+            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest", "SLACK_DIGEST_HOUR": "9"}),
         ):
             r1 = await slack_notify(
                 external_key="RHCLOUD-300",
@@ -239,7 +239,7 @@ class TestSlackNotifyDigest:
 
         with (
             patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest"}),
+            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest", "SLACK_DIGEST_HOUR": "9"}),
         ):
             result = await slack_notify(
                 external_key="RHCLOUD-300",


### PR DESCRIPTION
…ocument configuration

### Description

Follow-up to rehor#316 addressing review feedback:

* **Queue deduplication** — `slack_notify` in digest mode checks for existing unsent `(jira_key, event_type)` before inserting, preventing duplicate entries when the bot processes the same ticket across multiple cycles
* **Opt-in digest** — digest only activates when both `SLACK_NOTIFY_MODE=daily_digest` and `SLACK_DIGEST_HOUR` are set. Without `SLACK_DIGEST_HOUR`, notifications fall back to immediate mode — no orphaned queue growth.
* **Runner-triggered digest (zero tokens)** — `bot/run.py` imports and calls `try_slack_digest()` from `bot/slack_digest.py` directly after each cycle. No subprocess, no LLM involvement.
* **Reliable hour matching** — uses `now.hour >= digest_hour` instead of exact match, with sent-today deduplication via `digest_key` in `slack_notifications` table. Digest fires even if a cycle misses the exact hour.
* **Moved to bot module** — digest script lives in `bot/slack_digest.py`, `memory_mcp.py` copied to `bot/` as proper module. No more `sys.path.insert` reaching into `.claude/skills/`. Tests import real functions directly.
* **Removed `slack-digest` skill** — digest is not a skill, it's a bot runner module. Removed SKILL.md, skill directories, manifest registration, and CLAUDE.md references.
* **Documentation** — added `SLACK_NOTIFY_MODE` and `SLACK_DIGEST_HOUR` to onboarding docs and slack preset docs with opt-in explanation.

[RHCLOUD-48014](https://redhat.atlassian.net/browse/RHCLOUD-48014)

---

### Blast radius

* **Bot runner** (`bot/run.py`) — calls `try_slack_digest()` after each cycle. No-op if `SLACK_WEBHOOK_URL` not set.
* **Bot module** — new `bot/slack_digest.py` and `bot/memory_mcp.py`
* **Memory server** — `slack_send_digest` accepts optional `digest_key` for sent-today deduplication. `slack_notify` queues only when both `SLACK_NOTIFY_MODE=daily_digest` and `SLACK_DIGEST_HOUR` are set.
* **Removed** — `.claude/skills/slack-digest/` and `presets/envs/slack/skills/slack-digest/`, `slack-digest` from slack env manifest
* No changes to immediate mode behavior

---

### Rollback plan

Git revert is sufficient. Digest queue and notifications table are unchanged structurally.

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure

Assisted by: Claude Code (Claude Opus 4.6)
