### PR TITLE
fix(go): goenv profile script crashes container under set -e

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -179,7 +179,9 @@ fi
 
 
 # Source env preset profile scripts (persist env vars from install time)
-for pf in /etc/profile.d/*.sh; do [ -f "$pf" ] && . "$pf"; done
+# || true: profile scripts may return non-zero (e.g. goenv warnings) which
+# must not be fatal under set -e
+for pf in /etc/profile.d/*.sh; do [ -f "$pf" ] && . "$pf" || true; done
 
 # Run env preset entrypoint scripts — only for installed envs
 INSTALLED_ENVS=""

--- a/presets/envs/go/install.sh
+++ b/presets/envs/go/install.sh
@@ -32,6 +32,7 @@ goenv global "${DEFAULT}"
 # Add goenv init to profile so interactive shells get goenv
 cat > /etc/profile.d/goenv.sh << 'PROFILE'
 export GOENV_ROOT="/usr/local/goenv"
+export GOENV_PATH_ORDER=front
 export PATH="$GOENV_ROOT/bin:$PATH"
 eval "$(goenv init -)"
 PROFILE


### PR DESCRIPTION
## Summary

- All bot instances with the `go` env preset are in CrashLoopBackOff
- Root cause: `goenv init` in `/etc/profile.d/goenv.sh` returns non-zero when it detects system Go ahead of its shims — under `set -e` in `entrypoint.sh`, this kills the container silently
- Logs end at `goenv: WARNING: System 'go' found at /usr/local/bin/go` with no further output

## Changes

- **`entrypoint.sh`**: Add `|| true` to profile sourcing loop so non-zero exits from profile scripts are non-fatal
- **`presets/envs/go/install.sh`**: Set `GOENV_PATH_ORDER=front` in the generated profile script so goenv shims take priority over system Go, eliminating the warning

## Test plan

- [x] Reproduced crash locally: `set -e; for pf in /etc/profile.d/*.sh; do . "$pf"; done` — shell exits
- [x] Verified fix: `set -e; for pf in /etc/profile.d/*.sh; do . "$pf" || true; done; echo "survived"` — prints "survived"
- [x] Confirmed `GOENV_PATH_ORDER=front` eliminates goenv warning entirely
- [ ] Deploy and verify instances recover from CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)