### PR TITLE
fix(api): return paginated response from cycle-runs/by-task endpoint

### DIFF
--- a/dashboard/src/pages/CycleRuns.spec.ts
+++ b/dashboard/src/pages/CycleRuns.spec.ts
@@ -26,7 +26,7 @@ const defaultRun = {
 test.describe('CycleRuns page', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/cycle-runs/by-task*', (route) => {
-      route.fulfill({ json: [] });
+      route.fulfill({ json: { items: [], total: 0 } });
     });
     await page.route('**/api/cycle-runs?*', (route) => {
       route.fulfill({ json: { items: [], total: 0 } });
@@ -41,7 +41,7 @@ test.describe('CycleRuns page', () => {
   test('renders task groups from API', async ({ mount, page }) => {
     const group = { ...defaultGroup, external_key: 'RHCLOUD-100', title: 'Fix login', cycle_count: 5 };
     await page.route('**/api/cycle-runs/by-task*', (route) => {
-      route.fulfill({ json: [group] });
+      route.fulfill({ json: { items: [group], total: 1 } });
     });
 
     await mount('CycleRuns/Default');
@@ -54,7 +54,7 @@ test.describe('CycleRuns page', () => {
     let requestUrl = '';
     await page.route('**/api/cycle-runs/by-task*', (route) => {
       requestUrl = route.request().url();
-      route.fulfill({ json: [] });
+      route.fulfill({ json: { items: [], total: 0 } });
     });
 
     await mount('CycleRuns/WithInstanceId');
@@ -65,7 +65,7 @@ test.describe('CycleRuns page', () => {
 
   test('expands group and loads cycle runs on click', async ({ mount, page }) => {
     await page.route('**/api/cycle-runs/by-task*', (route) => {
-      route.fulfill({ json: [defaultGroup] });
+      route.fulfill({ json: { items: [defaultGroup], total: 1 } });
     });
     await page.route('**/api/cycle-runs?*', (route) => {
       route.fulfill({ json: { items: [defaultRun], total: 1 } });
@@ -81,7 +81,7 @@ test.describe('CycleRuns page', () => {
   test('renders orphan cycles group label', async ({ mount, page }) => {
     const orphanGroup = { ...defaultGroup, task_id: null, external_key: null, title: null, cycle_count: 2 };
     await page.route('**/api/cycle-runs/by-task*', (route) => {
-      route.fulfill({ json: [orphanGroup] });
+      route.fulfill({ json: { items: [orphanGroup], total: 1 } });
     });
 
     await mount('CycleRuns/Default');

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -1252,7 +1252,7 @@ async def api_cycle_runs_by_task(request: Request) -> JSONResponse:
                 "last_cycle": r["last_cycle"].isoformat() if r["last_cycle"] else None,
             }
         )
-    return JSONResponse(groups)
+    return JSONResponse({"items": groups, "total": len(groups)})
 
 
 async def api_instance_wake_trigger(request: Request) -> JSONResponse:

--- a/memory-server/tests/test_cycle_runs.py
+++ b/memory-server/tests/test_cycle_runs.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from bot_memory_server.api import api_cycle_run_transcript, api_cycle_runs
+from bot_memory_server.api import api_cycle_run_transcript, api_cycle_runs, api_cycle_runs_by_task
 from httpx import ASGITransport, AsyncClient
 from starlette.applications import Starlette
 from starlette.routing import Route
@@ -14,6 +14,7 @@ from starlette.routing import Route
 app = Starlette(
     routes=[
         Route("/api/cycle-runs", api_cycle_runs, methods=["GET", "POST"]),
+        Route("/api/cycle-runs/by-task", api_cycle_runs_by_task, methods=["GET"]),
         Route(
             "/api/cycle-runs/{id}/transcript",
             api_cycle_run_transcript,
@@ -44,6 +45,24 @@ def _fake_cycle_run_row(id=1, task_id=42, **kwargs):
         "progress": kwargs.get("progress", json.dumps({"last_step": "implemented"})),
         "created_at": kwargs.get("created_at", now),
         "has_transcript": kwargs.get("has_transcript", False),
+    }
+
+
+def _fake_by_task_row(**kwargs):
+    now = datetime.now(timezone.utc)
+    return {
+        "task_id": kwargs.get("task_id", 42),
+        "external_key": kwargs.get("external_key", "RHCLOUD-100"),
+        "source_type": kwargs.get("source_type", "jira"),
+        "title": kwargs.get("title", "Fix login"),
+        "task_status": kwargs.get("task_status", "in_progress"),
+        "repo": kwargs.get("repo", "test-repo"),
+        "cycle_count": kwargs.get("cycle_count", 3),
+        "transcript_count": kwargs.get("transcript_count", 1),
+        "total_tool_calls": kwargs.get("total_tool_calls", 100),
+        "total_tokens": kwargs.get("total_tokens", 250000),
+        "first_cycle": kwargs.get("first_cycle", now),
+        "last_cycle": kwargs.get("last_cycle", now),
     }
 
 
@@ -226,6 +245,34 @@ async def test_get_cycle_runs_filter_by_cycle_type(mock_pool):
     call_args = mock_pool.fetch.call_args
     query = call_args[0][0]
     assert "cycle_type = $" in query
+
+
+@pytest.mark.asyncio
+async def test_get_cycle_runs_by_task_returns_paginated(mock_pool):
+    """REHOR-79: by-task endpoint must return {items, total}, not a plain array."""
+    mock_pool.fetch = AsyncMock(return_value=[_fake_by_task_row(), _fake_by_task_row(external_key="RHCLOUD-200")])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/cycle-runs/by-task")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] == 2
+    assert len(data["items"]) == 2
+    assert data["items"][0]["external_key"] == "RHCLOUD-100"
+
+
+@pytest.mark.asyncio
+async def test_get_cycle_runs_by_task_empty(mock_pool):
+    mock_pool.fetch = AsyncMock(return_value=[])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/cycle-runs/by-task")
+
+    data = resp.json()
+    assert data == {"items": [], "total": 0}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `api_cycle_runs_by_task` returned a plain JSON array while all other paginated endpoints return `{items, total}` — the dashboard already expected the paginated shape (`data?.items || []`), so the raw array caused empty renders
- Wrapped the response in `{items, total}`, updated Playwright mocks to match, and added backend tests for the new shape

## Test plan
- [x] `uv run pytest tests/test_cycle_runs.py` — 22 passed (includes 2 new: `test_get_cycle_runs_by_task_returns_paginated`, `test_get_cycle_runs_by_task_empty`)
- [x] `npx vitest run` — 54 passed (api.test.ts, CycleRuns.test.tsx, CycleRuns.spec.ts mocks updated)
- [ ] Verify CycleRuns page renders task groups in staging

REHOR-79

---