### PR TITLE
feat: add shared API response schema validation (REHOR-80)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -27,15 +27,18 @@
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^26.1.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/three": "^0.185.0",
         "@vitejs/plugin-react": "^6.0.1",
+        "ajv": "^8.20.0",
         "jsdom": "^29.1.1",
         "typescript": "^7.0.0",
         "vite": "^8.0.10",
         "vitest": "^4.1.10",
-        "ws": "^8.21.0"
+        "ws": "^8.21.0",
+        "yaml": "^2.7.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1014,6 +1017,16 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
@@ -1559,6 +1572,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2055,6 +2085,30 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2341,6 +2395,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -4172,6 +4233,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -4595,6 +4663,22 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -33,14 +33,17 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^26.1.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/three": "^0.185.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "ajv": "^8.20.0",
     "jsdom": "^29.1.1",
     "typescript": "^7.0.0",
     "vite": "^8.0.10",
     "vitest": "^4.1.10",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "yaml": "^2.7.0"
   }
 }

--- a/dashboard/src/test/fixtures.json
+++ b/dashboard/src/test/fixtures.json
@@ -3,6 +3,7 @@
     "RHCLOUD-001": {
       "id": 1,
       "external_key": "RHCLOUD-001",
+      "jira_key": "RHCLOUD-001",
       "source_type": "jira",
       "source_url": "https://issues.redhat.com/browse/RHCLOUD-001",
       "artifacts": [
@@ -42,6 +43,7 @@
     "RHCLOUD-002": {
       "id": 2,
       "external_key": "RHCLOUD-002",
+      "jira_key": "RHCLOUD-002",
       "source_type": "jira",
       "source_url": "https://issues.redhat.com/browse/RHCLOUD-002",
       "artifacts": [
@@ -77,6 +79,7 @@
     "RHCLOUD-003": {
       "id": 3,
       "external_key": "RHCLOUD-003",
+      "jira_key": "RHCLOUD-003",
       "source_type": "jira",
       "source_url": "https://issues.redhat.com/browse/RHCLOUD-003",
       "artifacts": [
@@ -112,6 +115,7 @@
     "RHCLOUD-004": {
       "id": 4,
       "external_key": "RHCLOUD-004",
+      "jira_key": "RHCLOUD-004",
       "source_type": "jira",
       "source_url": "https://issues.redhat.com/browse/RHCLOUD-004",
       "artifacts": [
@@ -151,6 +155,7 @@
     "RHCLOUD-005": {
       "id": 5,
       "external_key": "RHCLOUD-005",
+      "jira_key": "RHCLOUD-005",
       "source_type": "jira",
       "source_url": "https://issues.redhat.com/browse/RHCLOUD-005",
       "artifacts": [
@@ -186,6 +191,7 @@
     "RHCLOUD-006": {
       "id": 6,
       "external_key": "RHCLOUD-006",
+      "jira_key": "RHCLOUD-006",
       "source_type": "jira",
       "source_url": "https://issues.redhat.com/browse/RHCLOUD-006",
       "artifacts": [
@@ -468,6 +474,34 @@
       "repo": "frontend",
       "work_type": "implementation",
       "summary": "Completed work on RHCLOUD-004"
+    }
+  ],
+  "dailyCosts": [
+    {
+      "day": "2026-07-01",
+      "cycles": 2,
+      "total_cost": 0.2,
+      "input_tokens": 20000,
+      "output_tokens": 10000,
+      "cache_read": 4000,
+      "cache_write": 2000,
+      "total_duration": 600000,
+      "total_turns": 16,
+      "idle_cycles": 0,
+      "error_cycles": 0
+    },
+    {
+      "day": "2026-07-02",
+      "cycles": 1,
+      "total_cost": 0.15,
+      "input_tokens": 10000,
+      "output_tokens": 5000,
+      "cache_read": 2000,
+      "cache_write": 1000,
+      "total_duration": 300000,
+      "total_turns": 8,
+      "idle_cycles": 0,
+      "error_cycles": 0
     }
   ],
   "embeddings": [

--- a/dashboard/src/test/schema-conformance.test.ts
+++ b/dashboard/src/test/schema-conformance.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Validate TypeScript test fixtures against OpenAPI component schemas.
+ *
+ * If the backend response shape changes and the OpenAPI spec is updated,
+ * these tests fail until the TS fixtures match — preventing drift between
+ * the Python backend and the React dashboard.
+ */
+
+import Ajv from 'ajv';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+import { describe, expect, it } from 'vitest';
+import fixtures from './fixtures.json';
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const specPath = resolve(thisDir, '../../../shared/openapi.yaml');
+const spec = parse(readFileSync(specPath, 'utf8'));
+const schemas = spec.components.schemas as Record<string, any>;
+
+function resolveRefs(schema: any, allSchemas: Record<string, any>): any {
+  if (Array.isArray(schema)) return schema.map((item) => resolveRefs(item, allSchemas));
+  if (typeof schema !== 'object' || schema === null) return schema;
+  if ('$ref' in schema) {
+    const refName = (schema.$ref as string).split('/').pop()!;
+    return resolveRefs(allSchemas[refName], allSchemas);
+  }
+  const result: Record<string, any> = {};
+  for (const [k, v] of Object.entries(schema)) {
+    if (k === 'nullable' && v === true) continue;
+    result[k] = resolveRefs(v, allSchemas);
+  }
+  if (schema.nullable === true) {
+    if ('type' in result) {
+      result.type = [result.type, 'null'];
+    } else if ('allOf' in result) {
+      result.oneOf = [...result.allOf, { type: 'null' }];
+      delete result.allOf;
+    }
+  }
+  return result;
+}
+
+const ajv = new Ajv({ allErrors: true });
+
+function compileSchema(name: string) {
+  const resolved = resolveRefs(schemas[name], schemas);
+  return ajv.compile(resolved);
+}
+
+const validateTask = compileSchema('TaskItem');
+const validateMemory = compileSchema('MemoryItem');
+const validateCycleRun = compileSchema('CycleRunItem');
+const validateCycleEntry = compileSchema('CycleEntryItem');
+const validatePaginated = compileSchema('PaginatedResponse');
+const validateCostsResponse = compileSchema('CostsResponse');
+
+function expectValid(validate: ReturnType<typeof ajv.compile>, data: unknown, label: string) {
+  const valid = validate(data);
+  if (!valid) {
+    const errors = validate.errors?.map((e) => `${e.instancePath} ${e.message}`).join('; ');
+    expect.fail(`${label}: ${errors}`);
+  }
+}
+
+describe('Task item schema conformance', () => {
+  it.each(Object.entries(fixtures.tasks))('task %s matches schema', (key, task) => {
+    expectValid(validateTask, task, `task ${key}`);
+  });
+
+  it('task has jira_key matching external_key', () => {
+    const task = fixtures.tasks['RHCLOUD-001'] as Record<string, unknown>;
+    expect(task.jira_key).toBe(task.external_key);
+  });
+});
+
+describe('Memory item schema conformance', () => {
+  it.each(fixtures.memories.map((m, i) => [i, m]))('memory %i matches schema', (idx, memory) => {
+    expectValid(validateMemory, memory, `memory ${idx}`);
+  });
+});
+
+describe('Cycle run item schema conformance', () => {
+  it.each(fixtures.cycleRuns.map((cr, i) => [i, cr]))('cycleRun %i matches schema', (idx, run) => {
+    expectValid(validateCycleRun, run, `cycleRun ${idx}`);
+  });
+});
+
+describe('Cycle entry (cost) item schema conformance', () => {
+  it.each(fixtures.costs.map((c, i) => [i, c]))('cost %i matches schema', (idx, cost) => {
+    expectValid(validateCycleEntry, cost, `cost ${idx}`);
+  });
+});
+
+describe('Paginated envelope schema conformance', () => {
+  it('tasks paginated envelope', () => {
+    const envelope = {
+      items: Object.values(fixtures.tasks),
+      total: Object.keys(fixtures.tasks).length,
+      limit: 20,
+      offset: 0,
+    };
+    expectValid(validatePaginated, envelope, 'tasks envelope');
+  });
+
+  it('memories paginated envelope', () => {
+    const envelope = {
+      items: fixtures.memories,
+      total: fixtures.memories.length,
+      limit: 20,
+      offset: 0,
+    };
+    expectValid(validatePaginated, envelope, 'memories envelope');
+  });
+
+  it('cycle runs paginated envelope', () => {
+    const envelope = {
+      items: fixtures.cycleRuns,
+      total: fixtures.cycleRuns.length,
+      limit: 50,
+      offset: 0,
+    };
+    expectValid(validatePaginated, envelope, 'cycle runs envelope');
+  });
+
+  it('rejects extra fields in envelope', () => {
+    const bad = { items: [], total: 0, limit: 20, offset: 0, extra: true };
+    expect(validatePaginated(bad)).toBe(false);
+  });
+});
+
+describe('Costs response schema conformance', () => {
+  it('costs response with daily data', () => {
+    const response = {
+      items: fixtures.costs,
+      daily: fixtures.dailyCosts,
+    };
+    expectValid(validateCostsResponse, response, 'costs response');
+  });
+
+  it('rejects paginated fields on costs', () => {
+    const bad = { items: [], daily: [], total: 0, limit: 200, offset: 0 };
+    expect(validateCostsResponse(bad)).toBe(false);
+  });
+});

--- a/dashboard/tests/fixtures/api_payloads.py
+++ b/dashboard/tests/fixtures/api_payloads.py
@@ -17,6 +17,7 @@ def task(
     return {
         "id": id,
         "external_key": key,
+        "jira_key": key,
         "source_type": "jira",
         "source_url": f"https://issues.redhat.com/browse/{key}",
         "artifacts": [
@@ -358,6 +359,35 @@ TASK_CYCLE_GROUPS = [
         "total_tokens": 45000,
         "first_cycle": "2026-07-02T10:00:00Z",
         "last_cycle": "2026-07-02T18:00:00Z",
+    },
+]
+
+DAILY_COSTS = [
+    {
+        "day": "2026-07-01",
+        "cycles": 2,
+        "total_cost": 0.20,
+        "input_tokens": 20000,
+        "output_tokens": 10000,
+        "cache_read": 4000,
+        "cache_write": 2000,
+        "total_duration": 600000,
+        "total_turns": 16,
+        "idle_cycles": 0,
+        "error_cycles": 0,
+    },
+    {
+        "day": "2026-07-02",
+        "cycles": 1,
+        "total_cost": 0.15,
+        "input_tokens": 10000,
+        "output_tokens": 5000,
+        "cache_read": 2000,
+        "cache_write": 1000,
+        "total_duration": 300000,
+        "total_turns": 8,
+        "idle_cycles": 0,
+        "error_cycles": 0,
     },
 ]
 

--- a/dashboard/tests/fixtures/generate_json.py
+++ b/dashboard/tests/fixtures/generate_json.py
@@ -17,6 +17,7 @@ from api_payloads import (
     BOT_STATUS,
     COSTS,
     CYCLE_RUNS,
+    DAILY_COSTS,
     EMBEDDINGS,
     MEMORIES,
     TAGS,
@@ -25,6 +26,97 @@ from api_payloads import (
 )
 
 OUTPUT = Path(__file__).resolve().parent.parent.parent / "src" / "test" / "fixtures.json"
+OPENAPI_PATH = Path(__file__).resolve().parent.parent.parent.parent / "shared" / "openapi.yaml"
+
+
+def _resolve_refs(schema: dict, all_schemas: dict) -> dict:
+    """Recursively resolve $ref pointers within an OpenAPI component schema."""
+    if isinstance(schema, dict):
+        if "$ref" in schema:
+            ref_name = schema["$ref"].split("/")[-1]
+            return _resolve_refs(all_schemas[ref_name], all_schemas)
+        result = {}
+        for k, v in schema.items():
+            if k == "nullable" and v is True:
+                continue
+            result[k] = _resolve_refs(v, all_schemas)
+        if schema.get("nullable"):
+            if "type" in result:
+                result["type"] = [result["type"], "null"]
+            elif "allOf" in result:
+                result["oneOf"] = [*result.pop("allOf"), {"type": "null"}]
+        return result
+    if isinstance(schema, list):
+        return [_resolve_refs(item, all_schemas) for item in schema]
+    return schema
+
+
+def _validate_fixtures(data):
+    """Validate fixture data against OpenAPI component schemas."""
+    import jsonschema
+    import yaml
+
+    spec = yaml.safe_load(OPENAPI_PATH.read_text())
+    all_schemas = spec["components"]["schemas"]
+
+    def resolve(name):
+        return _resolve_refs(all_schemas[name], all_schemas)
+
+    task_schema = resolve("TaskItem")
+    memory_schema = resolve("MemoryItem")
+    cycle_run_schema = resolve("CycleRunItem")
+    cycle_entry_schema = resolve("CycleEntryItem")
+    paginated_schema = resolve("PaginatedResponse")
+    costs_resp_schema = resolve("CostsResponse")
+
+    errors = []
+
+    for key, t in data["tasks"].items():
+        try:
+            jsonschema.validate(t, task_schema)
+        except jsonschema.ValidationError as e:
+            errors.append(f"task {key}: {e.message}")
+
+    for i, m in enumerate(data["memories"]):
+        try:
+            jsonschema.validate(m, memory_schema)
+        except jsonschema.ValidationError as e:
+            errors.append(f"memory {i}: {e.message}")
+
+    for i, cr in enumerate(data["cycleRuns"]):
+        try:
+            jsonschema.validate(cr, cycle_run_schema)
+        except jsonschema.ValidationError as e:
+            errors.append(f"cycleRun {i}: {e.message}")
+
+    for i, c in enumerate(data["costs"]):
+        try:
+            jsonschema.validate(c, cycle_entry_schema)
+        except jsonschema.ValidationError as e:
+            errors.append(f"cost {i}: {e.message}")
+
+    envelope = {"items": list(data["tasks"].values()), "total": len(data["tasks"]), "limit": 20, "offset": 0}
+    try:
+        jsonschema.validate(envelope, paginated_schema)
+    except jsonschema.ValidationError as e:
+        errors.append(f"paginated envelope: {e.message}")
+
+    costs_envelope = {"items": data["costs"], "daily": data["dailyCosts"]}
+    try:
+        jsonschema.validate(costs_envelope, costs_resp_schema)
+    except jsonschema.ValidationError as e:
+        errors.append(f"costs response: {e.message}")
+
+    if errors:
+        print("Schema validation errors:")
+        for err in errors:
+            print(f"  - {err}")
+        raise SystemExit(1)
+
+    print(
+        f"Validated {len(data['tasks'])} tasks, {len(data['memories'])} memories, "
+        f"{len(data['cycleRuns'])} cycle runs, {len(data['costs'])} costs against OpenAPI schemas"
+    )
 
 
 def main():
@@ -33,12 +125,16 @@ def main():
         "memories": MEMORIES,
         "cycleRuns": CYCLE_RUNS,
         "costs": COSTS,
+        "dailyCosts": DAILY_COSTS,
         "embeddings": EMBEDDINGS,
         "tags": TAGS,
         "analytics": ANALYTICS,
         "botStatus": BOT_STATUS,
         "taskCycleGroups": TASK_CYCLE_GROUPS,
     }
+
+    _validate_fixtures(data)
+
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(json.dumps(data, indent=2) + "\n")
     print(f"Wrote {OUTPUT}")

--- a/dashboard/tests/test_mock_route_coverage.py
+++ b/dashboard/tests/test_mock_route_coverage.py
@@ -1,0 +1,104 @@
+"""Ensure mock API routes match shared/openapi.yaml."""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MOCK_API_PATH = REPO_ROOT / "mock_api.py"
+OPENAPI_PATH = REPO_ROOT / "shared" / "openapi.yaml"
+
+METHOD_BODY_RE = re.compile(
+    r"def (do_GET|do_POST|do_DELETE)\(self\):(.*?)(?=\n    def |\nif __name__)",
+    re.DOTALL,
+)
+EXACT_PATH_RE = re.compile(r"path == \"([^\"]+)\"")
+# Bot polling endpoints — not needed by the dashboard dev mock.
+OPENAPI_SKIP_GET_PATHS = {
+    "/health",
+    "/api/instances/{instance_id}",
+    "/api/instances/{instance_id}/wake",
+}
+
+
+def _extract_method_bodies() -> dict[str, str]:
+    source = MOCK_API_PATH.read_text()
+    return dict(METHOD_BODY_RE.findall(source))
+
+
+def _extract_mock_routes() -> set[tuple[str, str]]:
+    bodies = _extract_method_bodies()
+    routes: set[tuple[str, str]] = set()
+
+    for path in EXACT_PATH_RE.findall(bodies.get("do_GET", "")):
+        routes.add((path, "GET"))
+
+    get_body = bodies.get("do_GET", "")
+    if 'path.startswith("/api/memories/")' in get_body:
+        routes.add(("/api/memories/{id}", "GET"))
+    if 'path.startswith("/api/cycle-runs/")' in get_body and "/transcript" in get_body:
+        routes.add(("/api/cycle-runs/{id}/transcript", "GET"))
+
+    for path in EXACT_PATH_RE.findall(bodies.get("do_POST", "")):
+        routes.add((path, "POST"))
+
+    post_body = bodies.get("do_POST", "")
+    if 'parts[3] == "pause"' in post_body:
+        routes.add(("/api/tasks/{key}/pause", "POST"))
+    if 'parts[3] == "unpause"' in post_body:
+        routes.add(("/api/tasks/{key}/unpause", "POST"))
+    if 'parts[3] == "unarchive"' in post_body:
+        routes.add(("/api/tasks/{key}/unarchive", "POST"))
+    if 'parts[3] == "wake"' in post_body:
+        routes.add(("/api/instances/{instance_id}/wake", "POST"))
+
+    delete_body = bodies.get("do_DELETE", "")
+    if 'parts[1] == "tasks"' in delete_body:
+        routes.add(("/api/tasks/{key}", "DELETE"))
+    if 'parts[1] == "memories"' in delete_body:
+        routes.add(("/api/memories/{id}", "DELETE"))
+
+    return routes
+
+
+def _extract_openapi_routes() -> set[tuple[str, str]]:
+    spec = yaml.safe_load(OPENAPI_PATH.read_text())
+    routes: set[tuple[str, str]] = set()
+    for path, path_item in spec["paths"].items():
+        for method, _operation in path_item.items():
+            if method in ("get", "post", "delete", "patch", "put"):
+                routes.add((path, method.upper()))
+    return routes
+
+
+def _extract_openapi_get_routes() -> set[tuple[str, str]]:
+    return {
+        (path, method)
+        for path, method in _extract_openapi_routes()
+        if method == "GET" and path not in OPENAPI_SKIP_GET_PATHS
+    }
+
+
+MOCK_ROUTES = _extract_mock_routes()
+OPENAPI_ROUTES = _extract_openapi_routes()
+OPENAPI_GET_ROUTES = _extract_openapi_get_routes()
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    sorted(MOCK_ROUTES),
+    ids=[f"{method} {path}" for path, method in sorted(MOCK_ROUTES)],
+)
+def test_every_mock_route_has_openapi_entry(path, method):
+    assert (path, method) in OPENAPI_ROUTES
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    sorted(OPENAPI_GET_ROUTES),
+    ids=[f"{method} {path}" for path, method in sorted(OPENAPI_GET_ROUTES)],
+)
+def test_every_openapi_get_route_has_mock(path, method):
+    assert (path, method) in MOCK_ROUTES

--- a/dashboard/tests/test_schema_conformance.py
+++ b/dashboard/tests/test_schema_conformance.py
@@ -1,0 +1,177 @@
+"""Validate dashboard test fixtures against OpenAPI component schemas.
+
+If a backend serializer changes the response shape and the OpenAPI spec
+is updated, these tests fail until the fixtures are updated to match —
+preventing frontend/backend drift.
+"""
+
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+from fixtures.api_payloads import (
+    COSTS,
+    CYCLE_RUNS,
+    DAILY_COSTS,
+    MEMORIES,
+    TASKS,
+    cycle_entry,
+    cycle_run,
+    memory,
+    task,
+)
+
+OPENAPI_PATH = Path(__file__).resolve().parent.parent.parent / "shared" / "openapi.yaml"
+
+
+def _load_schemas() -> dict[str, dict]:
+    spec = yaml.safe_load(OPENAPI_PATH.read_text())
+    return spec["components"]["schemas"]
+
+
+_SCHEMAS = _load_schemas()
+
+
+def _resolve_refs(schema: dict, all_schemas: dict) -> dict:
+    """Recursively resolve $ref pointers within an OpenAPI component schema."""
+    if isinstance(schema, dict):
+        if "$ref" in schema:
+            ref_name = schema["$ref"].split("/")[-1]
+            return _resolve_refs(all_schemas[ref_name], all_schemas)
+        result = {}
+        for k, v in schema.items():
+            if k == "nullable" and v is True:
+                continue
+            result[k] = _resolve_refs(v, all_schemas)
+        if schema.get("nullable"):
+            if "type" in result:
+                result["type"] = [result["type"], "null"]
+            elif "allOf" in result:
+                result["oneOf"] = [*result.pop("allOf"), {"type": "null"}]
+        return result
+    if isinstance(schema, list):
+        return [_resolve_refs(item, all_schemas) for item in schema]
+    return schema
+
+
+def _validate(instance, schema_name: str):
+    schema = _resolve_refs(_SCHEMAS[schema_name], _SCHEMAS)
+    jsonschema.validate(instance, schema)
+
+
+# --------------- item factory conformance ---------------
+
+
+class TestTaskFixtureConformance:
+    def test_basic_task_fixture(self):
+        t = task(1, "TEST-001", "Test", "in_progress")
+        _validate(t, "TaskItem")
+
+    def test_task_has_jira_key(self):
+        t = task(1, "TEST-001", "Test", "in_progress")
+        assert "jira_key" in t
+        assert t["jira_key"] == t["external_key"]
+
+    def test_task_paused_fixture(self):
+        t = task(1, "TEST-001", "Test", "paused", paused_reason="Blocked")
+        _validate(t, "TaskItem")
+
+    def test_task_done_fixture(self):
+        t = task(1, "TEST-001", "Test", "done")
+        _validate(t, "TaskItem")
+
+    @pytest.mark.parametrize("key", list(TASKS.keys()))
+    def test_all_default_tasks(self, key):
+        _validate(TASKS[key], "TaskItem")
+
+
+class TestMemoryFixtureConformance:
+    def test_basic_memory_fixture(self):
+        m = memory(1, "bug", "Title", "Content")
+        _validate(m, "MemoryItem")
+
+    def test_memory_with_tags(self):
+        m = memory(1, "bug", "Title", "Content", tags=["a", "b"])
+        _validate(m, "MemoryItem")
+
+    @pytest.mark.parametrize("idx", range(len(MEMORIES)))
+    def test_all_default_memories(self, idx):
+        _validate(MEMORIES[idx], "MemoryItem")
+
+
+class TestCycleRunFixtureConformance:
+    def test_basic_cycle_run_fixture(self):
+        cr = cycle_run(1, 42, "implementation")
+        _validate(cr, "CycleRunItem")
+
+    def test_cycle_run_null_task(self):
+        cr = cycle_run(1, None, "idle_check")
+        _validate(cr, "CycleRunItem")
+
+    @pytest.mark.parametrize("idx", range(len(CYCLE_RUNS)))
+    def test_all_default_cycle_runs(self, idx):
+        _validate(CYCLE_RUNS[idx], "CycleRunItem")
+
+
+class TestCycleEntryFixtureConformance:
+    def test_basic_cycle_entry_fixture(self):
+        c = cycle_entry(1, "test-label")
+        _validate(c, "CycleEntryItem")
+
+    def test_cycle_entry_with_optionals(self):
+        c = cycle_entry(1, "test", external_key="KEY-1", repo="myrepo")
+        _validate(c, "CycleEntryItem")
+
+    @pytest.mark.parametrize("idx", range(len(COSTS)))
+    def test_all_default_costs(self, idx):
+        _validate(COSTS[idx], "CycleEntryItem")
+
+
+# --------------- envelope conformance ---------------
+
+
+class TestPaginatedEnvelopeConformance:
+    def test_tasks_envelope(self):
+        envelope = {
+            "items": list(TASKS.values()),
+            "total": len(TASKS),
+            "limit": 20,
+            "offset": 0,
+        }
+        _validate(envelope, "PaginatedResponse")
+
+    def test_memories_envelope(self):
+        envelope = {
+            "items": MEMORIES,
+            "total": len(MEMORIES),
+            "limit": 20,
+            "offset": 0,
+        }
+        _validate(envelope, "PaginatedResponse")
+
+    def test_cycle_runs_envelope(self):
+        envelope = {
+            "items": CYCLE_RUNS,
+            "total": len(CYCLE_RUNS),
+            "limit": 50,
+            "offset": 0,
+        }
+        _validate(envelope, "PaginatedResponse")
+
+
+class TestCostsResponseConformance:
+    def test_costs_envelope(self):
+        response = {"items": COSTS, "daily": DAILY_COSTS}
+        _validate(response, "CostsResponse")
+
+    def test_costs_not_paginated(self):
+        response = {
+            "items": COSTS,
+            "daily": DAILY_COSTS,
+            "total": len(COSTS),
+            "limit": 200,
+            "offset": 0,
+        }
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            _validate(response, "CostsResponse")

--- a/memory-server/Dockerfile
+++ b/memory-server/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app/dashboard
 COPY dashboard/package.json dashboard/package-lock.json* ./
 RUN npm ci
 COPY dashboard/ .
+COPY shared/ /app/shared/
 RUN npm run build
 
 # Stage 2: Python memory server

--- a/memory-server/pyproject.toml
+++ b/memory-server/pyproject.toml
@@ -26,6 +26,8 @@ test = [
     "pytest-asyncio>=0.24",
     "httpx>=0.27",
     "pip-audit>=2.7",
+    "jsonschema>=4.20",
+    "pyyaml>=6.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/memory-server/tests/test_api_schemas.py
+++ b/memory-server/tests/test_api_schemas.py
@@ -1,0 +1,367 @@
+"""Validate that API serializer output conforms to OpenAPI component schemas.
+
+These tests catch drift between the backend response shape and the
+shared contract in shared/openapi.yaml.  If a serializer field is added,
+removed, or renamed, these tests fail until the spec is updated —
+which in turn breaks the dashboard fixture tests, enforcing cross-side
+consistency.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+from bot_memory_server.api import _cycle, _cycle_run, _memory, _task
+
+OPENAPI_PATH = Path(__file__).resolve().parent.parent.parent / "shared" / "openapi.yaml"
+
+
+def _load_schemas() -> dict[str, dict]:
+    spec = yaml.safe_load(OPENAPI_PATH.read_text())
+    return spec["components"]["schemas"]
+
+
+_SCHEMAS = _load_schemas()
+
+
+def _validate(instance, schema_name: str):
+    schema = _resolve_refs(_SCHEMAS[schema_name], _SCHEMAS)
+    jsonschema.validate(instance, schema)
+
+
+def _resolve_refs(schema: dict, all_schemas: dict) -> dict:
+    """Recursively resolve $ref pointers within an OpenAPI component schema."""
+    if isinstance(schema, dict):
+        if "$ref" in schema:
+            ref_name = schema["$ref"].split("/")[-1]
+            return _resolve_refs(all_schemas[ref_name], all_schemas)
+        result = {}
+        for k, v in schema.items():
+            if k == "nullable" and v is True:
+                continue
+            result[k] = _resolve_refs(v, all_schemas)
+        if schema.get("nullable"):
+            if "type" in result:
+                result["type"] = [result["type"], "null"]
+            elif "allOf" in result:
+                result["oneOf"] = [*result.pop("allOf"), {"type": "null"}]
+        return result
+    if isinstance(schema, list):
+        return [_resolve_refs(item, all_schemas) for item in schema]
+    return schema
+
+
+# --------------- fake row builders ---------------
+
+
+def _fake_task_row(**overrides):
+    now = datetime.now(UTC)
+    row = {
+        "id": 1,
+        "external_key": "TEST-001",
+        "source_type": "jira",
+        "source_url": "https://issues.redhat.com/browse/TEST-001",
+        "artifacts": json.dumps([{"name": "PR #1", "url": "https://github.com/test/pull/1", "type": "pr"}]),
+        "status": "in_progress",
+        "repo": "test-repo",
+        "branch": "main",
+        "title": "Test task",
+        "summary": "A test task",
+        "created_at": now,
+        "last_addressed": now,
+        "paused_reason": None,
+        "instance_id": "dev-bot",
+        "metadata": json.dumps({"priority": "high"}),
+    }
+    row.update(overrides)
+    return row
+
+
+def _fake_memory_row(**overrides):
+    now = datetime.now(UTC)
+    row = {
+        "id": 1,
+        "category": "bug",
+        "repo": "test-repo",
+        "external_key": "TEST-001",
+        "source_type": "jira",
+        "title": "Test memory",
+        "content": "Some content",
+        "tags": ["tag1", "tag2"],
+        "created_at": now,
+        "metadata": json.dumps({"key": "value"}),
+    }
+    row.update(overrides)
+    return row
+
+
+def _fake_cycle_run_row(**overrides):
+    now = datetime.now(UTC)
+    row = {
+        "id": 1,
+        "task_id": 42,
+        "cycle_type": "task_work",
+        "instance_id": "test-instance",
+        "started_at": now,
+        "finished_at": now,
+        "tool_calls": 50,
+        "tokens_used": 100000,
+        "progress": json.dumps({"last_step": "implemented"}),
+        "input_prompt": "Fix the bug",
+        "created_at": now,
+        "has_transcript": False,
+    }
+    row.update(overrides)
+    return row
+
+
+def _fake_cycle_row(**overrides):
+    now = datetime.now(UTC)
+    row = {
+        "id": 1,
+        "timestamp": now,
+        "label": "impl-TEST-001",
+        "session_id": "session-1",
+        "num_turns": 8,
+        "duration_ms": 300000,
+        "cost_usd": 0.15,
+        "input_tokens": 10000,
+        "output_tokens": 5000,
+        "cache_read_tokens": 2000,
+        "cache_write_tokens": 1000,
+        "model": "claude-sonnet-4",
+        "is_error": False,
+        "no_work": False,
+        "external_key": "TEST-001",
+        "source_type": "jira",
+        "repo": "test-repo",
+        "work_type": "implementation",
+        "summary": "Completed work",
+    }
+    row.update(overrides)
+    return row
+
+
+# --------------- item schema tests ---------------
+
+
+class TestTaskItemSchema:
+    def test_basic_task(self):
+        result = _task(_fake_task_row())
+        _validate(result, "TaskItem")
+
+    def test_task_with_slack_notification(self):
+        notif = {"event_type": "task_started", "message": "Started", "sent_at": "2026-07-01T10:00:00Z"}
+        result = _task(_fake_task_row(), slack_notif=notif)
+        _validate(result, "TaskItem")
+        assert result["slack_notification"] == notif
+
+    def test_task_with_null_optionals(self):
+        result = _task(
+            _fake_task_row(
+                source_url=None,
+                title=None,
+                summary=None,
+                last_addressed=datetime.now(UTC),
+                instance_id=None,
+            )
+        )
+        _validate(result, "TaskItem")
+
+    def test_task_jira_key_matches_external_key(self):
+        result = _task(_fake_task_row(external_key="RHCLOUD-999"))
+        assert result["jira_key"] == result["external_key"] == "RHCLOUD-999"
+
+    def test_task_with_multiple_artifacts(self):
+        artifacts = [
+            {"name": "PR #1", "url": "https://github.com/pull/1", "type": "pr"},
+            {"name": "Branch", "url": "https://github.com/tree/main", "type": "branch"},
+            {"name": "Build", "url": "https://ci.example.com/1", "type": "ci"},
+        ]
+        result = _task(_fake_task_row(artifacts=json.dumps(artifacts)))
+        _validate(result, "TaskItem")
+        assert len(result["artifacts"]) == 3
+
+    def test_task_with_empty_artifacts(self):
+        result = _task(_fake_task_row(artifacts=None))
+        _validate(result, "TaskItem")
+        assert result["artifacts"] == []
+
+    def test_task_metadata_as_dict(self):
+        result = _task(_fake_task_row(metadata={"key": "val"}))
+        _validate(result, "TaskItem")
+
+    def test_extra_field_rejected(self):
+        result = _task(_fake_task_row())
+        result["unexpected_field"] = "boom"
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            _validate(result, "TaskItem")
+
+
+class TestMemoryItemSchema:
+    def test_basic_memory(self):
+        result = _memory(_fake_memory_row())
+        _validate(result, "MemoryItem")
+
+    def test_memory_with_null_optionals(self):
+        result = _memory(_fake_memory_row(external_key=None, source_type=None))
+        _validate(result, "MemoryItem")
+
+    def test_memory_with_empty_tags(self):
+        result = _memory(_fake_memory_row(tags=[]))
+        _validate(result, "MemoryItem")
+        assert result["tags"] == []
+
+    def test_memory_metadata_as_dict(self):
+        result = _memory(_fake_memory_row(metadata={"nested": {"key": "val"}}))
+        _validate(result, "MemoryItem")
+
+    def test_extra_field_rejected(self):
+        result = _memory(_fake_memory_row())
+        result["unexpected"] = True
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            _validate(result, "MemoryItem")
+
+
+class TestCycleRunItemSchema:
+    def test_basic_cycle_run(self):
+        result = _cycle_run(_fake_cycle_run_row())
+        _validate(result, "CycleRunItem")
+
+    def test_cycle_run_with_null_task(self):
+        result = _cycle_run(_fake_cycle_run_row(task_id=None))
+        _validate(result, "CycleRunItem")
+        assert result["task_id"] is None
+
+    def test_cycle_run_with_null_timestamps(self):
+        result = _cycle_run(_fake_cycle_run_row(started_at=None, finished_at=None))
+        _validate(result, "CycleRunItem")
+
+    def test_cycle_run_with_null_input_prompt(self):
+        result = _cycle_run(_fake_cycle_run_row(input_prompt=None))
+        _validate(result, "CycleRunItem")
+
+    def test_cycle_run_without_input_prompt_key(self):
+        row = _fake_cycle_run_row()
+        del row["input_prompt"]
+        result = _cycle_run(row)
+        _validate(result, "CycleRunItem")
+        assert result["input_prompt"] is None
+
+    def test_extra_field_rejected(self):
+        result = _cycle_run(_fake_cycle_run_row())
+        result["extra"] = 123
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            _validate(result, "CycleRunItem")
+
+
+class TestCycleEntryItemSchema:
+    def test_basic_cycle_entry(self):
+        result = _cycle(_fake_cycle_row())
+        _validate(result, "CycleEntryItem")
+
+    def test_cycle_entry_with_null_optionals(self):
+        result = _cycle(
+            _fake_cycle_row(
+                external_key=None,
+                source_type=None,
+                repo=None,
+                work_type=None,
+                summary=None,
+            )
+        )
+        _validate(result, "CycleEntryItem")
+
+    def test_cycle_entry_cost_is_float(self):
+        result = _cycle(_fake_cycle_row(cost_usd=0))
+        _validate(result, "CycleEntryItem")
+        assert isinstance(result["cost_usd"], float)
+
+    def test_extra_field_rejected(self):
+        result = _cycle(_fake_cycle_row())
+        result["extra"] = "field"
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            _validate(result, "CycleEntryItem")
+
+
+# --------------- envelope schema tests ---------------
+
+
+class TestPaginatedEnvelopeSchema:
+    def test_valid_envelope(self):
+        envelope = {
+            "items": [_task(_fake_task_row())],
+            "total": 1,
+            "limit": 20,
+            "offset": 0,
+        }
+        _validate(envelope, "PaginatedResponse")
+
+    def test_empty_items(self):
+        envelope = {"items": [], "total": 0, "limit": 20, "offset": 0}
+        _validate(envelope, "PaginatedResponse")
+
+    def test_missing_total_rejected(self):
+        envelope = {"items": [], "limit": 20, "offset": 0}
+        with pytest.raises(jsonschema.ValidationError, match="'total' is a required"):
+            _validate(envelope, "PaginatedResponse")
+
+    def test_missing_limit_rejected(self):
+        envelope = {"items": [], "total": 0, "offset": 0}
+        with pytest.raises(jsonschema.ValidationError, match="'limit' is a required"):
+            _validate(envelope, "PaginatedResponse")
+
+    def test_extra_field_rejected(self):
+        envelope = {"items": [], "total": 0, "limit": 20, "offset": 0, "extra": True}
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            _validate(envelope, "PaginatedResponse")
+
+    def test_negative_total_rejected(self):
+        envelope = {"items": [], "total": -1, "limit": 20, "offset": 0}
+        with pytest.raises(jsonschema.ValidationError):
+            _validate(envelope, "PaginatedResponse")
+
+    def test_zero_limit_rejected(self):
+        envelope = {"items": [], "total": 0, "limit": 0, "offset": 0}
+        with pytest.raises(jsonschema.ValidationError):
+            _validate(envelope, "PaginatedResponse")
+
+
+class TestCostsResponseSchema:
+    def test_valid_costs_response(self):
+        response = {
+            "items": [_cycle(_fake_cycle_row())],
+            "daily": [
+                {
+                    "day": "2026-07-01",
+                    "cycles": 2,
+                    "total_cost": 0.20,
+                    "input_tokens": 20000,
+                    "output_tokens": 10000,
+                    "cache_read": 4000,
+                    "cache_write": 2000,
+                    "total_duration": 600000,
+                    "total_turns": 16,
+                    "idle_cycles": 0,
+                    "error_cycles": 0,
+                }
+            ],
+        }
+        _validate(response, "CostsResponse")
+
+    def test_empty_costs_response(self):
+        response = {"items": [], "daily": []}
+        _validate(response, "CostsResponse")
+
+    def test_costs_with_paginated_fields_rejected(self):
+        response = {"items": [], "daily": [], "total": 0, "limit": 20, "offset": 0}
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            _validate(response, "CostsResponse")
+
+    def test_missing_daily_rejected(self):
+        response = {"items": []}
+        with pytest.raises(jsonschema.ValidationError, match="'daily' is a required"):
+            _validate(response, "CostsResponse")

--- a/memory-server/tests/test_route_coverage.py
+++ b/memory-server/tests/test_route_coverage.py
@@ -1,0 +1,70 @@
+"""Ensure registered API routes match shared/openapi.yaml."""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SERVER_PATH = REPO_ROOT / "memory-server" / "bot_memory_server" / "server.py"
+OPENAPI_PATH = REPO_ROOT / "shared" / "openapi.yaml"
+
+CUSTOM_ROUTE_RE = re.compile(r"mcp\.custom_route\(\"([^\"]+)\",\s*methods=\[([^\]]+)\]\)")
+METHOD_RE = re.compile(r"\"([A-Z]+)\"")
+PATH_PARAM_RE = re.compile(r"\{(\w+):path\}")
+
+
+def _normalize_path(path: str) -> str:
+    return PATH_PARAM_RE.sub(r"{\1}", path)
+
+
+def _is_static_route(path: str) -> bool:
+    return path == "/" or path.startswith("/static/") or path.startswith("/assets/")
+
+
+def _extract_server_routes() -> set[tuple[str, str]]:
+    source = SERVER_PATH.read_text()
+    routes: set[tuple[str, str]] = set()
+    for path, methods_blob in CUSTOM_ROUTE_RE.findall(source):
+        if _is_static_route(path):
+            continue
+        normalized = _normalize_path(path)
+        for method in METHOD_RE.findall(methods_blob):
+            routes.add((normalized, method))
+    return routes
+
+
+def _extract_openapi_routes(skip_health: bool = False) -> set[tuple[str, str]]:
+    spec = yaml.safe_load(OPENAPI_PATH.read_text())
+    routes: set[tuple[str, str]] = set()
+    for path, path_item in spec["paths"].items():
+        if skip_health and path == "/health":
+            continue
+        for method, _operation in path_item.items():
+            if method in ("get", "post", "delete", "patch", "put"):
+                routes.add((path, method.upper()))
+    return routes
+
+
+SERVER_ROUTES = _extract_server_routes()
+OPENAPI_ROUTES = _extract_openapi_routes()
+OPENAPI_ROUTES_NO_HEALTH = _extract_openapi_routes(skip_health=True)
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    sorted(SERVER_ROUTES),
+    ids=[f"{method} {path}" for path, method in sorted(SERVER_ROUTES)],
+)
+def test_every_registered_route_has_openapi_entry(path, method):
+    assert (path, method) in OPENAPI_ROUTES
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    sorted(OPENAPI_ROUTES_NO_HEALTH),
+    ids=[f"{method} {path}" for path, method in sorted(OPENAPI_ROUTES_NO_HEALTH)],
+)
+def test_every_openapi_path_has_registered_route(path, method):
+    assert (path, method) in SERVER_ROUTES

--- a/mock_api.py
+++ b/mock_api.py
@@ -18,6 +18,7 @@ from fixtures.api_payloads import (
     BOT_STATUS,
     COSTS,
     CYCLE_RUNS,
+    DAILY_COSTS,
     EMBEDDINGS,
     MAX_ACTIVE,
     MEMORIES,
@@ -188,10 +189,10 @@ class Handler(BaseHTTPRequestHandler):
                 memories = [m for m in memories if tag in m["tags"]]
 
             memories = [{**m, "similarity": 0.85} for m in memories[:limit]]
-            self.send_json({"items": memories, "total": len(memories)})
+            self.send_json(memories)
 
         elif path == "/api/memories/embeddings":
-            self.send_json({"items": EMBEDDINGS, "total": len(EMBEDDINGS)})
+            self.send_json(EMBEDDINGS)
 
         elif path == "/api/tags":
             self.send_json(TAGS)
@@ -200,7 +201,7 @@ class Handler(BaseHTTPRequestHandler):
             limit = int(qs.get("limit", ["200"])[0])
 
             costs = COSTS[:limit]
-            self.send_json({"items": costs, "total": len(costs), "limit": limit, "offset": 0})
+            self.send_json({"items": costs, "daily": DAILY_COSTS})
 
         elif path == "/api/cycle-runs":
             task_id = qs.get("task_id", [None])[0]
@@ -228,9 +229,8 @@ class Handler(BaseHTTPRequestHandler):
             instance_id = qs.get("instance_id", [None])[0]
             groups = TASK_CYCLE_GROUPS[:]
             if instance_id:
-                # In real impl would filter, here just return all
                 pass
-            self.send_json({"items": groups, "total": len(groups)})
+            self.send_json(groups)
 
         elif path.startswith("/api/cycle-runs/") and "/transcript" in path:
             run_id = int(path.split("/")[3])

--- a/shared/openapi.yaml
+++ b/shared/openapi.yaml
@@ -1,0 +1,971 @@
+openapi: 3.0.3
+info:
+  title: Dev Bot Memory Server API
+  version: 0.1.0
+  description: API for the Dev Bot memory server — tasks, memories, costs, cycle runs, and analytics.
+
+servers:
+  - url: /
+
+paths:
+  /api/tasks:
+    get:
+      operationId: listTasks
+      summary: List tasks with optional filters
+      parameters:
+        - name: status
+          in: query
+          schema: { type: string }
+        - name: exclude_status
+          in: query
+          schema: { type: string }
+        - name: instance_id
+          in: query
+          schema: { type: string }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20, minimum: 1 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0, minimum: 0 }
+      responses:
+        '200':
+          description: Paginated list of tasks
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResponse'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/TaskItem'
+
+  /api/tasks/{key}:
+    delete:
+      operationId: archiveTask
+      summary: Archive (soft-delete) a task
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Task archived
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [archived, external_key, task]
+                properties:
+                  archived: { type: boolean }
+                  external_key: { type: string }
+                  task: { $ref: '#/components/schemas/TaskItem' }
+
+  /api/tasks/{key}/pause:
+    post:
+      operationId: pauseTask
+      summary: Pause a task
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                paused_reason: { type: string, nullable: true }
+      responses:
+        '200':
+          description: Task paused
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [paused, external_key, task]
+                properties:
+                  paused: { type: boolean }
+                  external_key: { type: string }
+                  task: { $ref: '#/components/schemas/TaskItem' }
+
+  /api/tasks/{key}/unpause:
+    post:
+      operationId: unpauseTask
+      summary: Unpause a task
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Task unpaused
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [unpaused, external_key, task]
+                properties:
+                  unpaused: { type: boolean }
+                  external_key: { type: string }
+                  task: { $ref: '#/components/schemas/TaskItem' }
+        '409':
+          description: Too many active tasks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/tasks/{key}/unarchive:
+    post:
+      operationId: unarchiveTask
+      summary: Restore an archived task
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Task unarchived
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [unarchived, external_key, task]
+                properties:
+                  unarchived: { type: boolean }
+                  external_key: { type: string }
+                  task: { $ref: '#/components/schemas/TaskItem' }
+
+  /api/memories:
+    get:
+      operationId: listMemories
+      summary: List memories with optional filters
+      parameters:
+        - name: category
+          in: query
+          schema: { type: string }
+        - name: repo
+          in: query
+          schema: { type: string }
+        - name: tag
+          in: query
+          schema: { type: string }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20, minimum: 1 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0, minimum: 0 }
+      responses:
+        '200':
+          description: Paginated list of memories
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResponse'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MemoryItem'
+
+  /api/memories/{id}:
+    get:
+      operationId: getMemory
+      summary: Get a single memory by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Memory item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemoryItem'
+    delete:
+      operationId: deleteMemory
+      summary: Delete a memory
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Memory deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [deleted, id]
+                properties:
+                  deleted: { type: boolean }
+                  id: { type: integer }
+
+  /api/memories/search:
+    get:
+      operationId: searchMemories
+      summary: Search memories by similarity
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema: { type: string }
+        - name: category
+          in: query
+          schema: { type: string }
+        - name: repo
+          in: query
+          schema: { type: string }
+        - name: tag
+          in: query
+          schema: { type: string }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20 }
+      responses:
+        '200':
+          description: Array of memory items with similarity scores
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - $ref: '#/components/schemas/MemoryItem'
+                    - type: object
+                      required: [similarity]
+                      properties:
+                        similarity: { type: number }
+
+  /api/memories/upload:
+    post:
+      operationId: uploadMemories
+      summary: Bulk upload memories
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [memories]
+              properties:
+                memories:
+                  type: array
+                  items: { type: object }
+      responses:
+        '200':
+          description: Upload result
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [uploaded, errors]
+                properties:
+                  uploaded: { type: integer }
+                  errors:
+                    type: array
+                    items: { type: string }
+
+  /api/memories/embeddings:
+    get:
+      operationId: getEmbeddings
+      summary: Get PCA-projected 3D embedding coordinates
+      responses:
+        '200':
+          description: Array of embedding points
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EmbeddingPoint'
+
+  /api/costs:
+    get:
+      operationId: listCosts
+      summary: List cost entries with daily aggregates
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 200 }
+        - name: days
+          in: query
+          schema: { type: integer }
+        - name: from
+          in: query
+          schema: { type: string, format: date }
+        - name: to
+          in: query
+          schema: { type: string, format: date }
+      responses:
+        '200':
+          description: Cost entries and daily aggregates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CostsResponse'
+    post:
+      operationId: addCostEntry
+      summary: Record a new cost entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CycleEntryItem'
+      responses:
+        '201':
+          description: Created cost entry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CycleEntryItem'
+
+  /api/cycle-runs:
+    get:
+      operationId: listCycleRuns
+      summary: List cycle runs with optional filters
+      parameters:
+        - name: task_id
+          in: query
+          schema: { type: string }
+        - name: instance_id
+          in: query
+          schema: { type: string }
+        - name: cycle_type
+          in: query
+          schema: { type: string }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50, minimum: 1 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0, minimum: 0 }
+      responses:
+        '200':
+          description: Paginated list of cycle runs
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResponse'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CycleRunItem'
+    post:
+      operationId: addCycleRun
+      summary: Record a new cycle run
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Created cycle run
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CycleRunItem'
+
+  /api/cycle-runs/by-task:
+    get:
+      operationId: listCycleRunsByTask
+      summary: Cycle runs grouped by task
+      parameters:
+        - name: instance_id
+          in: query
+          schema: { type: string }
+      responses:
+        '200':
+          description: Task cycle groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TaskCycleGroup'
+
+  /api/cycle-runs/{id}/transcript:
+    get:
+      operationId: getCycleRunTranscript
+      summary: Get cycle run transcript (binary)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+        - name: decompress
+          in: query
+          schema: { type: boolean }
+      responses:
+        '200':
+          description: Raw transcript data
+          content:
+            application/zstd:
+              schema:
+                type: string
+                format: binary
+            application/x-ndjson:
+              schema:
+                type: string
+
+  /api/bot-status:
+    get:
+      operationId: getBotStatus
+      summary: Get current bot status
+      responses:
+        '200':
+          description: Bot status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BotStatus'
+    post:
+      operationId: updateBotStatus
+      summary: Update bot status
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                state: { type: string }
+                message: { type: string }
+                repo: { type: string }
+                external_key: { type: string }
+                source_type: { type: string }
+      responses:
+        '200':
+          description: Status updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok]
+                properties:
+                  ok: { type: boolean }
+
+  /api/instances:
+    get:
+      operationId: listInstances
+      summary: List bot instances
+      responses:
+        '200':
+          description: Array of bot instances
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BotInstance'
+
+  /api/instances/{instance_id}:
+    get:
+      operationId: getInstance
+      summary: Get a single bot instance
+      parameters:
+        - name: instance_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Bot instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BotInstance'
+
+  /api/instances/{instance_id}/idle:
+    patch:
+      operationId: updateInstanceIdle
+      summary: Update idle tracking for an instance
+      parameters:
+        - name: instance_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                idle_consecutive_cycles: { type: integer }
+                last_idle_reminder_sent_at: { type: string, nullable: true }
+      responses:
+        '200':
+          description: Updated instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BotInstance'
+
+  /api/instances/{instance_id}/wake:
+    get:
+      operationId: checkInstanceWake
+      summary: Check if a wake signal is pending (consumed on read)
+      parameters:
+        - name: instance_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Wake status
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [wake]
+                properties:
+                  wake: { type: boolean }
+    post:
+      operationId: triggerInstanceWake
+      summary: Send a wake signal to an instance
+      parameters:
+        - name: instance_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Wake triggered
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok]
+                properties:
+                  ok: { type: boolean }
+
+  /api/analytics:
+    get:
+      operationId: getAnalytics
+      summary: Get analytics summary
+      parameters:
+        - name: days
+          in: query
+          schema: { type: integer }
+        - name: from
+          in: query
+          schema: { type: string, format: date }
+        - name: to
+          in: query
+          schema: { type: string, format: date }
+      responses:
+        '200':
+          description: Analytics data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyticsData'
+
+  /api/tags:
+    get:
+      operationId: listTags
+      summary: List all memory tags
+      responses:
+        '200':
+          description: Array of tag strings
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: string }
+
+  /api/stats:
+    get:
+      operationId: getStats
+      summary: Get summary statistics
+      responses:
+        '200':
+          description: Stats summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tasks:
+                    type: object
+                    additionalProperties: { type: integer }
+                  memories:
+                    type: object
+                    properties:
+                      total: { type: integer }
+                      by_category:
+                        type: object
+                        additionalProperties: { type: integer }
+                      by_repo:
+                        type: object
+                        additionalProperties: { type: integer }
+
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status: { type: string, enum: [ok] }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+
+  schemas:
+    PaginatedResponse:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items: { type: array }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+      additionalProperties: false
+
+    TaskItem:
+      type: object
+      required:
+        - id
+        - external_key
+        - jira_key
+        - source_type
+        - artifacts
+        - status
+        - repo
+        - branch
+        - created_at
+        - paused_reason
+        - metadata
+      properties:
+        id: { type: integer }
+        external_key: { type: string }
+        jira_key: { type: string }
+        source_type: { type: string }
+        source_url: { type: string, nullable: true }
+        artifacts:
+          type: array
+          items:
+            type: object
+            required: [name, url, type]
+            properties:
+              name: { type: string }
+              url: { type: string }
+              type: { type: string }
+        status: { type: string }
+        repo: { type: string }
+        branch: { type: string }
+        title: { type: string, nullable: true }
+        summary: { type: string, nullable: true }
+        created_at: { type: string }
+        last_addressed: { type: string, nullable: true }
+        paused_reason: { type: string, nullable: true }
+        instance_id: { type: string, nullable: true }
+        metadata: { type: object }
+        slack_notification:
+          nullable: true
+          type: object
+          properties:
+            event_type: { type: string }
+            message: { type: string }
+            sent_at: { type: string }
+      additionalProperties: false
+
+    MemoryItem:
+      type: object
+      required: [id, category, repo, title, content, tags, created_at, metadata]
+      properties:
+        id: { type: integer }
+        category: { type: string }
+        repo: { type: string }
+        external_key: { type: string, nullable: true }
+        source_type: { type: string, nullable: true }
+        title: { type: string }
+        content: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+        created_at: { type: string }
+        metadata: { type: object }
+      additionalProperties: false
+
+    CycleEntryItem:
+      type: object
+      required:
+        - id
+        - timestamp
+        - label
+        - session_id
+        - num_turns
+        - duration_ms
+        - cost_usd
+        - input_tokens
+        - output_tokens
+        - cache_read_tokens
+        - cache_write_tokens
+        - model
+        - is_error
+        - no_work
+      properties:
+        id: { type: integer }
+        timestamp: { type: string }
+        label: { type: string }
+        session_id: { type: string }
+        num_turns: { type: integer }
+        duration_ms: { type: integer }
+        cost_usd: { type: number }
+        input_tokens: { type: integer }
+        output_tokens: { type: integer }
+        cache_read_tokens: { type: integer }
+        cache_write_tokens: { type: integer }
+        model: { type: string }
+        is_error: { type: boolean }
+        no_work: { type: boolean }
+        external_key: { type: string, nullable: true }
+        source_type: { type: string, nullable: true }
+        repo: { type: string, nullable: true }
+        work_type: { type: string, nullable: true }
+        summary: { type: string, nullable: true }
+      additionalProperties: false
+
+    CycleRunItem:
+      type: object
+      required:
+        - id
+        - task_id
+        - cycle_type
+        - instance_id
+        - started_at
+        - finished_at
+        - tool_calls
+        - tokens_used
+        - progress
+        - created_at
+        - has_transcript
+      properties:
+        id: { type: integer }
+        task_id: { type: integer, nullable: true }
+        cycle_type: { type: string }
+        instance_id: { type: string }
+        started_at: { type: string, nullable: true }
+        finished_at: { type: string, nullable: true }
+        tool_calls: { type: integer }
+        tokens_used: { type: integer }
+        progress: { type: object }
+        input_prompt: { type: string, nullable: true }
+        created_at: { type: string }
+        has_transcript: { type: boolean }
+      additionalProperties: false
+
+    CostsResponse:
+      type: object
+      required: [items, daily]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CycleEntryItem'
+        daily:
+          type: array
+          items:
+            $ref: '#/components/schemas/DailyAggregate'
+      additionalProperties: false
+
+    DailyAggregate:
+      type: object
+      required: [day, cycles, total_cost, input_tokens, output_tokens, cache_read, cache_write, total_duration, total_turns, idle_cycles, error_cycles]
+      properties:
+        day: { type: string }
+        cycles: { type: integer }
+        total_cost: { type: number }
+        input_tokens: { type: integer }
+        output_tokens: { type: integer }
+        cache_read: { type: integer }
+        cache_write: { type: integer }
+        total_duration: { type: integer }
+        total_turns: { type: integer }
+        idle_cycles: { type: integer }
+        error_cycles: { type: integer }
+
+    BotStatus:
+      type: object
+      required: [state, message, external_key, source_type, repo, instance_id, updated_at, cycle_start]
+      properties:
+        state: { type: string }
+        message: { type: string }
+        external_key: { type: string, nullable: true }
+        source_type: { type: string, nullable: true }
+        source_url: { type: string, nullable: true }
+        repo: { type: string, nullable: true }
+        instance_id: { type: string }
+        updated_at: { type: string }
+        cycle_start: { type: string, nullable: true }
+        last_seen: { type: string, nullable: true }
+
+    BotInstance:
+      type: object
+      required: [instance_id, state, message, external_key, source_type, repo, cycle_start, updated_at, active_tasks, max_tasks]
+      properties:
+        instance_id: { type: string }
+        state: { type: string }
+        message: { type: string }
+        external_key: { type: string, nullable: true }
+        source_type: { type: string, nullable: true }
+        source_url: { type: string, nullable: true }
+        repo: { type: string, nullable: true }
+        cycle_start: { type: string, nullable: true }
+        updated_at: { type: string }
+        last_seen: { type: string, nullable: true }
+        active_tasks: { type: integer }
+        max_tasks: { type: integer }
+        idle_consecutive_cycles: { type: integer }
+        last_idle_reminder_sent_at: { type: string, nullable: true }
+
+    EmbeddingPoint:
+      type: object
+      required: [id, title, content, category, repo, tags, x, y, z]
+      properties:
+        id: { type: integer }
+        title: { type: string }
+        content: { type: string }
+        category: { type: string }
+        repo: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+        x: { type: number }
+        y: { type: number }
+        z: { type: number }
+
+    TaskCycleGroup:
+      type: object
+      required: [task_id, external_key, title, task_status, repo, cycle_count, transcript_count, total_tool_calls, total_tokens, first_cycle, last_cycle]
+      properties:
+        task_id: { type: integer }
+        external_key: { type: string }
+        title: { type: string }
+        task_status: { type: string }
+        repo: { type: string }
+        cycle_count: { type: integer }
+        transcript_count: { type: integer }
+        total_tool_calls: { type: integer }
+        total_tokens: { type: integer }
+        first_cycle: { type: string }
+        last_cycle: { type: string }
+
+    AnalyticsData:
+      type: object
+      required: [summary, work_types, repos, tickets, feedback]
+      properties:
+        summary:
+          $ref: '#/components/schemas/AnalyticsSummary'
+        work_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkTypeEntry'
+        repos:
+          type: array
+          items:
+            $ref: '#/components/schemas/RepoEntry'
+        tickets:
+          type: array
+          items:
+            $ref: '#/components/schemas/TicketEntry'
+        feedback:
+          $ref: '#/components/schemas/FeedbackStats'
+
+    AnalyticsSummary:
+      type: object
+      required: [total_cycles, work_cycles, idle_cycles, error_cycles, unique_tickets, total_cost, avg_cost_per_work_cycle, avg_turns, avg_duration_ms, repos_touched, tickets_resolved]
+      properties:
+        total_cycles: { type: integer }
+        work_cycles: { type: integer }
+        idle_cycles: { type: integer }
+        error_cycles: { type: integer }
+        unique_tickets: { type: integer }
+        total_cost: { type: number }
+        avg_cost_per_work_cycle: { type: number }
+        avg_turns: { type: number }
+        avg_duration_ms: { type: integer }
+        repos_touched: { type: integer }
+        tickets_resolved: { type: integer }
+
+    WorkTypeEntry:
+      type: object
+      required: [category, cycles, total_cost, avg_cost, avg_turns, avg_duration_ms]
+      properties:
+        category: { type: string }
+        cycles: { type: integer }
+        total_cost: { type: number }
+        avg_cost: { type: number }
+        avg_turns: { type: integer }
+        avg_duration_ms: { type: integer }
+
+    RepoEntry:
+      type: object
+      required: [repo, tickets, cycles, total_cost, avg_turns]
+      properties:
+        repo: { type: string }
+        tickets: { type: integer }
+        cycles: { type: integer }
+        total_cost: { type: number }
+        avg_turns: { type: integer }
+
+    TicketEntry:
+      type: object
+      required: [external_key, title, status, repo, total_cycles, impl_cycles, review_cycles, total_cost, hours_span]
+      properties:
+        external_key: { type: string }
+        title: { type: string }
+        status: { type: string }
+        repo: { type: string }
+        total_cycles: { type: integer }
+        impl_cycles: { type: integer }
+        review_cycles: { type: integer }
+        total_cost: { type: number }
+        hours_span: { type: number }
+
+    FeedbackStats:
+      type: object
+      required: [avg_review_rounds, zero_review, one_review, multi_review]
+      properties:
+        avg_review_rounds: { type: number }
+        zero_review: { type: integer }
+        one_review: { type: integer }
+        multi_review: { type: integer }
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error: { type: string }

--- a/uv.lock
+++ b/uv.lock
@@ -212,9 +212,11 @@ dependencies = [
 [package.optional-dependencies]
 test = [
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -222,12 +224,14 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27" },
+    { name = "jsonschema", marker = "extra == 'test'", specifier = ">=4.20" },
     { name = "pgvector", specifier = ">=0.3" },
     { name = "pip-audit", marker = "extra == 'test'", specifier = ">=2.7" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
+    { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "sentence-transformers", specifier = ">=3.0" },
     { name = "starlette", specifier = ">=0.40" },
     { name = "uvicorn", specifier = ">=0.30" },
@@ -674,37 +678,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add JSON Schema files in `shared/schemas/` as single source of truth for API response shapes
- Both Python (`jsonschema`) and JS (`ajv`) test suites validate against the same schemas — changing the response shape on one side without updating the other causes test failures
- Fix 4 `mock_api.py` response shape bugs where mock returned wrong envelope vs real API:
  - `/api/costs`: mock used `{items, total, limit, offset}`, real returns `{items, daily}`
  - `/api/memories/search`: mock wrapped in `{items, total}`, real returns bare array
  - `/api/memories/embeddings`: same
  - `/api/cycle-runs/by-task`: same
- Add missing `jira_key` to task fixture to match `_task()` serializer output
- **Route coverage tests**: bidirectional checks that every registered backend route and every mock route has a corresponding OpenAPI spec entry — adding a new endpoint without updating the spec fails tests

## Test coverage

- **34 backend schema tests** (`memory-server/tests/test_api_schemas.py`) — validate `_task()`, `_memory()`, `_cycle_run()`, `_cycle()` serializer output against schemas, including null optionals, extra field rejection, envelope validation
- **55 backend route coverage tests** (`memory-server/tests/test_route_coverage.py`) — bidirectional parity between `server.py` custom_route registrations and `openapi.yaml` paths (all methods: GET/POST/DELETE/PATCH)
- **34 Python fixture tests** (`dashboard/tests/test_schema_conformance.py`) — validate all fixture factories and default datasets against schemas
- **35 mock route coverage tests** (`dashboard/tests/test_mock_route_coverage.py`) — every mock route has an OpenAPI entry; every OpenAPI GET has a mock handler
- **26 vitest tests** (`dashboard/src/test/schema-conformance.test.ts`) — validate TS fixtures against same schemas
- **Schema validation gate** in `generate_json.py` — fixture generation fails if output doesn't match schemas

## Test plan

- [x] `pytest memory-server/tests/test_api_schemas.py` — 34 passed
- [x] `pytest memory-server/tests/test_route_coverage.py` — 55 passed
- [x] `pytest dashboard/tests/` — 78 passed (9 existing + 34 + 35 new)
- [x] `vitest run` — 80 passed (54 existing + 26 new)
- [x] `generate_json.py` validates and regenerates fixtures successfully
- [x] `ruff check . && ruff format --check .` clean

Resolves [REHOR-80](https://issues.redhat.com/browse/REHOR-80)

---