### PR TITLE
fix(preflight): upstream_repo fallback for bare repo names

### DIFF
--- a/presets/shared/preflight/common.py
+++ b/presets/shared/preflight/common.py
@@ -103,6 +103,12 @@ def upstream_repo(repo_name):
         return repo_name, host
     repos = load_project_repos()
     entry = repos.get(repo_name, {})
+    if not entry:
+        suffix = f"/{repo_name}"
+        for key, cfg in repos.items():
+            if key.endswith(suffix):
+                entry = cfg
+                break
     up = entry.get("upstream", "")
     if not up:
         return "", entry.get("host", "github")


### PR DESCRIPTION
## Summary
- `upstream_repo()` now falls back to suffix-matching when bare repo name (e.g. `lightspeed-stack`) doesn't match project-repos.json keys with org prefix (`lightspeed-core/lightspeed-stack`)
- Without this fix, `enrich_gh()` skips PRs entirely, resulting in "no GH PRs to check" even when PR metadata exists on the task
- Already hotfixed on devbot-lightspeed-core pod

## Test plan
- [x] Verified fix on devbot-lightspeed-core pod via `oc cp`
- [ ] Confirm preflight picks up PR comments for repos stored without org prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)