### PR TITLE
fix(preflights): fix JIRA comments in shared preflights

### DIFF
--- a/bot/tests/test_jira_kanban_preflight.py
+++ b/bot/tests/test_jira_kanban_preflight.py
@@ -176,6 +176,44 @@ def test_active_with_feedback_returns_start(env_vars, monkeypatch, capsys):
             "status": {"name": "In Progress"},
             "labels": [],
             "issuelinks": [],
+        },
+        "comments": [
+            {
+                "created": "2026-07-01T10:00:00",
+                "body": "Can you check this?",
+                "author": {"displayName": "Human"},
+            }
+        ],
+    }
+    monkeypatch.setattr("jira_kanban_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_kanban_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_kanban_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_kanban_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "JIRA FEEDBACK" in out["content"]
+
+
+def test_active_with_feedback_legacy_path(env_vars, monkeypatch, capsys):
+    """Fallback: comments under fields.comment.comments still works."""
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "LCORE-2b",
+                "status": "pr_open",
+                "repo": "lightspeed-stack",
+                "last_addressed": "2026-06-30T10:00:00",
+                "metadata": {"prs": [{"repo": "lightspeed-stack", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "In Progress"},
+            "labels": [],
+            "issuelinks": [],
             "comment": {
                 "comments": [
                     {

--- a/bot/tests/test_jira_sprint_preflight.py
+++ b/bot/tests/test_jira_sprint_preflight.py
@@ -127,6 +127,44 @@ def test_active_with_feedback_returns_start(env_vars, monkeypatch, capsys):
             "status": {"name": "In Progress"},
             "labels": [],
             "issuelinks": [],
+        },
+        "comments": [
+            {
+                "created": "2026-07-01T10:00:00",
+                "body": "Can you check this?",
+                "author": {"displayName": "Human"},
+            }
+        ],
+    }
+    monkeypatch.setattr("jira_sprint_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_sprint_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_sprint_preflight._jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_sprint_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "JIRA FEEDBACK" in out["content"]
+
+
+def test_active_with_feedback_legacy_path(env_vars, monkeypatch, capsys):
+    """Fallback: comments under fields.comment.comments still works."""
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "TEST-2b",
+                "status": "pr_open",
+                "repo": "my-repo",
+                "last_addressed": "2026-06-30T10:00:00",
+                "metadata": {"prs": [{"repo": "my-repo", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "In Progress"},
+            "labels": [],
+            "issuelinks": [],
             "comment": {
                 "comments": [
                     {

--- a/bot/tests/test_jira_triage.py
+++ b/bot/tests/test_jira_triage.py
@@ -1,0 +1,223 @@
+"""Tests for jira_triage preflight module."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
+SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / ".claude" / "skills"
+sys.path.insert(0, str(SHARED_DIR))
+sys.path.insert(0, str(SKILLS_DIR))
+
+from jira_triage import (  # noqa: E402
+    has_new_jira_feedback,
+    main,
+)
+
+# --- has_new_jira_feedback ---
+
+
+def test_new_feedback_detected():
+    comments = [{"created": "2026-07-01T10:00:00", "body": "Hey can you check this?"}]
+    assert has_new_jira_feedback(comments, "2026-06-30T10:00:00") is True
+
+
+def test_old_feedback_ignored():
+    comments = [{"created": "2026-06-30T08:00:00", "body": "Hey can you check this?"}]
+    assert has_new_jira_feedback(comments, "2026-06-30T10:00:00") is False
+
+
+def test_bot_structured_comment_not_feedback():
+    comments = [{"created": "2026-07-01T10:00:00", "body": "### Analysis\n\n| col1 | col2 |\n|---|---|\n| a | b |"}]
+    assert has_new_jira_feedback(comments, "2026-06-30T10:00:00") is False
+
+
+def test_pr_link_not_feedback():
+    comments = [{"created": "2026-07-01T10:00:00", "body": "PR: https://github.com/org/repo/pull/42"}]
+    assert has_new_jira_feedback(comments, "2026-06-30T10:00:00") is False
+
+
+def test_empty_comments():
+    assert has_new_jira_feedback([], "2026-06-30T10:00:00") is False
+
+
+# --- main() decision logic ---
+
+
+def _mock_tasks(active=None, done=None, paused=None):
+    items = []
+    for t in active or []:
+        items.append({**t, "status": t.get("status", "in_progress")})
+    for t in done or []:
+        items.append({**t, "status": "done"})
+    for t in paused or []:
+        items.append({**t, "status": "paused"})
+    return items
+
+
+@pytest.fixture
+def env_vars(monkeypatch):
+    monkeypatch.setattr("jira_triage.INSTANCE_ID", "test-instance")
+    monkeypatch.setattr("jira_triage.save_state", lambda x: None)
+
+
+def test_no_active_returns_start(env_vars, monkeypatch, capsys):
+    """No active tasks → start (Priority 2: new Jira work)."""
+    tasks = _mock_tasks()
+    monkeypatch.setattr("jira_triage.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_triage.get_capacity", lambda: (0, 10))
+    monkeypatch.setattr("jira_triage.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "No active tasks" in out["content"]
+
+
+def test_active_with_feedback_returns_start(env_vars, monkeypatch, capsys):
+    """Top-level comments key (MCP response format) triggers feedback detection."""
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "TEST-1",
+                "status": "in_progress",
+                "repo": "my-repo",
+                "last_addressed": "2026-06-30T10:00:00",
+                "metadata": {"prs": [{"repo": "my-repo", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "In Progress"},
+            "labels": [],
+            "issuelinks": [],
+        },
+        "comments": [
+            {
+                "created": "2026-07-01T10:00:00",
+                "body": "Can you check this?",
+                "author": {"displayName": "Human"},
+            }
+        ],
+    }
+    monkeypatch.setattr("jira_triage.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_triage.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_triage.jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_triage.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "JIRA FEEDBACK" in out["content"]
+
+
+def test_active_with_feedback_legacy_path(env_vars, monkeypatch, capsys):
+    """Fallback: comments under fields.comment.comments still works."""
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "TEST-1b",
+                "status": "in_progress",
+                "repo": "my-repo",
+                "last_addressed": "2026-06-30T10:00:00",
+                "metadata": {"prs": [{"repo": "my-repo", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "In Progress"},
+            "labels": [],
+            "issuelinks": [],
+            "comment": {
+                "comments": [
+                    {
+                        "created": "2026-07-01T10:00:00",
+                        "body": "Can you check this?",
+                        "author": {"displayName": "Human"},
+                    }
+                ]
+            },
+        }
+    }
+    monkeypatch.setattr("jira_triage.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_triage.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_triage.jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_triage.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "JIRA FEEDBACK" in out["content"]
+
+
+def test_active_all_clean_returns_skip(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "TEST-2",
+                "status": "pr_open",
+                "repo": "my-repo",
+                "last_addressed": "2026-07-01T12:00:00",
+                "metadata": {"prs": [{"repo": "my-repo", "number": 1, "host": "github"}]},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "Code Review"},
+            "labels": [],
+            "issuelinks": [],
+        },
+        "comments": [],
+    }
+    monkeypatch.setattr("jira_triage.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_triage.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_triage.jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_triage.jira_cleanup", lambda: None)
+    monkeypatch.setattr("jira_triage.load_state", lambda: {})
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "skip"
+
+
+def test_interrupted_task_returns_start(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "TEST-3",
+                "status": "in_progress",
+                "repo": "my-repo",
+                "metadata": {"last_step": "implemented"},
+            }
+        ]
+    )
+    jira_data = {
+        "fields": {
+            "status": {"name": "In Progress"},
+            "labels": [],
+            "issuelinks": [],
+        },
+        "comments": [],
+    }
+    monkeypatch.setattr("jira_triage.get_tasks", lambda: tasks)
+    monkeypatch.setattr("jira_triage.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("jira_triage.jira_issue", lambda key: jira_data)
+    monkeypatch.setattr("jira_triage.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "INTERRUPTED" in out["content"]
+
+
+def test_missing_instance_id_returns_error(monkeypatch, capsys):
+    monkeypatch.setattr("jira_triage.INSTANCE_ID", "")
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "error"

--- a/presets/shared/preflight/jira_kanban_preflight.py
+++ b/presets/shared/preflight/jira_kanban_preflight.py
@@ -44,7 +44,7 @@ def _jira_issue(key):
         "jira_get_issue",
         {
             "issue_key": key,
-            "fields": "summary,status,assignee,labels,issuelinks",
+            "fields": "summary,status,assignee,labels,issuelinks,comment",
             "comment_limit": 10,
         },
     )
@@ -278,7 +278,9 @@ def main():
             jira = _jira_issue(key) if key else None
             jira_comments = []
             if jira:
-                jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
+                jira_comments = (
+                    jira.get("comments") or jira.get("fields", {}).get("comment", {}).get("comments") or []
+                )[-10:]
 
             is_interrupted = (
                 t.get("status") == "in_progress"

--- a/presets/shared/preflight/jira_sprint_preflight.py
+++ b/presets/shared/preflight/jira_sprint_preflight.py
@@ -42,7 +42,7 @@ def _jira_issue(key):
         "jira_get_issue",
         {
             "issue_key": key,
-            "fields": "summary,status,assignee,labels,issuelinks",
+            "fields": "summary,status,assignee,labels,issuelinks,comment",
             "comment_limit": 10,
         },
     )
@@ -274,7 +274,9 @@ def main():
             jira = _jira_issue(key) if key else None
             jira_comments = []
             if jira:
-                jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
+                jira_comments = (
+                    jira.get("comments") or jira.get("fields", {}).get("comment", {}).get("comments") or []
+                )[-10:]
 
             is_interrupted = (
                 t.get("status") == "in_progress"

--- a/presets/shared/preflight/jira_triage.py
+++ b/presets/shared/preflight/jira_triage.py
@@ -25,7 +25,7 @@ def jira_issue(key):
         "jira_get_issue",
         {
             "issue_key": key,
-            "fields": "summary,status,assignee,labels,issuelinks",
+            "fields": "summary,status,assignee,labels,issuelinks,comment",
             "comment_limit": 10,
         },
     )
@@ -109,7 +109,9 @@ def main():
         jira = jira_issue(key) if key else None
         jira_comments = []
         if jira:
-            jira_comments = (jira.get("fields", {}).get("comment", {}).get("comments") or [])[-10:]
+            jira_comments = (jira.get("comments") or jira.get("fields", {}).get("comment", {}).get("comments") or [])[
+                -10:
+            ]
 
         last_addr = t.get("last_addressed", "")
         is_interrupted = t.get("status") == "in_progress" and not t.get("pr_number") and not meta.get("prs") and not prs


### PR DESCRIPTION
PR 2 — Shared preflight fix (sprint/kanban/triage):

  ### Description

  Fix Jira comment feedback detection in sprint, kanban, and triage preflights — same root cause as the onboarding preflight fix: `_jira_issue()` omits `comment` from the MCP `fields` parameter, so `_has_new_jira_feedback()` always gets an empty comment list and never detects human replies.

  **How we verified this is a real bug (not just theoretical):**

  1. Left a test comment on RHCLOUD-49811, an active ticket the framework bot was working on (comment ID `17803643`, posted at `22:04:03`).
  2. The preflight ran 15 seconds later (`22:04:18`) — `03-jira-sprint.py → skip (671 chars)`. It did **not** detect the comment as feedback.
  3. The bot started anyway because `01-gh-pr-status.py → start` (CodeRabbit review on PR #3632). It processed the PR review but **completely ignored** the Jira comment.
  4. The bot then called `task_update` on RHCLOUD-49811 after handling the PR feedback, which likely advanced `last_addressed` past the Jira comment timestamp — silently
  consuming it so future cycles won't see it either.
  5. Confirmed via git history: `comment` was never included in any preflight's `_jira_issue` fields since inception (commit `28819a6`, July 2). No PRs or branches have
  ever addressed this.

  The framework bot has been functioning despite this bug because it starts cycles through other triggers (PR reviews, interrupted work, new sprint candidates). But direct

  The framework bot has been functioning despite this bug because it starts cycles through other triggers (PR reviews, interrupted work, new sprint candidates). But direct Jira comment feedback on active tasks has never been detected by the preflight — `_has_new_jira_feedback` is effectively dead code without this fix.

  Also fixes the comment access path from `jira.get("fields", {}).get("comment", {}).get("comments")` to try the top-level `comments` key first (matching the MCP response format when `comment` is in `fields`).

  ---

  ### Blast radius

  - **All jira-sprint, jira-kanban, and jira-triage workflow consumers** — every bot instance using these preflights will now correctly detect Jira comment feedback and wake up for it.
  - This changes skip/start behavior: tickets with new human comments that previously produced `skip` will now produce `start`, triggering an LLM cycle. This is the intended behavior but will increase token usage for instances
  that receive frequent Jira comments.

  Tested by:
  - Live observation on RHCLOUD-49811 confirming the bug
  - Empirical MCP response verification (with/without `comment` in fields)
  - Full bot test suite (259 tests pass)
  - ruff 0.16.0 format, lint, and check clean
  - Verified against mcp-atlassian 2.14.5 (same unpinned version deployed in bot proxy container) — without `comment` in fields, the response contains no `comments` key at all; with it, comments appear at the top-level `comments`
  key

  ---

  ### Rollback plan

  Git revert is sufficient. Reverting restores the previous (broken) behavior where Jira comment feedback is never detected by preflights. Bots will continue to function via other triggers (PR status, interrupted work,
  candidates).

  ---

  ### Checklist
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not `latest`

  ### AI disclosure
  Assisted by: Claude Code (Claude Opus 4.6)