### PR TITLE
fix(browser): persist env vars and move Chromium startup to env preset

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -177,6 +177,10 @@ if [ -n "${BOT_MEMORY_HEALTH_URL:-}" ]; then
     wait_for_http "memory-server" "$BOT_MEMORY_HEALTH_URL" "${BOT_MEMORY_HEALTH_TIMEOUT:-120}"
 fi
 
+
+# Source env preset profile scripts (persist env vars from install time)
+for pf in /etc/profile.d/*.sh; do [ -f "$pf" ] && . "$pf"; done
+
 # Run env preset entrypoint scripts — only for installed envs
 INSTALLED_ENVS=""
 for cfg in instance/*/agent/instance.yaml; do

--- a/presets/envs/browser/install.sh
+++ b/presets/envs/browser/install.sh
@@ -21,3 +21,10 @@ npx playwright install chromium
 
 # chrome-devtools MCP server
 npm install -g chrome-devtools-mcp@latest
+
+# Persist env vars for runtime (NVM bin isn't in default PATH; Playwright path needed for Chromium)
+NPM_GLOBAL_BIN="$(npm bin -g 2>/dev/null || dirname "$(which node)")"
+cat > /etc/profile.d/browser-env.sh << PROFILE
+export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+export PATH="${NPM_GLOBAL_BIN}:\$PATH"
+PROFILE

--- a/presets/envs/browser/install.sh
+++ b/presets/envs/browser/install.sh
@@ -22,9 +22,9 @@ npx playwright install chromium
 # chrome-devtools MCP server
 npm install -g chrome-devtools-mcp@latest
 
-# Persist env vars for runtime (NVM bin isn't in default PATH; Playwright path needed for Chromium)
-NPM_GLOBAL_BIN="$(npm bin -g 2>/dev/null || dirname "$(which node)")"
+# Persist env vars for runtime (Playwright path needed to find Chromium)
+NODE_BIN_DIR="$(dirname "$(which node)")"
 cat > /etc/profile.d/browser-env.sh << PROFILE
 export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-export PATH="${NPM_GLOBAL_BIN}:\$PATH"
+export PATH="${NODE_BIN_DIR}:\$PATH"
 PROFILE


### PR DESCRIPTION
## Summary
- `PLAYWRIGHT_BROWSERS_PATH` and NVM global bin `PATH` persisted via `/etc/profile.d/browser-env.sh` — set at install time, sourced at container startup
- Removed inline Chromium startup from `entrypoint.sh` — this belongs in `presets/envs/browser/entrypoint.d/10-chromium.sh`
- Entrypoint now sources `/etc/profile.d/*.sh` before running env preset entrypoint scripts
- Fixes `chrome-devtools-mcp` not in PATH and Chromium binary not found at runtime

## Test plan
- [x] Build image with browser env, verify `chrome-devtools-mcp` in PATH
- [x] Verify `PLAYWRIGHT_BROWSERS_PATH` set after sourcing profile.d
- [x] Verify Chromium starts via 10-chromium.sh entrypoint script
- [x] Verify non-browser instances still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)