### PR TITLE
fix: derive MEMORY_API_BASE from BOT_MEMORY_URL [REHOR-61]

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -1,5 +1,18 @@
 import os
+import re
 
 _DEFAULT_COOLDOWN_SECONDS = 172800  # 48 hours
 
-MEMORY_API_BASE = os.environ.get("MEMORY_API_URL", "http://localhost:8080/api")
+
+def _derive_memory_api_base() -> str:
+    explicit = os.environ.get("MEMORY_API_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    bot_memory = os.environ.get("BOT_MEMORY_URL", "")
+    if bot_memory:
+        base = re.sub(r"/mcp/?$", "", bot_memory.rstrip("/"))
+        return f"{base}/api"
+    return "http://localhost:8080/api"
+
+
+MEMORY_API_BASE = _derive_memory_api_base()

--- a/bot/tests/test_idle_reminder.py
+++ b/bot/tests/test_idle_reminder.py
@@ -187,12 +187,39 @@ def test_memory_api_base_from_env(monkeypatch):
     importlib.reload(constants_mod)
 
 
+def test_memory_api_base_derived_from_bot_memory_url(monkeypatch):
+    import importlib
+
+    import bot.constants as constants_mod
+
+    monkeypatch.delenv("MEMORY_API_URL", raising=False)
+    monkeypatch.setenv("BOT_MEMORY_URL", "http://memory-server:8080/mcp")
+    importlib.reload(constants_mod)
+    assert constants_mod.MEMORY_API_BASE == "http://memory-server:8080/api"
+    monkeypatch.delenv("BOT_MEMORY_URL")
+    importlib.reload(constants_mod)
+
+
+def test_memory_api_base_derived_strips_trailing_slash(monkeypatch):
+    import importlib
+
+    import bot.constants as constants_mod
+
+    monkeypatch.delenv("MEMORY_API_URL", raising=False)
+    monkeypatch.setenv("BOT_MEMORY_URL", "http://memory-server:8080/mcp/")
+    importlib.reload(constants_mod)
+    assert constants_mod.MEMORY_API_BASE == "http://memory-server:8080/api"
+    monkeypatch.delenv("BOT_MEMORY_URL")
+    importlib.reload(constants_mod)
+
+
 def test_memory_api_base_default(monkeypatch):
     import importlib
 
     import bot.constants as constants_mod
 
     monkeypatch.delenv("MEMORY_API_URL", raising=False)
+    monkeypatch.delenv("BOT_MEMORY_URL", raising=False)
     importlib.reload(constants_mod)
     assert constants_mod.MEMORY_API_BASE == "http://localhost:8080/api"
     importlib.reload(constants_mod)


### PR DESCRIPTION
## Summary

- `MEMORY_API_URL` env var was never set in docker-compose or the deploy template, causing `idle_reminder.py` to fall back to `http://localhost:8080/api` — unreachable inside the bot pod in k8s
- Now derives `MEMORY_API_BASE` from `BOT_MEMORY_URL` (already set) by stripping `/mcp` and appending `/api`
- Precedence: `MEMORY_API_URL` > `BOT_MEMORY_URL`-derived > localhost fallback

## Test plan

- [x] All 41 idle_reminder tests pass (including 2 new derivation tests)
- [x] Ruff check + format clean
- [ ] Verify idle reminder stops throwing ConnectError after deploy

Fixes: [REHOR-61](https://redhat.atlassian.net/browse/REHOR-61)