### PR TITLE
REHOR-26 Add hosted docs site (GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,8 @@ rehor-impact-assessment-generated.md
 .claude/skills/wrap-up/
 .claude/skills/triage/
 .claude/skills/new-work/
+# MkDocs build output
+site/
+
 # IDEs and Editors
 .vscode/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An autonomous developer agent that picks groomed Jira tickets, implements them, 
 
 ## Documentation
 
+**[Browse the full documentation site](https://redhatinsights.github.io/platform-frontend-ai-dev/)**
+
 | Document | Description |
 |----------|-------------|
 | [Architecture](ARCHITECTURE.md) | System design, credential isolation, component overview |

--- a/docs/bot-workflow-loop.md
+++ b/docs/bot-workflow-loop.md
@@ -6,16 +6,24 @@ The bot operates as an autonomous loop: a scheduler triggers cycles, lightweight
 
 ```mermaid
 graph TB
-    KEDA["KEDA Cron Scaler<br/>(Kubernetes)<br/>Scales pod to 1 during working hours"]
-    Loop["Polling Loop<br/>(bot/run.py)<br/>preflight → session or sleep → repeat"]
-    Preflight["Preflight Scripts<br/>(Python, $0)<br/>Gather data, classify, decide"]
-    Session["Claude Code Session<br/>(AI, tokens)<br/>Reads CLAUDE.md + preflight data<br/>Writes code, opens PRs"]
-    Sleep["Sleep<br/>(no session)<br/>Wait for next cycle"]
-    Memory["Memory Server<br/>(FastMCP + PostgreSQL)"]
 
-    TasksDB["Tasks DB<br/>(Postgres)"]
-    SSE["SSE Event Bus<br/>(real-time)"]
-    REST["REST API<br/>(dashboard)"]
+    subgraph Scheduler["Scheduler"]
+        KEDA["KEDA Cron Scaler<br/>(Kubernetes)"]
+    end
+
+    subgraph Core["Polling Loop (bot/run.py)"]
+        Loop["preflight → session or sleep → repeat"]
+        Preflight["Preflight Scripts<br/>(Python, $0)"]
+        Session["Claude Code Session<br/>(AI, tokens)"]
+        Sleep["Sleep<br/>(no session)"]
+    end
+
+    subgraph Persistence["Memory Layer"]
+        Memory["Memory Server<br/>(FastMCP + PostgreSQL)"]
+        TasksDB["Tasks DB"]
+        SSE["SSE Event Bus"]
+        REST["REST API"]
+    end
 
     KEDA -->|"pod running"| Loop
     Loop -->|"each cycle"| Preflight
@@ -25,13 +33,6 @@ graph TB
     Memory --- TasksDB
     Memory --- SSE
     Memory --- REST
-
-    style KEDA fill:#f5f5f5,stroke:#999
-    style Loop fill:#f5f5f5,stroke:#999
-    style Preflight fill:#f5f5f5,stroke:#999
-    style Sleep fill:#f5f5f5,stroke:#999
-    style Session fill:#e8f5e9,stroke:#4caf50
-    style Memory fill:#f5f5f5,stroke:#999
 ```
 
 ## The Cycle
@@ -365,7 +366,7 @@ graph LR
 
 ### MCP Tools
 
-The agent interacts with tasks through MCP tools exposed by the `bot-memory` server. For the full tool reference, see [the core instructions](../presets/core/CLAUDE.md#task-tools).
+The agent interacts with tasks through MCP tools exposed by the `bot-memory` server. For the full tool reference, see [the core instructions](https://github.com/RedHatInsights/platform-frontend-ai-dev/blob/master/presets/core/CLAUDE.md#task-tools).
 
 | Tool | Purpose | Key behavior |
 |------|---------|-------------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,110 @@
+# Dev Bot (Rehor)
+
+## What
+
+Rehor is an autonomous developer agent that picks groomed Jira tickets, implements code changes in target repos, opens PRs/MRs, and maintains them through CI and review cycles. It runs as a polling loop using the Claude Agent SDK, integrating with Jira Cloud, GitHub, GitLab, and a persistent memory system backed by PostgreSQL.
+
+The bot operates in cycles. Each cycle, lightweight Python preflight scripts check external systems (GitHub PRs, GitLab MRs, Jira sprint) for actionable work. An AI session only starts when there's something to do, so the common "nothing changed" case costs zero tokens.
+
+## Why
+
+- **Hands-free ticket implementation** — groomed tickets get picked up, implemented, and PRed without human intervention
+- **Consistent quality** — every PR follows the same patterns: persona-specific coding standards, test verification, visual checks for UI changes
+- **Scales across repos** — one bot instance handles multiple repos via label-based routing and fork-based PRs
+- **Learns from past work** — completed work is stored as RAG memories, so the bot improves over time
+- **Cost-efficient** — preflight scripts filter out "nothing to do" cycles before any AI tokens are spent
+
+## How
+
+1. **Configure your instance** — select a workflow and env presets using the [Presets Overview](presets/README.md)
+2. **Label tickets** — add your bot's primary label and a `repo:<name>` label to groomed Jira tickets
+3. **Preflight scripts gather data** — each cycle, Python scripts check GitHub PRs, GitLab MRs, and Jira for actionable changes
+4. **AI session runs only when needed** — if any preflight script returns "start", Claude receives all gathered data and acts on it
+5. **PR lifecycle is automatic** — the bot handles CI failures, review feedback, merge conflicts, and post-merge cleanup
+
+For the full cycle diagram and state machine, see [Bot Workflow Loop](bot-workflow-loop.md).
+
+```
+Ticket groomed + labeled
+    → Bot claims ticket (In Progress)
+        → Bot implements on branch bot/KEY
+            → PR opened (Code Review)
+                → CI fix / review feedback loop
+                    → PR merged (Done, learnings stored)
+```
+
+## Example
+
+A real ticket: RHCLOUD-37254 ("RBAC allowing roles with same name as System Roles").
+
+1. A human groomed the ticket and added labels `hcc-ai-platform-accessmanagement` and `repo:insights-rbac`
+2. The bot found it via JQL, assigned itself, transitioned to "In Progress", added it to the active sprint
+3. It cloned `insights-rbac`, created branch `bot/RHCLOUD-37254`, loaded the `rbac` persona, read the repo's `CLAUDE.md`, and implemented the fix
+4. It pushed the branch, opened a PR via `gh pr create`, transitioned the ticket to "Code Review", and commented on Jira with the PR link
+5. A human reviewed the PR. Each cycle, the bot checked for new feedback and addressed comments
+6. Once merged, the bot transitioned the ticket to "Done" and stored learnings in RAG memory
+
+For more examples (cross-repo features, CVE triage, UI changes with screenshots), see the [Operations Guide](https://github.com/RedHatInsights/platform-frontend-ai-dev/blob/master/OPERATIONS.md#what-the-bot-has-done).
+
+## Common Mistakes
+
+**Wrong NetworkPolicy proxy label.** The proxy pod's label is `app.kubernetes.io/name: devbot-proxy`, not `proxy`. Using the wrong label silently blocks all bot egress. The bot will start but hang forever waiting for the executor connection. See [Onboarding](onboarding-new-instance.md#gotchas) for details.
+
+**DNS port is 5353, not 53.** OpenShift uses a custom DNS server on port 5353 in the `openshift-dns` namespace. Standard port 53 or `kube-dns` selectors cause pods to hang on name resolution.
+
+**Missing `ScaledObject.keda.sh` in managedResourceTypes.** Without this, app-interface prunes the KEDA cron scaler on every sync, and your bot won't auto-scale. See [Scheduling](scheduling.md).
+
+**Unused env presets waste build time.** The `node` and `go` presets install version managers and compilers. Skip them if your repos don't need them. See [Env Presets](presets/envs.md).
+
+## Troubleshooting
+
+**Bot isn't picking up tickets:**
+
+- Check that tickets have the correct primary label matching your `BOT_LABEL`
+- Tickets must be unassigned — the bot skips assigned tickets
+- Verify `repo:<name>` labels match keys in `project-repos.json`
+- Check if the bot is at the 10-task capacity limit via the dashboard
+
+**Bot pod starts but hangs:**
+
+- Check NetworkPolicy labels (must be `devbot-proxy`, not `proxy`)
+- Check DNS egress (port 5353, not 53, targeting `openshift-dns` namespace)
+- Verify executor connectivity in logs: "Connected to executor at devbot-proxy:9090"
+
+**Bot runs but never starts AI sessions:**
+
+- Check preflight logs — all scripts returning "skip" means no actionable work was found
+- Verify there are open PRs with CI failures, review feedback, or unassigned sprint tickets
+- Look for "error" results in preflight output, which indicate API connectivity issues
+
+For the full operations guide, see [OPERATIONS.md](https://github.com/RedHatInsights/platform-frontend-ai-dev/blob/master/OPERATIONS.md).
+
+---
+
+## Documentation
+
+| Section | What you'll find |
+|---------|-----------------|
+| [Onboarding a New Instance](onboarding-new-instance.md) | Step-by-step guide: runner repo, deploy template, Konflux, app-interface, Jira setup |
+| [Scheduling](scheduling.md) | KEDA cron scaler configuration for business-hours-only operation |
+| [Bot Workflow Loop](bot-workflow-loop.md) | Cycle architecture, preflight system, task state machine with diagrams |
+| [Git Auth Proxy](git-auth-proxy.md) | Credential isolation design for the proxy sidecar |
+| [Preset System Design](presets-design.md) | Architecture decisions behind the preset composition model |
+| [Presets Overview](presets/README.md) | How workflow and env presets work together |
+| [Workflow Presets](presets/workflows.md) | Built-in workflow reference (jira-sprint) |
+| [Env Presets](presets/envs.md) | Available env presets: node, go, browser, container-scan, slack, etc. |
+| [Custom Workflows](presets/custom-workflows.md) | Building your own workflow for specialized automation |
+| [Custom Preflight Scripts](presets/custom-preflight.md) | Writing pre-session data-gathering scripts |
+| [Preset Migration Guide](migrations/preset-migration-guide.md) | Migrating existing instances to the preset system |
+| [Roadmap](roadmap.md) | Planned improvements and new capabilities |
+
+## Contributing to these docs
+
+Preview changes locally:
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs serve
+```
+
+Open [http://127.0.0.1:8000](http://127.0.0.1:8000) to preview. Run `mkdocs build --strict` before pushing to catch broken links.

--- a/docs/javascripts/extra.js
+++ b/docs/javascripts/extra.js
@@ -1,0 +1,8 @@
+// open the repo link (header icon) in a new tab
+document.addEventListener("DOMContentLoaded", function () {
+  var repoLink = document.querySelector(".md-source");
+  if (repoLink) {
+    repoLink.setAttribute("target", "_blank");
+    repoLink.setAttribute("rel", "noopener");
+  }
+});

--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -2,7 +2,7 @@
 
 How to add a new bot runner instance to the shared OpenShift cluster. Each instance gets its own Jira label, repo set, and personas, but shares the memory server, database, and Vault secrets deployed by the primary instance (platform-frontend-ai-dev). Instances share the proxy by default, but can optionally deploy their own proxy for custom Jira credentials.
 
-For the system architecture, see [ARCHITECTURE.md](../ARCHITECTURE.md).
+For the system architecture, see [ARCHITECTURE.md](https://github.com/RedHatInsights/platform-frontend-ai-dev/blob/master/ARCHITECTURE.md).
 
 ---
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.6
+mkdocs-material>=9.6

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,34 @@
+.md-typeset {
+  font-size: 0.85rem;
+  line-height: 1.65;
+}
+
+.md-typeset h1 {
+  font-size: 2.2rem;
+}
+
+.md-typeset h2 {
+  font-size: 1.6rem;
+}
+
+.md-typeset h3 {
+  font-size: 1.3rem;
+}
+
+.md-typeset code {
+  font-size: 0.85rem;
+}
+
+/* tables inherit a smaller relative size from Material, bump them back up */
+.md-typeset table:not([class]) {
+  font-size: 0.85rem;
+}
+
+/* let code blocks use more horizontal space to reduce scrolling */
+.md-typeset pre {
+  max-width: 100%;
+}
+
+.md-content {
+  max-width: 960px;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,74 @@
+site_name: Dev Bot (Rehor)
+site_description: Autonomous Jira-driven developer agent documentation
+repo_url: https://github.com/RedHatInsights/platform-frontend-ai-dev
+repo_name: RedHatInsights/platform-frontend-ai-dev
+
+theme:
+  name: material
+  font:
+    text: Red Hat Text
+    code: Red Hat Mono
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.instant
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: red
+      accent: deep orange
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: red
+      accent: deep orange
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+extra_css:
+  - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/extra.js
+
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Onboarding a New Instance: onboarding-new-instance.md
+    - Scheduling: scheduling.md
+  - Architecture:
+    - Bot Workflow Loop: bot-workflow-loop.md
+    - Git Auth Proxy: git-auth-proxy.md
+    - Preset System Design: presets-design.md
+  - Presets:
+    - Overview: presets/README.md
+    - Workflow Presets: presets/workflows.md
+    - Env Presets: presets/envs.md
+    - Custom Workflows: presets/custom-workflows.md
+    - Custom Preflight Scripts: presets/custom-preflight.md
+  - Migrations:
+    - Preset Migration Guide: migrations/preset-migration-guide.md
+  - Roadmap: roadmap.md


### PR DESCRIPTION
## Ticket

[REHOR-26](https://redhat.atlassian.net/browse/REHOR-26)

## Summary

- publishes existing `docs/` as a browsable MkDocs Material site on GitHub Pages
- auto-deploys on push to master when `docs/` or `mkdocs.yml` changes
- adds a landing page (`docs/index.md`) with What/Why/How/Example/Common Mistakes/Troubleshooting
- fixes two broken cross-links that pointed outside `docs/` with relative paths
- improves architecture overview diagram with subgraph grouping for readability
- removes hardcoded Mermaid style colors that broke dark mode

## What changed

**New files:**
- `mkdocs.yml` — Material theme config (Red Hat fonts, dark/light toggle, Mermaid, search, tabs)
- `docs/index.md` — landing page
- `docs/requirements.txt` — mkdocs + mkdocs-material
- `.github/workflows/docs.yml` — build + deploy via actions/deploy-pages
- `docs/stylesheets/extra.css` — font sizing, line-height, table fix
- `docs/javascripts/extra.js` — repo header link opens in new tab

**Modified files:**
- `docs/bot-workflow-loop.md` — subgraph grouping on architecture diagram, removed hardcoded colors, fixed cross-link
- `docs/onboarding-new-instance.md` — fixed cross-link to ARCHITECTURE.md
- `README.md` — added link to hosted docs site
- `.gitignore` — added `site/`

## Post-merge action required

GitHub Pages must be enabled in repo **Settings > Pages > Source = "GitHub Actions"**. Without this, the workflow succeeds but nothing appears. @Hyperkid123 

## Validation

- [x] `mkdocs build --strict` passes
- [x] `ruff check .` passes
- [x] `pytest` — 782 passed (15 pre-existing failures on master, unrelated to this change)
- [x] local `mkdocs serve` verified in browser (light mode, dark mode, diagrams, navigation, code blocks)
- [x] no secrets or credentials in diff


https://github.com/user-attachments/assets/69bb5324-cb3a-4026-ab0e-656596bfa873

