### PR TITLE
feat(executor): add GlitchTip auth reverse proxy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -45,6 +45,7 @@ objects:
 #      jira-token            — Jira API token (unless JIRA_SECRET_NAME overrides)
 #      upload-memory-password — (temporary) shared secret for bulk memory upload
 #      konflux-read-token    — (optional) KubeArchive SA token for Konflux build logs
+#      glitchtip-token       — GlitchTip API token for error tracking
 # 3. (Optional) Separate Jira secret (JIRA_SECRET_NAME) with keys:
 #      jira-email            — Jira username/email for this instance
 #      jira-token            — Jira API token for this instance
@@ -246,6 +247,9 @@ objects:
           - containerPort: 8446
             name: screenshot
             protocol: TCP
+          - containerPort: 8447
+            name: glitchtip
+            protocol: TCP
           - containerPort: 9091
             name: metrics
             protocol: TCP
@@ -300,6 +304,13 @@ objects:
               secretKeyRef:
                 name: ${JIRA_SECRET_NAME}
                 key: jira-token
+          - name: GLITCHTIP_URL
+            value: https://glitchtip.devshift.net
+          - name: GLITCHTIP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: glitchtip-token
           livenessProbe:
             tcpSocket:
               port: 3128
@@ -351,6 +362,10 @@ objects:
       targetPort: screenshot
       protocol: TCP
       name: screenshot
+    - port: 8447
+      targetPort: glitchtip
+      protocol: TCP
+      name: glitchtip
     - port: 9091
       targetPort: metrics
       protocol: TCP
@@ -384,6 +399,8 @@ objects:
       - port: 8444
         protocol: TCP
       - port: 8446
+        protocol: TCP
+      - port: 8447
         protocol: TCP
     - from:
       - namespaceSelector:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -45,6 +45,7 @@ objects:
 #      jira-token            — Jira API token (unless JIRA_SECRET_NAME overrides)
 #      upload-memory-password — (temporary) shared secret for bulk memory upload
 #      konflux-read-token    — (optional) KubeArchive SA token for Konflux build logs
+#      glitchtip-url         — GlitchTip instance URL (e.g. https://glitchtip.devshift.net)
 #      glitchtip-token       — GlitchTip API token for error tracking
 # 3. (Optional) Separate Jira secret (JIRA_SECRET_NAME) with keys:
 #      jira-email            — Jira username/email for this instance
@@ -305,7 +306,10 @@ objects:
                 name: ${JIRA_SECRET_NAME}
                 key: jira-token
           - name: GLITCHTIP_URL
-            value: https://glitchtip.devshift.net
+            valueFrom:
+              secretKeyRef:
+                name: devbot-secrets
+                key: glitchtip-url
           - name: GLITCHTIP_TOKEN
             valueFrom:
               secretKeyRef:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       - JIRA_URL=${JIRA_URL:-https://redhat.atlassian.net}
       - JIRA_USERNAME
       - JIRA_API_TOKEN
+      - GLITCHTIP_URL=${GLITCHTIP_URL:-https://glitchtip.devshift.net}
+      - GLITCHTIP_TOKEN
     volumes:
       - executor-sock:/var/run/devbot
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - JIRA_URL=${JIRA_URL:-https://redhat.atlassian.net}
       - JIRA_USERNAME
       - JIRA_API_TOKEN
-      - GLITCHTIP_URL=${GLITCHTIP_URL:-https://glitchtip.devshift.net}
+      - GLITCHTIP_URL
       - GLITCHTIP_TOKEN
     volumes:
       - executor-sock:/var/run/devbot

--- a/proxy/executor/cmd/server/main.go
+++ b/proxy/executor/cmd/server/main.go
@@ -39,6 +39,10 @@ var (
 
 	screenshotListen = flag.String("screenshot-listen", ":8446", "screenshot upload proxy listen address")
 
+	glitchtipListen = flag.String("glitchtip-listen", ":8447", "glitchtip auth proxy listen address")
+	glitchtipURL    = flag.String("glitchtip-url", "", "upstream GlitchTip URL")
+	glitchtipToken  = flag.String("glitchtip-token", "", "GlitchTip API token")
+
 	metricsListen = flag.String("metrics-listen", ":9091", "address for Prometheus /metrics endpoint (env: METRICS_LISTEN)")
 )
 
@@ -230,6 +234,15 @@ func main() {
 	if v := os.Getenv("SCREENSHOT_LISTEN"); v != "" {
 		*screenshotListen = v
 	}
+	if v := os.Getenv("GLITCHTIP_LISTEN"); v != "" {
+		*glitchtipListen = v
+	}
+	if v := os.Getenv("GLITCHTIP_URL"); v != "" {
+		*glitchtipURL = v
+	}
+	if v := os.Getenv("GLITCHTIP_TOKEN"); v != "" {
+		*glitchtipToken = v
+	}
 	if v := os.Getenv("METRICS_LISTEN"); v != "" {
 		*metricsListen = v
 	}
@@ -307,6 +320,21 @@ func main() {
 		}()
 	}
 
+	var glitchtipSrv *http.Server
+	if *glitchtipURL != "" {
+		if err := executor.ValidateGlitchTipConfig(*glitchtipURL, *glitchtipToken); err != nil {
+			log.Fatalf("glitchtip config: %v", err)
+		}
+		handler := executor.InstrumentHTTPHandler("glitchtip", executor.NewGlitchTipProxy(*glitchtipURL, *glitchtipToken))
+		glitchtipSrv = &http.Server{Addr: *glitchtipListen, Handler: handler}
+		go func() {
+			log.Printf("glitchtip-auth-proxy listening on %s (upstream=%s)", *glitchtipListen, *glitchtipURL)
+			if err := glitchtipSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("glitchtip proxy: %v", err)
+			}
+		}()
+	}
+
 	go func() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -323,6 +351,9 @@ func main() {
 		}
 		if screenshotSrv != nil {
 			screenshotSrv.Shutdown(ctx)
+		}
+		if glitchtipSrv != nil {
+			glitchtipSrv.Shutdown(ctx)
 		}
 		if err := metricsSrv.Shutdown(ctx); err != nil {
 			log.Printf("metrics server shutdown error: %v", err)

--- a/proxy/executor/glitchtip.go
+++ b/proxy/executor/glitchtip.go
@@ -1,0 +1,56 @@
+package executor
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+func NewGlitchTipProxy(glitchtipURL, token string) http.Handler {
+	upstream, err := url.Parse(glitchtipURL)
+	if err != nil {
+		log.Fatalf("glitchtip: invalid URL %q: %v", glitchtipURL, err)
+	}
+
+	bearerAuth := "Bearer " + token
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(upstream)
+			r.Out.URL.Path = r.In.URL.Path
+			r.Out.URL.RawQuery = r.In.URL.RawQuery
+			r.Out.Host = upstream.Host
+			r.Out.Header.Set("Authorization", bearerAuth)
+		},
+		FlushInterval: -1,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok\n"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w}
+		proxy.ServeHTTP(rec, r)
+		log.Printf("glitchtip: method=%s path=%s status=%d dur=%s",
+			r.Method, r.URL.Path, rec.status,
+			time.Since(start).Round(time.Millisecond))
+	})
+
+	return mux
+}
+
+func ValidateGlitchTipConfig(glitchtipURL, token string) error {
+	if glitchtipURL == "" {
+		return fmt.Errorf("GLITCHTIP_URL is required")
+	}
+	if token == "" {
+		return fmt.Errorf("GLITCHTIP_TOKEN is required")
+	}
+	return nil
+}

--- a/proxy/executor/glitchtip_test.go
+++ b/proxy/executor/glitchtip_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGlitchTipHealthz(t *testing.T) {
-	handler := NewGlitchTipProxy("https://glitchtip.devshift.net", "tok-123")
+	handler := NewGlitchTipProxy("https://glitchtip.example.com", "tok-123")
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	w := httptest.NewRecorder()
@@ -78,13 +78,13 @@ func TestGlitchTipQueryParamsPreserved(t *testing.T) {
 }
 
 func TestGlitchTipValidateConfig(t *testing.T) {
-	if err := ValidateGlitchTipConfig("https://glitchtip.devshift.net", "token"); err != nil {
+	if err := ValidateGlitchTipConfig("https://glitchtip.example.com", "token"); err != nil {
 		t.Errorf("valid config returned error: %v", err)
 	}
 	if err := ValidateGlitchTipConfig("", "token"); err == nil {
 		t.Error("empty URL should fail")
 	}
-	if err := ValidateGlitchTipConfig("https://glitchtip.devshift.net", ""); err == nil {
+	if err := ValidateGlitchTipConfig("https://glitchtip.example.com", ""); err == nil {
 		t.Error("empty token should fail")
 	}
 }

--- a/proxy/executor/glitchtip_test.go
+++ b/proxy/executor/glitchtip_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGlitchTipHealthz(t *testing.T) {
+	handler := NewGlitchTipProxy("https://glitchtip.devshift.net", "tok-123")
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("/healthz status = %d, want 200", w.Code)
+	}
+}
+
+func TestGlitchTipBearerTokenInjected(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler := NewGlitchTipProxy(upstream.URL, "my-secret-token")
+
+	req := httptest.NewRequest("GET", "/api/0/organizations/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	want := "Bearer my-secret-token"
+	if gotAuth != want {
+		t.Errorf("upstream got Authorization = %q, want %q", gotAuth, want)
+	}
+}
+
+func TestGlitchTipPathPreserved(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler := NewGlitchTipProxy(upstream.URL, "token")
+
+	req := httptest.NewRequest("POST", "/api/0/projects/my-org/my-proj/issues/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if gotPath != "/api/0/projects/my-org/my-proj/issues/" {
+		t.Errorf("upstream path = %q, want /api/0/projects/my-org/my-proj/issues/", gotPath)
+	}
+}
+
+func TestGlitchTipQueryParamsPreserved(t *testing.T) {
+	var gotQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler := NewGlitchTipProxy(upstream.URL, "token")
+
+	req := httptest.NewRequest("GET", "/api/0/issues/?query=is:unresolved&limit=25", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	want := "query=is:unresolved&limit=25"
+	if gotQuery != want {
+		t.Errorf("upstream query = %q, want %q", gotQuery, want)
+	}
+}
+
+func TestGlitchTipValidateConfig(t *testing.T) {
+	if err := ValidateGlitchTipConfig("https://glitchtip.devshift.net", "token"); err != nil {
+		t.Errorf("valid config returned error: %v", err)
+	}
+	if err := ValidateGlitchTipConfig("", "token"); err == nil {
+		t.Error("empty URL should fail")
+	}
+	if err := ValidateGlitchTipConfig("https://glitchtip.devshift.net", ""); err == nil {
+		t.Error("empty token should fail")
+	}
+}


### PR DESCRIPTION
## Description

Add a new sidecar reverse proxy for GlitchTip error tracking, following the established Jira proxy pattern. The proxy injects a Bearer token into requests forwarded to the upstream GlitchTip instance at glitchtip.devshift.net.

### New files
- `proxy/executor/glitchtip.go` — reverse proxy handler with Bearer token injection, `/healthz` endpoint, and request logging
- `proxy/executor/glitchtip_test.go` — tests for healthz, auth injection, path/query preservation, and config validation

### Modified files
- `proxy/executor/cmd/server/main.go` — wire up GlitchTip proxy with flags, env var overrides, and graceful shutdown
- `deploy/template.yaml` — add container port 8447, service port, NetworkPolicy rule, and env vars (`GLITCHTIP_URL` + `GLITCHTIP_TOKEN` from Vault secret)
- `docker-compose.yml` — add GlitchTip env vars for local dev

### Configuration
| Env var | Source | Default | Description |
|---------|--------|---------|-------------|
| `GLITCHTIP_URL` | plain value | `https://glitchtip.devshift.net` | Upstream GlitchTip URL |
| `GLITCHTIP_TOKEN` | Vault (`devbot-secrets/glitchtip-token`) | — | GlitchTip API token |
| `GLITCHTIP_LISTEN` | env override | `:8447` | Listen address |

### App-interface prerequisite
The `glitchtip-token` key needs to be added to the `devbot-secrets` Vault secret via app-interface before deployment.

## Testing

All tests pass:
```
cd proxy/executor && go test ./... -count=1
```

The proxy is only started when `GLITCHTIP_URL` is set, so existing deployments are unaffected.

Note: Requires the companion squid.conf change (#377) to allow `glitchtip.devshift.net` through the proxy.