### PR TITLE
feat(browser): configurable extra-hosts for DNS resolution

### DIFF
--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -62,6 +62,7 @@ instance/my-config/
     │   ├── frontend/
     │   │   └── prompt.md
     │   └── ...
+    ├── extra-hosts           # custom /etc/hosts entries for browser preset (optional)
     ├── preflight/            # instance-specific preflight scripts (optional)
     │   └── 01-check-something.py
     └── workflows/            # custom workflows (optional, if not using a built-in)

--- a/docs/presets/envs.md
+++ b/docs/presets/envs.md
@@ -106,6 +106,16 @@ Installs Chromium and the chrome-devtools MCP server for visual verification. Th
 
 **When to use**: Any instance working on UI repos where visual verification matters. The bot starts a dev server, navigates to the relevant page, and takes screenshots.
 
+**Custom DNS (extra-hosts)**: Create `instance/<name>/agent/extra-hosts` to inject hostnames into `/etc/hosts` before Chrome starts. Standard hosts format:
+
+```
+# Dev proxy hostname — resolves to localhost where Caddy listens
+127.0.0.1    stage.foo.redhat.com
+::1          stage.foo.redhat.com
+```
+
+The entrypoint loads this file automatically. Instances without `extra-hosts` are unaffected. Use this when Chrome needs to resolve hostnames that don't exist in public DNS (e.g. dev-proxy targets).
+
 **Requires env var**: `PLAYWRIGHT_BROWSERS_PATH` (set automatically in the container)
 
 **Depends on**: nothing

--- a/presets/envs/browser/entrypoint.d/10-chromium.sh
+++ b/presets/envs/browser/entrypoint.d/10-chromium.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 # Start headless Chromium for chrome-devtools MCP
 
+# Load extra hosts from instance config (e.g. instance/<name>/agent/extra-hosts)
+# Standard /etc/hosts format — one entry per line:
+#   127.0.0.1    stage.foo.redhat.com
+#   ::1          stage.foo.redhat.com
+#   10.0.0.5     custom.internal
+for hosts_file in instance/*/agent/extra-hosts; do
+    [ -f "$hosts_file" ] || continue
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%%#*}"
+        [ -z "${line// /}" ] && continue
+        echo "$line" >> /etc/hosts 2>/dev/null || true
+    done < "$hosts_file"
+    echo "Loaded extra hosts from ${hosts_file}"
+done
+
 # Skip if Chromium already running (idempotent during transition period)
 if curl -s http://127.0.0.1:9222/json/version > /dev/null 2>&1; then
     echo "Chromium already running, skipping"


### PR DESCRIPTION
## Summary

- Browser env preset now loads `instance/<name>/agent/extra-hosts` into `/etc/hosts` before Chrome starts
- Standard `/etc/hosts` format — supports IPv4, IPv6, comments, blank lines
- Enables dev-proxy hostname resolution (e.g. `stage.foo.redhat.com`) without hardcoding platform-specific domains
- Universal: any instance can ship its own hosts file for any environment

## Usage

Create `instance/<config>/agent/extra-hosts`:
```
# Dev proxy
127.0.0.1    stage.foo.redhat.com
::1          stage.foo.redhat.com
```

## Test plan

- [ ] Instance with `extra-hosts` file — verify entries appear in `/etc/hosts`
- [ ] Instance without `extra-hosts` — verify no errors, Chrome starts normally
- [ ] Chrome can navigate to hostname defined in extra-hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)