### PR TITLE
feat(proxy): allow GlitchTip through Squid allowlist

### DIFF
--- a/proxy/squid.conf
+++ b/proxy/squid.conf
@@ -32,6 +32,9 @@ acl allowed_domains dstdomain proxy.golang.org
 acl allowed_domains dstdomain sum.golang.org
 acl allowed_domains dstdomain storage.googleapis.com
 
+# GlitchTip (error tracking)
+acl allowed_domains dstdomain glitchtip.devshift.net
+
 # Red Hat registries (UBI base image layers, if needed at runtime)
 acl allowed_domains dstdomain .redhat.com
 acl allowed_domains dstdomain .fedoraproject.org


### PR DESCRIPTION
## Description

Add glitchtip.devshift.net to the Squid proxy allowed domains so the
bot container can reach the GlitchTip error-tracking service.

Without this entry, outbound HTTPS requests to GlitchTip are rejected
with HTTP 403 by the proxy.

## Changes

- proxy/squid.conf — added glitchtip.devshift.net to the allowed_domains ACL

## Testing

After deploying, from inside the bot container run a request to
glitchtip.devshift.net — it should no longer return 403 from the proxy.