### PR TITLE
fix(preflight): exclude investigation_posted from interrupted check

### DIFF
--- a/presets/shared/preflight/jira_kanban_preflight.py
+++ b/presets/shared/preflight/jira_kanban_preflight.py
@@ -281,7 +281,11 @@ def main():
                 jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
 
             is_interrupted = (
-                t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs") and not prs
+                t.get("status") == "in_progress"
+                and not t.get("pr_number")
+                and not meta.get("prs")
+                and not prs
+                and meta.get("last_step") != "investigation_posted"
             )
 
             if _has_new_jira_feedback(jira_comments, t.get("last_addressed", "")):

--- a/presets/shared/preflight/jira_sprint_preflight.py
+++ b/presets/shared/preflight/jira_sprint_preflight.py
@@ -277,7 +277,11 @@ def main():
                 jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
 
             is_interrupted = (
-                t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs") and not prs
+                t.get("status") == "in_progress"
+                and not t.get("pr_number")
+                and not meta.get("prs")
+                and not prs
+                and meta.get("last_step") != "investigation_posted"
             )
 
             if _has_new_jira_feedback(jira_comments, t.get("last_addressed", "")):


### PR DESCRIPTION
## Summary
- Tasks with `last_step=investigation_posted` are intentionally parked awaiting human feedback
- Without this fix, preflight classifies them as INTERRUPTED and starts unnecessary Claude sessions (~11K tokens/cycle)
- Fix applied to both `jira_sprint_preflight.py` and `jira_kanban_preflight.py`

## Test plan
- [x] Verified on devbot-lightspeed-core pod (kanban) — all preflight scripts return `skip`
- [x] Verified on devbot-framework pod (sprint) — RHCLOUD-49689 no longer classified as INTERRUPTED
- [x] CI passes

Linked: REHOR-57

🤖 Generated with [Claude Code](https://claude.com/claude-code)