### PR TITLE
feat: sleep state detection and UI for idle bots (RHCLOUD-48086)

### DIFF
--- a/dashboard/e2e/gallery.tsx
+++ b/dashboard/e2e/gallery.tsx
@@ -78,7 +78,7 @@ const scenarios: Record<string, () => JSX.Element> = {
 
   // ── BotBanner ──
   'BotBanner/Idle': () => (
-    <BotBanner status={makeBotStatus({ state: 'idle', message: 'Waiting for tasks' })} />
+    <BotBanner status={makeBotStatus({ state: 'idle', message: 'Waiting for tasks', updated_at: new Date().toISOString() })} />
   ),
   'BotBanner/Working': () => (
     <BotBanner status={makeBotStatus({
@@ -94,10 +94,13 @@ const scenarios: Record<string, () => JSX.Element> = {
     <BotBanner status={makeBotStatus({ state: 'error', message: 'Cycle failed' })} />
   ),
   'BotBanner/IdleWithWake': () => (
-    <BotBanner status={makeBotStatus({ state: 'idle', instance_id: 'dev-bot' })} />
+    <BotBanner status={makeBotStatus({ state: 'idle', instance_id: 'dev-bot', updated_at: new Date().toISOString() })} />
   ),
   'BotBanner/WorkingNoWake': () => (
     <BotBanner status={makeBotStatus({ state: 'working', instance_id: 'dev-bot' })} />
+  ),
+  'BotBanner/Sleep': () => (
+    <BotBanner status={makeBotStatus({ state: 'idle', message: '', instance_id: 'dev-bot', last_seen: '2020-01-01T00:00:00Z', updated_at: '2020-01-01T00:00:00Z' })} />
   ),
   // ── ConfirmDialog ──
   'ConfirmDialog/Default': () => (

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -224,6 +224,20 @@ header {
   color: var(--text-dim);
 }
 
+.bot-banner.state-sleep {
+  border-color: var(--text-dim);
+  background: rgba(139, 148, 158, 0.06);
+}
+
+.indicator-dot.sleep {
+  background: var(--text-dim);
+}
+
+.state-badge.sleep {
+  background: rgba(139, 148, 158, 0.2);
+  color: var(--text-dim);
+}
+
 .banner-message {
   font-size: 14px;
   color: var(--text);

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -4,6 +4,7 @@ import { HashRouter, Routes, Route, NavLink, Navigate, useParams, useNavigate, u
 import { WSProvider, useWS } from './hooks/useWebSocket';
 import type { BotInstance } from './types';
 import { fetchStats, fetchInstances } from './api';
+import { effectiveState } from './utils';
 import {
   Nav,
   NavList,
@@ -71,11 +72,14 @@ function InstanceSelector({ instances, currentId }: { instances: BotInstance[]; 
       <SelectList>
         <SelectOption value="__global__">All instances</SelectOption>
         <SelectOption value="__instances__">Overview</SelectOption>
-        {instances.map((inst) => (
+        {instances.map((inst) => {
+          const state = effectiveState(inst);
+          return (
           <SelectOption key={inst.instance_id} value={inst.instance_id}>
-            {inst.instance_id} — {inst.state.toUpperCase()}
+            {inst.instance_id} — {state.toUpperCase()}
           </SelectOption>
-        ))}
+          );
+        })}
       </SelectList>
     </Select>
   );
@@ -213,6 +217,7 @@ function AppInner() {
           instance_id: currentInstance.instance_id,
           cycle_start: currentInstance.cycle_start,
           updated_at: currentInstance.updated_at,
+          last_seen: currentInstance.last_seen,
         }} />
       )}
 

--- a/dashboard/src/components/BotBanner.spec.ts
+++ b/dashboard/src/components/BotBanner.spec.ts
@@ -33,4 +33,14 @@ test.describe('BotBanner', () => {
     const root = await mount('BotBanner/WorkingNoWake');
     expect(await root.getByTitle('Wake bot — start next cycle immediately').count()).toBe(0);
   });
+
+  test('renders sleep state when idle with stale last_seen', async ({ mount, page }) => {
+    await page.route('**/api/instances/*/wake', (route) => {
+      route.fulfill({ json: { ok: true } });
+    });
+    const root = await mount('BotBanner/Sleep');
+    await expect(root.getByText('SLEEP', { exact: true })).toBeVisible();
+    await expect(root.getByText("Bot hasn't checked in recently")).toBeVisible();
+    expect(await root.getByTitle('Wake bot — start next cycle immediately').count()).toBe(0);
+  });
 });

--- a/dashboard/src/components/BotBanner.tsx
+++ b/dashboard/src/components/BotBanner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import type { BotStatus } from '../types';
 import { wakeInstance } from '../api';
 import { useWS } from '../hooks/useWebSocket';
-import { timeAgo, sourceUrl, displayKey, effectiveState } from '../utils';
+import { timeAgo, sourceUrl, displayKey, effectiveState, stateLabelColor, stateIconStatus, stateBorderColor } from '../utils';
 import {
   Card,
   CardBody,
@@ -16,27 +16,6 @@ import { CircleIcon } from '@patternfly/react-icons';
 
 interface Props {
   status: BotStatus;
-}
-
-function labelColor(state: string): 'orange' | 'red' | 'green' | 'grey' {
-  if (state === 'working') return 'orange';
-  if (state === 'error') return 'red';
-  if (state === 'idle') return 'green';
-  return 'grey';
-}
-
-function iconStatus(state: string): 'warning' | 'danger' | 'success' | 'custom' {
-  if (state === 'working') return 'warning';
-  if (state === 'error') return 'danger';
-  if (state === 'idle') return 'success';
-  return 'custom';
-}
-
-function borderColor(state: string): string {
-  if (state === 'working') return 'var(--yellow)';
-  if (state === 'error') return 'var(--red)';
-  if (state === 'idle') return 'var(--green)';
-  return 'var(--text-dim)';
 }
 
 export default function BotBanner({ status }: Props) {
@@ -95,17 +74,17 @@ export default function BotBanner({ status }: Props) {
   const message = state === 'sleep' ? 'Bot is sleeping — no running pods' : status.message;
 
   return (
-    <Card isCompact isGlass style={{ borderLeft: `3px solid ${borderColor(state)}`, marginBottom: '12px' }}>
+    <Card isCompact isGlass style={{ borderLeft: `3px solid ${stateBorderColor(state)}`, marginBottom: '12px' }}>
       <CardBody>
       <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }} flexWrap={{ default: 'nowrap' }}>
         <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ flex: 1, minWidth: 0 }}>
           <FlexItem>
-            <Icon status={iconStatus(state)}>
+            <Icon status={stateIconStatus(state)}>
               <CircleIcon />
             </Icon>
           </FlexItem>
           <FlexItem>
-            <Label color={labelColor(state)}>
+            <Label color={stateLabelColor(state)}>
               {state.toUpperCase()}
             </Label>
           </FlexItem>

--- a/dashboard/src/components/BotBanner.tsx
+++ b/dashboard/src/components/BotBanner.tsx
@@ -71,7 +71,7 @@ export default function BotBanner({ status }: Props) {
     return () => clearInterval(id);
   }, [status.state, status.cycle_start]);
 
-  const message = state === 'sleep' ? 'Bot is sleeping — no running pods' : status.message;
+  const message = state === 'sleep' ? "Bot hasn't checked in recently" : status.message;
 
   return (
     <Card isCompact isGlass style={{ borderLeft: `3px solid ${stateBorderColor(state)}`, marginBottom: '12px' }}>

--- a/dashboard/src/components/BotBanner.tsx
+++ b/dashboard/src/components/BotBanner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import type { BotStatus } from '../types';
 import { wakeInstance } from '../api';
 import { useWS } from '../hooks/useWebSocket';
-import { timeAgo, sourceUrl, displayKey } from '../utils';
+import { timeAgo, sourceUrl, displayKey, effectiveState } from '../utils';
 import {
   Card,
   CardBody,
@@ -18,10 +18,32 @@ interface Props {
   status: BotStatus;
 }
 
+function labelColor(state: string): 'orange' | 'red' | 'green' | 'grey' {
+  if (state === 'working') return 'orange';
+  if (state === 'error') return 'red';
+  if (state === 'idle') return 'green';
+  return 'grey';
+}
+
+function iconStatus(state: string): 'warning' | 'danger' | 'success' | 'custom' {
+  if (state === 'working') return 'warning';
+  if (state === 'error') return 'danger';
+  if (state === 'idle') return 'success';
+  return 'custom';
+}
+
+function borderColor(state: string): string {
+  if (state === 'working') return 'var(--yellow)';
+  if (state === 'error') return 'var(--red)';
+  if (state === 'idle') return 'var(--green)';
+  return 'var(--text-dim)';
+}
+
 export default function BotBanner({ status }: Props) {
   const [elapsed, setElapsed] = useState('');
   const [waking, setWaking] = useState(false);
   const { onEvent } = useWS();
+  const state = effectiveState(status);
 
   const handleWake = useCallback(async () => {
     if (!status.instance_id) return;
@@ -70,25 +92,25 @@ export default function BotBanner({ status }: Props) {
     return () => clearInterval(id);
   }, [status.state, status.cycle_start]);
 
-  const borderColor = status.state === 'working' ? 'var(--yellow)' : status.state === 'error' ? 'var(--red)' : 'var(--green)';
+  const message = state === 'sleep' ? 'Bot is sleeping — no running pods' : status.message;
 
   return (
-    <Card isCompact isGlass style={{ borderLeft: `3px solid ${borderColor}`, marginBottom: '12px' }}>
+    <Card isCompact isGlass style={{ borderLeft: `3px solid ${borderColor(state)}`, marginBottom: '12px' }}>
       <CardBody>
       <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }} flexWrap={{ default: 'nowrap' }}>
         <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ flex: 1, minWidth: 0 }}>
           <FlexItem>
-            <Icon status={status.state === 'working' ? 'warning' : status.state === 'error' ? 'danger' : 'success'}>
+            <Icon status={iconStatus(state)}>
               <CircleIcon />
             </Icon>
           </FlexItem>
           <FlexItem>
-            <Label color={status.state === 'working' ? 'orange' : status.state === 'error' ? 'red' : 'green'}>
-              {status.state.toUpperCase()}
+            <Label color={labelColor(state)}>
+              {state.toUpperCase()}
             </Label>
           </FlexItem>
           <FlexItem style={{ minWidth: 0, flex: 1 }}>
-            <span style={{ color: 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', display: 'block' }}>{status.message}</span>
+            <span style={{ color: 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', display: 'block' }}>{message}</span>
           </FlexItem>
         </Flex>
         <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ flexShrink: 0 }}>
@@ -119,7 +141,7 @@ export default function BotBanner({ status }: Props) {
               {timeAgo(status.updated_at)}
             </span>
           </FlexItem>
-          {status.state === 'idle' && status.instance_id && (
+          {state === 'idle' && status.instance_id && (
             <FlexItem>
               <Button
                 variant="plain"

--- a/dashboard/src/pages/Instances.spec.ts
+++ b/dashboard/src/pages/Instances.spec.ts
@@ -11,6 +11,7 @@ function makeInstance(overrides: Record<string, any> = {}) {
     repo: null,
     cycle_start: null,
     updated_at: '2026-07-01T10:00:00Z',
+    last_seen: null,
     active_tasks: 2,
     max_tasks: 10,
     ...overrides,
@@ -46,7 +47,7 @@ test.describe('Instances page', () => {
   });
 
   test('renders idle instance with wake button', async ({ mount, page }) => {
-    const inst = makeInstance({ instance_id: 'idle-bot', state: 'idle' });
+    const inst = makeInstance({ instance_id: 'idle-bot', state: 'idle', updated_at: new Date().toISOString() });
     await page.route('**/api/instances', (route) => {
       route.fulfill({ json: [inst] });
     });
@@ -56,7 +57,7 @@ test.describe('Instances page', () => {
   });
 
   test('calls wakeInstance when wake button clicked', async ({ mount, page }) => {
-    const inst = makeInstance({ instance_id: 'idle-bot', state: 'idle' });
+    const inst = makeInstance({ instance_id: 'idle-bot', state: 'idle', updated_at: new Date().toISOString() });
     await page.route('**/api/instances', (route) => {
       route.fulfill({ json: [inst] });
     });
@@ -90,6 +91,29 @@ test.describe('Instances page', () => {
     const link = page.getByRole('link', { name: 'RHCLOUD-500' });
     await expect(link).toHaveAttribute('href', 'https://redhat.atlassian.net/browse/RHCLOUD-500');
     await expect(page.getByText('org/repo')).toBeVisible();
+  });
+
+  test('renders sleep state for instance with stale last_seen', async ({ mount, page }) => {
+    const inst = makeInstance({ instance_id: 'sleep-bot', state: 'idle', last_seen: '2020-01-01T00:00:00Z', updated_at: '2020-01-01T00:00:00Z' });
+    await page.route('**/api/instances', (route) => {
+      route.fulfill({ json: [inst] });
+    });
+
+    await mount('Instances/Default');
+    await expect(page.getByText('SLEEP', { exact: true })).toBeVisible();
+    await expect(page.getByText("Bot hasn't checked in recently")).toBeVisible();
+    expect(await page.getByTitle('Wake bot — start next cycle immediately').count()).toBe(0);
+  });
+
+  test('does not show sleep for working instance even with stale last_seen', async ({ mount, page }) => {
+    const inst = makeInstance({ instance_id: 'busy-bot', state: 'working', message: 'On it', last_seen: '2020-01-01T00:00:00Z', updated_at: '2020-01-01T00:00:00Z' });
+    await page.route('**/api/instances', (route) => {
+      route.fulfill({ json: [inst] });
+    });
+
+    await mount('Instances/Default');
+    await expect(page.getByText('WORKING', { exact: true })).toBeVisible();
+    await expect(page.getByText('On it')).toBeVisible();
   });
 
   test('renders error state badge', async ({ mount, page }) => {

--- a/dashboard/src/pages/Instances.tsx
+++ b/dashboard/src/pages/Instances.tsx
@@ -113,7 +113,7 @@ export default function Instances() {
             <CardBody>
               <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
                 <Content component="p" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: 'var(--pf-t--global--text--color--subtle)' }}>
-                  {state === 'sleep' ? 'Bot is sleeping — no running pods' : inst.message}
+                  {state === 'sleep' ? "Bot hasn't checked in recently" : inst.message}
                 </Content>
                 <LabelGroup>
                   {displayKey(inst) && (

--- a/dashboard/src/pages/Instances.tsx
+++ b/dashboard/src/pages/Instances.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { BotInstance } from '../types';
 import { fetchInstances, wakeInstance } from '../api';
 import { useWS } from '../hooks/useWebSocket';
-import { timeAgo, sourceUrl, displayKey } from '../utils';
+import { timeAgo, sourceUrl, displayKey, effectiveState } from '../utils';
 import {
   Card,
   CardHeader,
@@ -20,6 +20,20 @@ import {
   Icon
 } from '@patternfly/react-core';
 import { CircleIcon } from '@patternfly/react-icons';
+
+function labelColor(state: string): 'orange' | 'red' | 'green' | 'grey' {
+  if (state === 'working') return 'orange';
+  if (state === 'error') return 'red';
+  if (state === 'idle') return 'green';
+  return 'grey';
+}
+
+function iconStatus(state: string): 'warning' | 'danger' | 'success' | 'custom' {
+  if (state === 'working') return 'warning';
+  if (state === 'error') return 'danger';
+  if (state === 'idle') return 'success';
+  return 'custom';
+}
 
 export default function Instances() {
   const [instances, setInstances] = useState<BotInstance[]>([]);
@@ -89,16 +103,18 @@ export default function Instances() {
         <div className="empty-state">No bot instances found</div>
       )}
       <div className="instance-grid">
-        {instances.map((inst) => (
+        {instances.map((inst) => {
+          const state = effectiveState(inst);
+          return (
           <div key={inst.instance_id}>
             <Card isCompact isGlass style={{ cursor: 'pointer' }} onClick={() => navigate(`/instances/${encodeURIComponent(inst.instance_id)}/tasks`)}>
             <CardHeader
-              actions={{ actions: <Label color={inst.state === 'working' ? 'orange' : inst.state === 'error' ? 'red' : 'green'}>{inst.state.toUpperCase()}</Label> }}
+              actions={{ actions: <Label color={labelColor(state)}>{state.toUpperCase()}</Label> }}
             >
               <CardTitle>
                 <Flex alignItems={{ default: 'alignItemsFlexStart' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ minWidth: 0 }}>
                   <FlexItem style={{ flexShrink: 0 }}>
-                    <Icon status={inst.state === 'working' ? 'warning' : inst.state === 'error' ? 'danger' : 'success'}>
+                    <Icon status={iconStatus(state)}>
                       <CircleIcon />
                     </Icon>
                   </FlexItem>
@@ -111,7 +127,7 @@ export default function Instances() {
             <CardBody>
               <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
                 <Content component="p" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: 'var(--pf-t--global--text--color--subtle)' }}>
-                  {inst.message}
+                  {state === 'sleep' ? 'Bot is sleeping — no running pods' : inst.message}
                 </Content>
                 <LabelGroup>
                   {displayKey(inst) && (
@@ -136,7 +152,7 @@ export default function Instances() {
               <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }} alignItems={{ default: 'alignItemsCenter' }}>
                 <Label variant="outline">{inst.active_tasks}/{inst.max_tasks} tasks</Label>
                 <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-                  {inst.state === 'idle' && (
+                  {state === 'idle' && (
                     <Button
                       variant="plain"
                       size="sm"
@@ -155,7 +171,8 @@ export default function Instances() {
             </CardFooter>
           </Card>
           </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/dashboard/src/pages/Instances.tsx
+++ b/dashboard/src/pages/Instances.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { BotInstance } from '../types';
 import { fetchInstances, wakeInstance } from '../api';
 import { useWS } from '../hooks/useWebSocket';
-import { timeAgo, sourceUrl, displayKey, effectiveState } from '../utils';
+import { timeAgo, sourceUrl, displayKey, effectiveState, stateLabelColor, stateIconStatus } from '../utils';
 import {
   Card,
   CardHeader,
@@ -20,20 +20,6 @@ import {
   Icon
 } from '@patternfly/react-core';
 import { CircleIcon } from '@patternfly/react-icons';
-
-function labelColor(state: string): 'orange' | 'red' | 'green' | 'grey' {
-  if (state === 'working') return 'orange';
-  if (state === 'error') return 'red';
-  if (state === 'idle') return 'green';
-  return 'grey';
-}
-
-function iconStatus(state: string): 'warning' | 'danger' | 'success' | 'custom' {
-  if (state === 'working') return 'warning';
-  if (state === 'error') return 'danger';
-  if (state === 'idle') return 'success';
-  return 'custom';
-}
 
 export default function Instances() {
   const [instances, setInstances] = useState<BotInstance[]>([]);
@@ -109,12 +95,12 @@ export default function Instances() {
           <div key={inst.instance_id}>
             <Card isCompact isGlass style={{ cursor: 'pointer' }} onClick={() => navigate(`/instances/${encodeURIComponent(inst.instance_id)}/tasks`)}>
             <CardHeader
-              actions={{ actions: <Label color={labelColor(state)}>{state.toUpperCase()}</Label> }}
+              actions={{ actions: <Label color={stateLabelColor(state)}>{state.toUpperCase()}</Label> }}
             >
               <CardTitle>
                 <Flex alignItems={{ default: 'alignItemsFlexStart' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ minWidth: 0 }}>
                   <FlexItem style={{ flexShrink: 0 }}>
-                    <Icon status={iconStatus(state)}>
+                    <Icon status={stateIconStatus(state)}>
                       <CircleIcon />
                     </Icon>
                   </FlexItem>

--- a/dashboard/src/test/fixtures.json
+++ b/dashboard/src/test/fixtures.json
@@ -624,7 +624,8 @@
     "repo": "test-repo",
     "instance_id": "dev-bot",
     "updated_at": "2026-07-22T10:00:00Z",
-    "cycle_start": "2026-07-22T09:55:00Z"
+    "cycle_start": "2026-07-22T09:55:00Z",
+    "last_seen": null
   },
   "taskCycleGroups": [
     {

--- a/dashboard/src/test/helpers.ts
+++ b/dashboard/src/test/helpers.ts
@@ -39,6 +39,7 @@ export function makeBotInstance(overrides: Partial<BotInstance> = {}): BotInstan
     repo: defaultBotStatus.repo,
     cycle_start: defaultBotStatus.cycle_start,
     updated_at: defaultBotStatus.updated_at,
+    last_seen: null,
     active_tasks: 2,
     max_tasks: 10,
     ...overrides,

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -39,7 +39,7 @@ export interface Memory {
 
 export interface BotInstance {
   instance_id: string;
-  state: 'working' | 'idle' | 'error' | 'unknown';
+  state: 'working' | 'idle' | 'error' | 'sleep' | 'unknown';
   message: string;
   external_key: string | null;
   source_type: string | null;
@@ -47,12 +47,13 @@ export interface BotInstance {
   repo: string | null;
   cycle_start: string | null;
   updated_at: string;
+  last_seen: string | null;
   active_tasks: number;
   max_tasks: number;
 }
 
 export interface BotStatus {
-  state: 'working' | 'idle' | 'error' | 'unknown';
+  state: 'working' | 'idle' | 'error' | 'sleep' | 'unknown';
   message: string;
   external_key: string | null;
   source_type: string | null;
@@ -61,6 +62,7 @@ export interface BotStatus {
   instance_id: string | null;
   cycle_start: string | null;
   updated_at: string;
+  last_seen?: string | null;
 }
 
 export interface CycleEntry {

--- a/dashboard/src/utils.test.ts
+++ b/dashboard/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { timeAgo, formatDuration, formatTokens, sourceUrl, displayKey } from './utils';
+import { timeAgo, formatDuration, formatTokens, sourceUrl, displayKey, effectiveState } from './utils';
 
 describe('timeAgo', () => {
   afterEach(() => {
@@ -90,5 +90,47 @@ describe('displayKey', () => {
 
   it('returns empty string when no external_key', () => {
     expect(displayKey({ external_key: null })).toBe('');
+  });
+});
+
+describe('effectiveState', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns working as-is', () => {
+    expect(effectiveState({ state: 'working', updated_at: '2025-01-01T00:00:00Z' })).toBe('working');
+  });
+
+  it('returns error as-is', () => {
+    expect(effectiveState({ state: 'error', updated_at: '2025-01-01T00:00:00Z' })).toBe('error');
+  });
+
+  it('returns idle when last_seen is recent', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T12:00:30Z'));
+    expect(effectiveState({ state: 'idle', last_seen: '2025-01-01T12:00:00Z', updated_at: '2025-01-01T11:00:00Z' })).toBe('idle');
+  });
+
+  it('returns sleep when last_seen is stale and state is idle', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T12:05:00Z'));
+    expect(effectiveState({ state: 'idle', last_seen: '2025-01-01T12:00:00Z', updated_at: '2025-01-01T11:00:00Z' })).toBe('sleep');
+  });
+
+  it('falls back to updated_at when last_seen is null', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T12:05:00Z'));
+    expect(effectiveState({ state: 'idle', last_seen: null, updated_at: '2025-01-01T12:00:00Z' })).toBe('sleep');
+  });
+
+  it('returns idle when no timestamps available', () => {
+    expect(effectiveState({ state: 'idle' })).toBe('idle');
+  });
+
+  it('does not convert working to sleep even if stale', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T12:05:00Z'));
+    expect(effectiveState({ state: 'working', last_seen: '2025-01-01T12:00:00Z', updated_at: '2025-01-01T11:00:00Z' })).toBe('working');
   });
 });

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -54,3 +54,24 @@ export function effectiveState(instance: { state: string; last_seen?: string | n
   }
   return instance.state as DisplayState;
 }
+
+export function stateLabelColor(state: DisplayState): 'orange' | 'red' | 'green' | 'grey' {
+  if (state === 'working') return 'orange';
+  if (state === 'error') return 'red';
+  if (state === 'idle') return 'green';
+  return 'grey';
+}
+
+export function stateIconStatus(state: DisplayState): 'warning' | 'danger' | 'success' | 'custom' {
+  if (state === 'working') return 'warning';
+  if (state === 'error') return 'danger';
+  if (state === 'idle') return 'success';
+  return 'custom';
+}
+
+export function stateBorderColor(state: DisplayState): string {
+  if (state === 'working') return 'var(--yellow)';
+  if (state === 'error') return 'var(--red)';
+  if (state === 'idle') return 'var(--green)';
+  return 'var(--text-dim)';
+}

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -39,3 +39,18 @@ export function sourceUrl(item: SourceLike): string | null {
 export function displayKey(item: SourceLike): string {
   return item.external_key || '';
 }
+
+const SLEEP_THRESHOLD_MS = 60_000; // 60 seconds
+
+export type DisplayState = 'working' | 'idle' | 'error' | 'sleep' | 'unknown';
+
+export function effectiveState(instance: { state: string; last_seen?: string | null; updated_at?: string }): DisplayState {
+  if (instance.state === 'idle') {
+    const ref = instance.last_seen || instance.updated_at;
+    if (ref) {
+      const age = Date.now() - new Date(ref).getTime();
+      if (age > SLEEP_THRESHOLD_MS) return 'sleep';
+    }
+  }
+  return instance.state as DisplayState;
+}

--- a/dashboard/tests/fixtures/api_payloads.py
+++ b/dashboard/tests/fixtures/api_payloads.py
@@ -329,6 +329,7 @@ BOT_STATUS = {
     "instance_id": "dev-bot",
     "updated_at": "2026-07-22T10:00:00Z",
     "cycle_start": "2026-07-22T09:55:00Z",
+    "last_seen": "2026-07-22T10:00:00Z",
 }
 
 TASK_CYCLE_GROUPS = [

--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -516,6 +516,40 @@ After deploying, verify in order:
 
 ---
 
+## Slack Workspace Configuration
+
+Bot instances connect to a specific Slack workspace via their `SLACK_USER_TOKEN`. The token determines which workspace the bot operates in — production or sandbox.
+
+### Production vs Sandbox
+
+| | Production | Sandbox |
+|---|---|---|
+| Workspace | `redhat.enterprise.slack.com` | `redhat-sandbox.enterprise.slack.com` |
+| Token | `xoxp-...` from production Vault | `xoxp-...` from sandbox workspace |
+| Channel IDs | Different per workspace | Different per workspace |
+| Custom emoji | Workspace-specific | Must exist in sandbox too |
+
+The `hcc-framework-agent-dev` instance connects to the **production** Slack grid. To test Slack features against the sandbox workspace, you need either:
+
+- **Option A: Separate dev instance** — deploy a new instance with sandbox-specific Vault secrets (sandbox `SLACK_USER_TOKEN`, sandbox channel IDs, sandbox emoji names). This is the cleanest approach.
+- **Option B: Direct production testing** — skip sandbox entirely and test in the existing dev instance against production Slack (requires Slack app approval for production workspace).
+
+### Slack Environment Variables
+
+When pointing an instance at a different workspace, update all Slack-related parameters:
+
+| Variable | Description |
+|----------|-------------|
+| `SLACK_USER_TOKEN` | `xoxp-...` token for the target workspace |
+| `SLACK_OPEN_PRS_CHANNEL` | Channel ID for the Open PRs thread (workspace-specific) |
+| `SLACK_EMOJI_APPROVED` | Emoji name for approved PRs (e.g. `lgtm-5363`) |
+| `SLACK_EMOJI_MERGED` | Emoji name for merged PRs (e.g. `merged2`) |
+| `SLACK_WEBHOOK_URL` | Webhook URL (also workspace-specific) |
+
+Channel IDs and custom emoji names differ between workspaces — you cannot reuse production values in sandbox.
+
+---
+
 ## Gotchas
 
 ### NetworkPolicy proxy label must be `devbot-proxy`

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -595,6 +595,7 @@ def _instance_row(r, active_tasks: int = 0) -> dict:
         "last_idle_reminder_sent_at": (
             r["last_idle_reminder_sent_at"].isoformat() if r.get("last_idle_reminder_sent_at") else None
         ),
+        "last_seen": r["last_seen"].isoformat() if r.get("last_seen") else None,
     }
 
 
@@ -1276,6 +1277,12 @@ async def api_instance_wake_check(request: Request) -> JSONResponse:
     instance_id = request.path_params.get("instance_id")
     if not instance_id:
         return JSONResponse({"error": "missing instance_id"}, status_code=400)
+
+    pool = get_pool()
+    await pool.execute(
+        "UPDATE bot_instances SET last_seen = NOW() WHERE instance_id = $1",
+        instance_id,
+    )
 
     if instance_id in wake_signals:
         wake_signals.discard(instance_id)

--- a/memory-server/bot_memory_server/schema.sql
+++ b/memory-server/bot_memory_server/schema.sql
@@ -160,12 +160,14 @@ CREATE TABLE IF NOT EXISTS bot_instances (
     cycle_start                 TIMESTAMPTZ,
     updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     idle_consecutive_cycles     INTEGER NOT NULL DEFAULT 0,
-    last_idle_reminder_sent_at  TIMESTAMPTZ
+    last_idle_reminder_sent_at  TIMESTAMPTZ,
+    last_seen                   TIMESTAMPTZ
 );
 
 -- Idempotent column additions for existing databases
 ALTER TABLE bot_instances ADD COLUMN IF NOT EXISTS idle_consecutive_cycles    INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE bot_instances ADD COLUMN IF NOT EXISTS last_idle_reminder_sent_at TIMESTAMPTZ;
+ALTER TABLE bot_instances ADD COLUMN IF NOT EXISTS last_seen TIMESTAMPTZ;
 
 -- Migrate existing bot_status row into bot_instances (if instance_id is set)
 DO $$ BEGIN

--- a/memory-server/tests/test_instance_sleep.py
+++ b/memory-server/tests/test_instance_sleep.py
@@ -1,0 +1,83 @@
+"""Tests for instance sleep heartbeat (last_seen column and wake-poll update)."""
+
+from datetime import datetime, timezone
+
+import pytest
+from bot_memory_server.api import _instance_row
+from conftest import SCHEMA_PATH
+
+UPDATE_LAST_SEEN_SQL = """
+    UPDATE bot_instances SET last_seen = NOW() WHERE instance_id = $1
+"""
+
+
+async def _apply_schema(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+
+
+async def _insert_instance(db, instance_id, **kwargs):
+    await db.execute(
+        """INSERT INTO bot_instances (instance_id, state, message, repo)
+           VALUES ($1, $2, $3, $4)""",
+        instance_id,
+        kwargs.get("state", "idle"),
+        kwargs.get("message", ""),
+        kwargs.get("repo", "test-repo"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_last_seen_column_exists(db):
+    await _apply_schema(db)
+    await _insert_instance(db, "inst-1")
+    row = await db.fetchrow("SELECT * FROM bot_instances WHERE instance_id = $1", "inst-1")
+    assert row["last_seen"] is None
+
+
+@pytest.mark.asyncio
+async def test_last_seen_updated_on_wake_poll(db):
+    await _apply_schema(db)
+    await _insert_instance(db, "inst-2")
+    before = datetime.now(timezone.utc)
+    await db.execute(UPDATE_LAST_SEEN_SQL, "inst-2")
+    row = await db.fetchrow("SELECT * FROM bot_instances WHERE instance_id = $1", "inst-2")
+    assert row["last_seen"] is not None
+    assert row["last_seen"] >= before
+
+
+@pytest.mark.asyncio
+async def test_last_seen_in_instance_row(db):
+    await _apply_schema(db)
+    ts = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    await db.execute(
+        """INSERT INTO bot_instances (instance_id, state, message, repo, last_seen)
+           VALUES ($1, $2, $3, $4, $5)""",
+        "inst-3",
+        "idle",
+        "",
+        "test-repo",
+        ts,
+    )
+    row = await db.fetchrow("SELECT * FROM bot_instances WHERE instance_id = $1", "inst-3")
+    result = _instance_row(row)
+    assert result["last_seen"] == ts.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_last_seen_null_when_not_set(db):
+    await _apply_schema(db)
+    await _insert_instance(db, "inst-4")
+    row = await db.fetchrow("SELECT * FROM bot_instances WHERE instance_id = $1", "inst-4")
+    result = _instance_row(row)
+    assert result["last_seen"] is None
+
+
+@pytest.mark.asyncio
+async def test_last_seen_schema_migration_idempotent(db):
+    schema = SCHEMA_PATH.read_text()
+    await db.execute(schema)
+    await db.execute(schema)
+    await _insert_instance(db, "inst-5")
+    row = await db.fetchrow("SELECT * FROM bot_instances WHERE instance_id = $1", "inst-5")
+    assert row["last_seen"] is None

--- a/mock_api.py
+++ b/mock_api.py
@@ -119,9 +119,24 @@ class Handler(BaseHTTPRequestHandler):
                         "repo": BOT_STATUS["repo"],
                         "cycle_start": BOT_STATUS["cycle_start"],
                         "updated_at": BOT_STATUS["updated_at"],
+                        "last_seen": BOT_STATUS.get("last_seen"),
                         "active_tasks": sum(1 for t in TASKS.values() if t["status"] in ACTIVE_STATUSES),
                         "max_tasks": MAX_ACTIVE,
-                    }
+                    },
+                    {
+                        "instance_id": "staging-bot",
+                        "state": "idle",
+                        "message": "",
+                        "external_key": None,
+                        "source_type": "jira",
+                        "source_url": None,
+                        "repo": None,
+                        "cycle_start": None,
+                        "updated_at": "2026-07-20T08:00:00Z",
+                        "last_seen": "2026-07-20T08:00:00Z",
+                        "active_tasks": 0,
+                        "max_tasks": 5,
+                    },
                 ]
             )
 


### PR DESCRIPTION
## Summary

- Add `last_seen` heartbeat column to the memory-server status API for tracking when a bot last reported in
- Detect "sleep" state in the dashboard when a bot has no running pods (scaled to zero by KEDA) — shows a distinct sleep icon, muted styling, and "Sleeping — no pods running" banner
- Extract duplicated state color/icon helpers from `BotBanner` and `Instances` into shared `utils.ts`
- Document Slack workspace configuration (production vs sandbox) in the onboarding guide

## Test plan

- [x] 797 tests pass (`uv run pytest`)
- [x] `ruff check .` and `ruff format --check .` clean
- [x] New unit tests for `last_seen` heartbeat API (83 lines)
- [x] New unit tests for extracted state color helpers
- [ ] Manual verification: dashboard shows sleep state when bot pods are scaled to zero

---