### PR TITLE
feat(skills): add custom workflow scaffolding skill

### DIFF
--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -236,6 +236,8 @@ The merge system (`bot/merge.py` → `apply_merged_config()`) combines persona f
 
 ## Complete Example: Review-Only Workflow
 
+> **Tip:** Use the `scaffold-custom-workflow` shared skill to generate this boilerplate automatically. The example below shows what the generated files look like.
+
 Let's build a workflow that only reviews PRs — no new Jira work, no ticket claiming.
 
 ### 1. Create the directory

--- a/presets/shared/skills/scaffold-custom-workflow/SKILL.md
+++ b/presets/shared/skills/scaffold-custom-workflow/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: scaffold-custom-workflow
+description: >
+  Generate a custom workflow directory with manifest.yaml, CLAUDE.md, and preflight script skeleton.
+when_to_use: >
+  When setting up a new custom workflow for a bot instance. Triggers: "scaffold workflow",
+  "create custom workflow", "generate workflow", "new workflow".
+user-invocable: true
+allowed-tools:
+  - "Bash(python3 .claude/skills/scaffold-custom-workflow/scaffold_custom_workflow.py *)"
+  - Read
+  - Bash
+---
+
+## Usage
+
+```bash
+python3 .claude/skills/scaffold-custom-workflow/scaffold_custom_workflow.py \
+  --name <workflow-name> \
+  --description "<one-line description>" \
+  --trigger <jira|scheduled> \
+  --output-dir <instance-agent-dir> \
+  [--mcp-servers bot-memory,mcp-atlassian] \
+  [--env-vars BOT_LABEL,SLACK_WEBHOOK_URL] \
+  [--shared-skills push-and-pr,post-pr] \
+  [--dry-run] 2>&1
+```
+
+## What it generates
+
+```
+workflows/<name>/
+  manifest.yaml           # Workflow metadata and requirements
+  CLAUDE.md               # Decision loop stub for the bot
+  preflight/
+    01-check.py           # Skeleton preflight script
+```
+
+## Arguments
+
+| Arg | Required | Description |
+|-----|----------|-------------|
+| `--name` | Yes | Workflow name (kebab-case) |
+| `--description` | Yes | One-line description |
+| `--trigger` | Yes | `jira` or `scheduled` — determines preflight template |
+| `--output-dir` | Yes | Instance agent directory (creates `workflows/<name>/` under it) |
+| `--mcp-servers` | No | Comma-separated MCP server names for manifest |
+| `--env-vars` | No | Comma-separated env var names for manifest |
+| `--shared-skills` | No | Comma-separated shared skill names for manifest |
+| `--dry-run` | No | Show what would be created without writing |
+
+## Trigger modes
+
+- **`jira`** — Preflight imports `common.py` utilities, checks tasks and capacity,
+  gates on Jira ticket availability. CLAUDE.md includes Jira task lifecycle.
+- **`scheduled`** — Preflight is standalone with fetch/classify/skip pattern, includes
+  throttle example. CLAUDE.md includes sleep signal and schedule-based loop.
+
+## Error handling
+
+- Refuses to overwrite an existing workflow directory
+- Validates workflow name is kebab-case (lowercase, digits, hyphens)
+- Exits with code 1 on any validation error

--- a/presets/shared/skills/scaffold-custom-workflow/scaffold_custom_workflow.py
+++ b/presets/shared/skills/scaffold-custom-workflow/scaffold_custom_workflow.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Scaffold a custom workflow directory with manifest, CLAUDE.md, and preflight skeleton."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+KEBAB_RE = re.compile(r"^[a-z][a-z0-9]+(-[a-z0-9]+)*$")
+
+
+def validate_name(name: str) -> str:
+    if not KEBAB_RE.match(name):
+        raise argparse.ArgumentTypeError(
+            f"'{name}' is not valid kebab-case (lowercase letters, digits, hyphens; "
+            f"must start with a letter, no leading/trailing/double hyphens)"
+        )
+    return name
+
+
+def parse_csv(value: str) -> list[str]:
+    if not value:
+        return []
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description="Scaffold a custom workflow directory.")
+    p.add_argument("--name", required=True, type=validate_name, help="Workflow name (kebab-case)")
+    p.add_argument("--description", required=True, help="One-line workflow description")
+    p.add_argument("--trigger", required=True, choices=["jira", "scheduled"], help="Trigger type")
+    p.add_argument("--output-dir", required=True, help="Instance agent directory")
+    p.add_argument("--mcp-servers", default="", help="Comma-separated MCP servers")
+    p.add_argument("--env-vars", default="", help="Comma-separated env vars")
+    p.add_argument("--shared-skills", default="", help="Comma-separated shared skill names")
+    p.add_argument("--dry-run", action="store_true", help="Show plan without writing files")
+    return p.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+
+def render_manifest(cfg: dict) -> str:
+    lines = [
+        f"name: {cfg['name']}",
+        "type: workflow",
+        f"description: {cfg['description']}",
+        "",
+        "preflight:",
+        "  - 01-check.py",
+    ]
+
+    shared = cfg.get("shared_skills", [])
+    if shared:
+        lines.append("")
+        lines.append("shared_skills:")
+        for s in shared:
+            lines.append(f"  - {s}")
+
+    lines.append("")
+    lines.append("provides:")
+    lines.append("  claude_md: CLAUDE.md")
+
+    mcp = cfg.get("mcp_servers", [])
+    env = cfg.get("env_vars", [])
+    if mcp or env:
+        lines.append("")
+        lines.append("requires:")
+        if mcp:
+            lines.append("  mcp_servers:")
+            for m in mcp:
+                lines.append(f"    - {m}")
+        if env:
+            lines.append("  env_vars:")
+            for e in env:
+                lines.append(f"    - {e}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_claude_md_jira(cfg: dict) -> str:
+    name = cfg["name"]
+    description = cfg["description"]
+    return f"""\
+# {name.replace("-", " ").title()} Workflow
+
+{description}
+
+## Decision Loop
+
+Each cycle, the preflight script pre-fetches data at zero token cost.
+You only run when there is actionable work.
+
+### Step 1 — Read preflight data
+
+The preflight script already checked Jira and task state. The data is in
+your prompt as JSON. Do NOT re-query Jira for this information.
+
+### Step 2 — Evaluate the work item
+
+Read the preflight content. Decide whether to act or skip.
+
+### Step 3 — Take action
+
+Implement the required change. Use the tools available to you.
+
+### Step 4 — Update task tracking
+
+Use MCP task tools (`task_add`, `task_update`, `task_get`) to track progress.
+Always pass `source_type="jira"` for Jira-driven workflows.
+
+Never call the memory server HTTP API directly — use the MCP tools, which
+enforce capacity caps, publish events, and build artifact links.
+
+### Step 5 — Report results
+
+Post a Jira comment summarizing what was done. If a PR was created, use
+the `/post-pr` skill to handle labels, transitions, and notifications.
+
+## Rules
+
+- ONE task per cycle — finish or pause before picking the next
+- Read preflight data first — it was fetched at zero token cost
+- Track work via MCP task tools, not raw HTTP
+- Be idempotent — safe to re-run if a cycle is interrupted
+"""
+
+
+def render_claude_md_scheduled(cfg: dict) -> str:
+    name = cfg["name"]
+    description = cfg["description"]
+    return f"""\
+# {name.replace("-", " ").title()} Workflow
+
+{description}
+
+## Decision Loop
+
+Each cycle, the preflight script pre-fetches data at zero token cost.
+You only run when there is actionable work — if everything is healthy,
+the preflight returns `skip` and no AI session starts (zero tokens).
+
+### Step 1 — Read pre-fetched data
+
+The preflight script already fetched, filtered, and classified the data.
+It is in your prompt as JSON. Do NOT re-fetch this data.
+
+### Step 2 — Classify and prioritize
+
+Review the items in the preflight data. Determine which need action.
+
+### Step 3 — Take action
+
+Process actionable items. Use the tools available to you.
+
+### Step 4 — Update task tracking
+
+Use MCP task tools (`task_add`, `task_update`, `task_get`, `task_remove`)
+to track work items. Always pass `source_type="scheduled"` for scheduled
+workflows — the default is `"jira"` which will break task lookups.
+
+Never call the memory server HTTP API directly — use the MCP tools.
+
+### Step 5 — Signal sleep and end cycle
+
+Write the sleep signal so the runner waits before the next cycle:
+
+```bash
+mkdir -p data && echo '{{"recommended_sleep": 3600, "reason": "{name} hourly cycle"}}' > data/cycle-sleep.json
+```
+
+Do NOT loop back — one pass per cycle.
+
+## Rules
+
+- One pass per cycle — do not loop
+- Read preflight data first — it was fetched at zero token cost
+- Track work via MCP task tools, not raw HTTP
+- Pass `source_type="scheduled"` in all task calls
+- If the preflight already handled reporting (zero-token compact message),
+  you should NOT duplicate that report
+"""
+
+
+def render_preflight_jira(cfg: dict) -> str:
+    name = cfg["name"]
+    return f'''\
+#!/usr/bin/env python3
+"""Pre-flight: check for actionable work in Jira.
+
+Runs before each AI session. Returns JSON to stdout:
+  {{"status": "start", "content": "..."}}  — actionable work found, start session
+  {{"status": "skip",  "content": "..."}}  — nothing to do, skip session (zero tokens)
+
+Token-saving pattern:
+  This script runs at ZERO token cost. Do all data fetching here so the
+  AI session only starts when there is a decision to make. Pre-fetch and
+  include all relevant data in the "content" field — the AI reads it from
+  its prompt instead of making its own API calls.
+"""
+
+import json
+import sys
+
+# These imports resolve at runtime when PYTHONPATH includes presets/shared/preflight/
+from common import get_capacity, get_tasks, output_result
+
+TASK_KEY_PREFIX = "{name}:"
+
+
+def main():
+    tasks = get_tasks()
+    active = [t for t in tasks if t.get("status") in ("in_progress", "pr_open", "pr_changes")]
+
+    # Already working on something for this workflow?
+    my_tasks = [t for t in active if t.get("external_key", "").startswith(TASK_KEY_PREFIX)]
+    if my_tasks:
+        output_result("skip", f"Already in progress: {{my_tasks[0][\'external_key\']}}")
+        return
+
+    # Respect capacity — don\'t overload the bot
+    active_n, max_n = get_capacity()
+    if active_n >= max_n:
+        output_result("skip", f"At capacity ({{active_n}}/{{max_n}})")
+        return
+
+    # TODO: Add your data-fetching logic here
+    # Example: query Jira for tickets matching your workflow\'s criteria,
+    # check an external API, scan a repo for issues, etc.
+    #
+    # Key principle: fetch ALL data the AI will need and include it in
+    # the "content" field. This avoids the AI making its own API calls
+    # during the session, saving tokens.
+    actionable_items = []  # Replace with your logic
+
+    if not actionable_items:
+        output_result("skip", f"No actionable items found ({{len(tasks)}} tasks checked)")
+        return
+
+    content = f"{{len(actionable_items)}} items need attention:\\n"
+    content += json.dumps(actionable_items, indent=2)
+    output_result("start", content)
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def render_preflight_scheduled(cfg: dict) -> str:
+    name = cfg["name"]
+    return f'''\
+#!/usr/bin/env python3
+"""Pre-flight: check external service for actionable items.
+
+Runs before each AI session. Returns JSON to stdout:
+  {{"status": "start", "content": "..."}}  — actionable work found, start session
+  {{"status": "skip",  "content": "..."}}  — nothing to do, skip session (zero tokens)
+
+Token-saving pattern:
+  This script runs at ZERO token cost. Do all data fetching, filtering,
+  and classification here. The AI session only starts when there is a
+  NEW decision to make (not just a status update).
+
+  Include pre-fetched data in the "content" field so the AI reads it from
+  its prompt instead of making its own API calls.
+
+Throttle pattern:
+  For expensive checks, use a state file to throttle how often this runs.
+  Example: check every 8 hours instead of every cycle.
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+THROTTLE_HOURS = 1
+STATE_FILE = Path(os.environ.get("BOT_DATA_DIR", "data")) / "{name}-last-run.json"
+
+
+def is_throttled():
+    """Skip if last run was too recent."""
+    if not STATE_FILE.exists():
+        return False
+    try:
+        state = json.loads(STATE_FILE.read_text())
+        last_run = state.get("last_run", 0)
+        return (time.time() - last_run) < (THROTTLE_HOURS * 3600)
+    except (json.JSONDecodeError, OSError):
+        return False
+
+
+def save_run_time():
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps({{"last_run": time.time()}}))
+
+
+def fetch_data():
+    """Fetch data from your external service.
+
+    Replace this with your actual data source — API call, CLI command,
+    file read, database query, etc.
+
+    Returns parsed data or None on error.
+    """
+    # TODO: implement your data fetching
+    # Example patterns:
+    #   subprocess.run(["curl", ...], capture_output=True)
+    #   urllib.request.urlopen(url)
+    #   subprocess.run(["gh", "api", ...], capture_output=True)
+    return None
+
+
+def classify(data):
+    """Classify fetched data into actionable vs ignorable.
+
+    Do deterministic filtering here (no AI needed). Only items that
+    require AI judgment should cause a "start" result.
+
+    Returns (actionable_items, summary_stats).
+    """
+    # TODO: implement your classification logic
+    actionable = []
+    stats = {{"total": 0, "actionable": 0, "healthy": 0}}
+    return actionable, stats
+
+
+def main():
+    if is_throttled():
+        msg = f"{name} check throttled (last run < {{THROTTLE_HOURS}}h ago)"
+        print(json.dumps({{"status": "skip", "content": msg}}))
+        return
+
+    data = fetch_data()
+    save_run_time()
+
+    if data is None:
+        print(json.dumps({{"status": "skip", "content": "Could not fetch data from service"}}))
+        return
+
+    actionable, stats = classify(data)
+
+    if not actionable:
+        print(json.dumps({{
+            "status": "skip",
+            "content": f"All healthy — {{stats[\'total\']}} items checked, none actionable",
+        }}))
+        return
+
+    # Build content with ALL data the AI will need
+    header = f"{{len(actionable)}} items need attention ({{stats[\'total\']}} total checked)\\n"
+    output = {{
+        "actionable": actionable,
+        "stats": stats,
+    }}
+
+    print(json.dumps({{
+        "status": "start",
+        "content": header + json.dumps(output, indent=2),
+    }}))
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+# ---------------------------------------------------------------------------
+# File writing
+# ---------------------------------------------------------------------------
+
+
+def scaffold(cfg: dict, dry_run: bool = False) -> list[dict]:
+    """Generate workflow files. Returns list of {path, status, content} dicts."""
+    output_dir = Path(cfg["output_dir"])
+    workflow_dir = output_dir / "workflows" / cfg["name"]
+
+    if workflow_dir.exists() and not dry_run:
+        print(f"[FAIL] Directory already exists: {workflow_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if cfg["trigger"] == "jira":
+        claude_md = render_claude_md_jira(cfg)
+        preflight = render_preflight_jira(cfg)
+    else:
+        claude_md = render_claude_md_scheduled(cfg)
+        preflight = render_preflight_scheduled(cfg)
+
+    manifest = render_manifest(cfg)
+
+    files = [
+        {"path": workflow_dir / "manifest.yaml", "content": manifest},
+        {"path": workflow_dir / "CLAUDE.md", "content": claude_md},
+        {"path": workflow_dir / "preflight" / "01-check.py", "content": preflight},
+    ]
+
+    results = []
+    for f in files:
+        rel = f["path"].relative_to(output_dir)
+        if dry_run:
+            results.append({"path": str(rel), "status": "dry-run", "content": f["content"]})
+            print(f"[DRY-RUN] {rel}")
+        else:
+            f["path"].parent.mkdir(parents=True, exist_ok=True)
+            f["path"].write_text(f["content"])
+            results.append({"path": str(rel), "status": "ok", "content": f["content"]})
+            print(f"[OK] {rel}")
+
+    return results
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    cfg = {
+        "name": args.name,
+        "description": args.description,
+        "trigger": args.trigger,
+        "output_dir": args.output_dir,
+        "mcp_servers": parse_csv(args.mcp_servers),
+        "env_vars": parse_csv(args.env_vars),
+        "shared_skills": parse_csv(args.shared_skills),
+    }
+    scaffold(cfg, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/presets/shared/skills/scaffold-custom-workflow/tests/test_scaffold.py
+++ b/presets/shared/skills/scaffold-custom-workflow/tests/test_scaffold.py
@@ -1,0 +1,245 @@
+"""Tests for scaffold_custom_workflow."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SKILL_DIR))
+
+from scaffold_custom_workflow import (  # noqa: E402
+    parse_csv,
+    render_claude_md_jira,
+    render_claude_md_scheduled,
+    render_manifest,
+    render_preflight_jira,
+    render_preflight_scheduled,
+    scaffold,
+    validate_name,
+)
+
+BASE_CFG = {
+    "name": "my-workflow",
+    "description": "A test workflow",
+    "trigger": "jira",
+    "output_dir": "",  # set per test via tmp_path
+    "mcp_servers": [],
+    "env_vars": [],
+    "shared_skills": [],
+}
+
+
+def cfg_with(tmp_path, **overrides):
+    c = {**BASE_CFG, "output_dir": str(tmp_path), **overrides}
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_valid_kebab_names(self):
+        for name in ["watchduty", "my-workflow", "pr-review2", "ab12-cd"]:
+            assert validate_name(name) == name
+
+    def test_rejects_uppercase(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            validate_name("MyWorkflow")
+
+    def test_rejects_underscores(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            validate_name("my_workflow")
+
+    def test_rejects_leading_digit(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            validate_name("1workflow")
+
+    def test_rejects_trailing_hyphen(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            validate_name("my-workflow-")
+
+    def test_rejects_double_hyphen(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            validate_name("my--workflow")
+
+    def test_rejects_single_char(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            validate_name("a")
+
+    def test_parse_csv_empty(self):
+        assert parse_csv("") == []
+
+    def test_parse_csv_values(self):
+        assert parse_csv("a, b, c") == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    def test_basic_manifest(self):
+        text = render_manifest(BASE_CFG)
+        data = yaml.safe_load(text)
+        assert data["name"] == "my-workflow"
+        assert data["type"] == "workflow"
+        assert data["description"] == "A test workflow"
+        assert data["preflight"] == ["01-check.py"]
+        assert data["provides"]["claude_md"] == "CLAUDE.md"
+
+    def test_manifest_with_mcp_and_env(self):
+        cfg = {**BASE_CFG, "mcp_servers": ["bot-memory", "mcp-atlassian"], "env_vars": ["BOT_LABEL"]}
+        data = yaml.safe_load(render_manifest(cfg))
+        assert data["requires"]["mcp_servers"] == ["bot-memory", "mcp-atlassian"]
+        assert data["requires"]["env_vars"] == ["BOT_LABEL"]
+
+    def test_manifest_with_shared_skills(self):
+        cfg = {**BASE_CFG, "shared_skills": ["push-and-pr", "post-pr"]}
+        data = yaml.safe_load(render_manifest(cfg))
+        assert data["shared_skills"] == ["push-and-pr", "post-pr"]
+
+    def test_manifest_no_requires_when_empty(self):
+        data = yaml.safe_load(render_manifest(BASE_CFG))
+        assert "requires" not in data
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeMd:
+    def test_jira_mentions_jira(self):
+        md = render_claude_md_jira(BASE_CFG)
+        assert 'source_type="jira"' in md
+        assert "Jira" in md
+        assert "cycle-sleep.json" not in md
+
+    def test_scheduled_mentions_sleep(self):
+        md = render_claude_md_scheduled(BASE_CFG)
+        assert "cycle-sleep.json" in md
+        assert 'source_type="scheduled"' in md
+
+    def test_title_uses_workflow_name(self):
+        cfg = {**BASE_CFG, "name": "pr-review"}
+        md = render_claude_md_jira(cfg)
+        assert "# Pr Review Workflow" in md
+
+    def test_description_appears(self):
+        md = render_claude_md_jira(BASE_CFG)
+        assert "A test workflow" in md
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+class TestPreflight:
+    def test_jira_imports_common(self):
+        py = render_preflight_jira(BASE_CFG)
+        assert "from common import" in py
+        assert "get_tasks" in py
+        assert "get_capacity" in py
+        assert "output_result" in py
+
+    def test_jira_uses_task_prefix(self):
+        cfg = {**BASE_CFG, "name": "code-scan"}
+        py = render_preflight_jira(cfg)
+        assert 'TASK_KEY_PREFIX = "code-scan:"' in py
+
+    def test_scheduled_is_standalone(self):
+        py = render_preflight_scheduled(BASE_CFG)
+        assert "from common import" not in py
+        assert "THROTTLE_HOURS" in py
+        assert "is_throttled" in py
+
+    def test_scheduled_uses_state_file(self):
+        cfg = {**BASE_CFG, "name": "health-check"}
+        py = render_preflight_scheduled(cfg)
+        assert "health-check-last-run.json" in py
+
+    def test_output_contract_jira(self):
+        py = render_preflight_jira(BASE_CFG)
+        assert '"status": "start"' in py or "output_result" in py
+
+    def test_output_contract_scheduled(self):
+        py = render_preflight_scheduled(BASE_CFG)
+        assert '"status": "start"' in py
+        assert '"status": "skip"' in py
+
+
+# ---------------------------------------------------------------------------
+# Scaffold (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestScaffold:
+    def test_creates_all_files(self, tmp_path):
+        cfg = cfg_with(tmp_path, trigger="jira")
+        results = scaffold(cfg)
+        assert len(results) == 3
+        assert all(r["status"] == "ok" for r in results)
+
+        wf = tmp_path / "workflows" / "my-workflow"
+        assert (wf / "manifest.yaml").exists()
+        assert (wf / "CLAUDE.md").exists()
+        assert (wf / "preflight" / "01-check.py").exists()
+
+    def test_scheduled_creates_all_files(self, tmp_path):
+        cfg = cfg_with(tmp_path, trigger="scheduled")
+        scaffold(cfg)
+        wf = tmp_path / "workflows" / "my-workflow"
+        assert (wf / "manifest.yaml").exists()
+        assert (wf / "CLAUDE.md").exists()
+        assert (wf / "preflight" / "01-check.py").exists()
+
+        preflight = (wf / "preflight" / "01-check.py").read_text()
+        assert "THROTTLE_HOURS" in preflight
+
+    def test_refuses_existing_directory(self, tmp_path):
+        cfg = cfg_with(tmp_path)
+        scaffold(cfg)
+        with pytest.raises(SystemExit):
+            scaffold(cfg)
+
+    def test_dry_run_creates_no_files(self, tmp_path):
+        cfg = cfg_with(tmp_path)
+        results = scaffold(cfg, dry_run=True)
+        assert all(r["status"] == "dry-run" for r in results)
+        wf = tmp_path / "workflows" / "my-workflow"
+        assert not wf.exists()
+
+    def test_dry_run_returns_content(self, tmp_path):
+        cfg = cfg_with(tmp_path)
+        results = scaffold(cfg, dry_run=True)
+        for r in results:
+            assert len(r["content"]) > 0
+
+    def test_manifest_is_valid_yaml(self, tmp_path):
+        cfg = cfg_with(
+            tmp_path,
+            mcp_servers=["bot-memory"],
+            env_vars=["BOT_LABEL"],
+            shared_skills=["push-and-pr"],
+        )
+        scaffold(cfg)
+        manifest_path = tmp_path / "workflows" / "my-workflow" / "manifest.yaml"
+        data = yaml.safe_load(manifest_path.read_text())
+        assert data["name"] == "my-workflow"
+        assert data["requires"]["mcp_servers"] == ["bot-memory"]
+
+    def test_preflight_is_valid_python(self, tmp_path):
+        for trigger in ("jira", "scheduled"):
+            out = tmp_path / trigger
+            cfg = cfg_with(out, trigger=trigger)
+            scaffold(cfg)
+            preflight_path = out / "workflows" / "my-workflow" / "preflight" / "01-check.py"
+            code = preflight_path.read_text()
+            compile(code, str(preflight_path), "exec")


### PR DESCRIPTION
### Description

  Add a new shared skill scaffold-custom-workflow that generates a custom workflow directory structure from CLI args. Teams onboarding to Rehor often need custom workflows (monitoring, scheduled tasks, domain-specific automation) — today that means manually assembling manifest.yaml, CLAUDE.md, and preflight scripts from docs and examples. This skill automates the scaffolding with correct output contracts and token-saving patterns baked in.

####   What it generates:
  - workflows/<name>/manifest.yaml — workflow metadata and requirements
  - workflows/<name>/CLAUDE.md — decision loop stub (jira vs scheduled variants)
  - workflows/<name>/preflight/01-check.py — skeleton preflight with output contract and token-saving patterns

  Two trigger modes: jira (preflight imports shared common.py, checks tasks/capacity) and scheduled (standalone preflight with fetch/classify/skip and throttle pattern).

  Also adds a tip in docs/presets/custom-workflows.md pointing to the skill as the preferred bootstrapping path.

  REHOR-59 (https://issues.redhat.com/browse/REHOR-59)

  ---
###   Blast radius
  
  No existing consumers affected. This is a new skill added to presets/shared/skills/ — it doesn't modify any existing skills, workflows, or preflight scripts. The only change to an existing file is a 2-line doc tip in docs/presets/custom-workflows.md.

  Will be consumed by a future onboarding persona in the instance config repo (not part of this PR).

  ---
###   Rollback plan
  
  git revert is sufficient. The skill is additive — no existing behavior depends on it.

  ---
###   Checklist
  
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest
  
###   AI disclosure

  Assisted by: Claude Code
