### PR TITLE
Pass notify_mode as parameter to slack_notify MCP tool instead of rea…

### DIFF
--- a/.claude/skills/slack-notify/slack_notify.py
+++ b/.claude/skills/slack-notify/slack_notify.py
@@ -40,6 +40,7 @@ def main():
             "event_type": event_type,
             "message": message,
             "webhook_url": webhook_url,
+            "notify_mode": os.environ.get("SLACK_NOTIFY_MODE", "immediate"),
         },
     )
     memory_cleanup()

--- a/memory-server/bot_memory_server/tools/slack.py
+++ b/memory-server/bot_memory_server/tools/slack.py
@@ -23,6 +23,7 @@ def register_slack_tools(mcp: FastMCP):
         webhook_url: str | None = os.environ.get("SLACK_WEBHOOK_URL"),
         source_type: str = "jira",
         instance_id: str | None = None,
+        notify_mode: str = "immediate",
         pr_url: str | None = None,
         pr_number: int | None = None,
         repo: str | None = None,
@@ -30,8 +31,8 @@ def register_slack_tools(mcp: FastMCP):
     ) -> dict:
         """Send a Slack notification. Deduplicates by external_key (48h cooldown per ticket, any event type).
 
-        In daily_digest mode (SLACK_NOTIFY_MODE=daily_digest), queues the notification
-        instead of sending immediately. Use slack_send_digest to send the digest.
+        In daily_digest mode, queues the notification instead of sending immediately.
+        Use slack_send_digest to send the digest.
 
         external_key: The external identifier (e.g. Jira key 'RHCLOUD-12345').
         source_type: Source system — 'jira', 'github', etc.
@@ -39,6 +40,7 @@ def register_slack_tools(mcp: FastMCP):
         message: Human-readable message to post. Keep it concise (1-2 sentences + links).
         webhook_url: Slack webhook URL. Defaults to SLACK_WEBHOOK_URL env var on the memory server.
         instance_id: Bot instance identifier (optional, used for digest grouping).
+        notify_mode: 'immediate' (default) or 'daily_digest'. Passed by the caller from its env.
         pr_url: PR URL (optional, used for richer digest formatting).
         pr_number: PR number (optional, used for richer digest formatting).
         repo: Repository name (optional, used for richer digest formatting).
@@ -50,9 +52,7 @@ def register_slack_tools(mcp: FastMCP):
         if not webhook_url:
             return {"sent": False, "reason": "SLACK_WEBHOOK_URL not configured"}
 
-        notify_mode = os.environ.get("SLACK_NOTIFY_MODE", "immediate")
-
-        if notify_mode == "daily_digest" and os.environ.get("SLACK_DIGEST_HOUR"):
+        if notify_mode == "daily_digest":
             existing = await pool.fetchrow(
                 """
                 SELECT id FROM slack_digest_queue

--- a/memory-server/tests/test_slack_digest.py
+++ b/memory-server/tests/test_slack_digest.py
@@ -6,7 +6,6 @@ capture them by registering into a real FastMCP instance and pulling
 them out of its internal registry.
 """
 
-import os
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -79,7 +78,6 @@ class TestSlackNotifyImmediate:
 
         with (
             patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "immediate"}),
             patch("bot_memory_server.tools.slack.httpx.AsyncClient") as mock_client_class,
             patch("bot_memory_server.tools.slack.bus", new_callable=AsyncMock),
         ):
@@ -113,7 +111,6 @@ class TestSlackNotifyImmediate:
 
         with (
             patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "immediate"}),
         ):
             result = await slack_notify(
                 external_key="RHCLOUD-100",
@@ -148,7 +145,6 @@ class TestSlackNotifyImmediate:
 
         with (
             patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "immediate"}),
             patch("bot_memory_server.tools.slack.httpx.AsyncClient") as mock_client_class,
         ):
             mock_client = AsyncMock()
@@ -177,15 +173,13 @@ class TestSlackNotifyDigest:
         slack_notify = slack_tools["slack_notify"]
         pool = _make_pool(fetchrow_return=None)
 
-        with (
-            patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest", "SLACK_DIGEST_HOUR": "9"}),
-        ):
+        with patch("bot_memory_server.tools.slack.get_pool", return_value=pool):
             result = await slack_notify(
                 external_key="RHCLOUD-200",
                 event_type="pr_created",
                 message="New PR: #99",
                 webhook_url="https://hooks.slack.com/test",
+                notify_mode="daily_digest",
                 instance_id="framework-1",
                 pr_url="https://github.com/org/repo/pull/99",
                 pr_number=99,
@@ -210,21 +204,20 @@ class TestSlackNotifyDigest:
         slack_notify = slack_tools["slack_notify"]
         pool = _make_pool(fetchrow_return=None)
 
-        with (
-            patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest", "SLACK_DIGEST_HOUR": "9"}),
-        ):
+        with patch("bot_memory_server.tools.slack.get_pool", return_value=pool):
             r1 = await slack_notify(
                 external_key="RHCLOUD-300",
                 event_type="pr_created",
                 message="First",
                 webhook_url="https://hooks.slack.com/test",
+                notify_mode="daily_digest",
             )
             r2 = await slack_notify(
                 external_key="RHCLOUD-300",
                 event_type="review_reminder",
                 message="Second",
                 webhook_url="https://hooks.slack.com/test",
+                notify_mode="daily_digest",
             )
 
         assert r1["queued"] is True
@@ -237,15 +230,13 @@ class TestSlackNotifyDigest:
         slack_notify = slack_tools["slack_notify"]
         pool = _make_pool(fetchrow_return={"id": 99})
 
-        with (
-            patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
-            patch.dict(os.environ, {"SLACK_NOTIFY_MODE": "daily_digest", "SLACK_DIGEST_HOUR": "9"}),
-        ):
+        with patch("bot_memory_server.tools.slack.get_pool", return_value=pool):
             result = await slack_notify(
                 external_key="RHCLOUD-300",
                 event_type="pr_created",
                 message="Duplicate",
                 webhook_url="https://hooks.slack.com/test",
+                notify_mode="daily_digest",
             )
 
         assert result["queued"] is False

--- a/presets/envs/slack/skills/slack-notify/slack_notify.py
+++ b/presets/envs/slack/skills/slack-notify/slack_notify.py
@@ -40,6 +40,7 @@ def main():
             "event_type": event_type,
             "message": message,
             "webhook_url": webhook_url,
+            "notify_mode": os.environ.get("SLACK_NOTIFY_MODE", "immediate"),
         },
     )
     memory_cleanup()

--- a/presets/shared/skills/post-pr/scripts/post_pr_operations.py
+++ b/presets/shared/skills/post-pr/scripts/post_pr_operations.py
@@ -532,6 +532,7 @@ class PostPROperations:
                         "event_type": "pr_created",
                         "message": message,
                         "webhook_url": self.slack_webhook,
+                        "notify_mode": os.environ.get("SLACK_NOTIFY_MODE", "immediate"),
                         "pr_url": pr_url,
                         "pr_number": pr_number,
                         "repo": repo,

--- a/presets/workflows/jira-kanban/skills/wrap-up/wrap_up.py
+++ b/presets/workflows/jira-kanban/skills/wrap-up/wrap_up.py
@@ -156,6 +156,7 @@ def slack_notify(jira_key, pr_info):
             "event_type": "release_pending",
             "message": msg,
             "webhook_url": webhook_url,
+            "notify_mode": os.environ.get("SLACK_NOTIFY_MODE", "immediate"),
         },
     )
     if result and result.get("sent"):

--- a/presets/workflows/jira-sprint/skills/wrap-up/wrap_up.py
+++ b/presets/workflows/jira-sprint/skills/wrap-up/wrap_up.py
@@ -156,6 +156,7 @@ def slack_notify(jira_key, pr_info):
             "event_type": "release_pending",
             "message": msg,
             "webhook_url": webhook_url,
+            "notify_mode": os.environ.get("SLACK_NOTIFY_MODE", "immediate"),
         },
     )
     if result and result.get("sent"):


### PR DESCRIPTION
…ding from memory server env

### Description

`slack_notify` MCP tool read `SLACK_NOTIFY_MODE` from its own environment (`os.environ`), but this env var is set on **bot instance pods**, not on the shared memory server. Notifications were never queued because the memory server always saw `immediate` as default.

Fix: `notify_mode` is now a parameter passed by callers from their own environment. All callers updated: `slack-notify` skill, `post-pr`, `wrap-up` (both jira-sprint and jira-kanban workflows).

[RHCLOUD-48014](https://redhat.atlassian.net/browse/RHCLOUD-48014)

---

### Blast radius

* **Memory server** — `slack_notify` tool has new optional `notify_mode` parameter (default `"immediate"`, backward compatible)
* **Callers** — `slack-notify` skill, `post-pr`, `wrap-up` (both workflows) now pass `notify_mode` from their env
* No changes to immediate mode behavior — callers without `SLACK_NOTIFY_MODE` env var pass `"immediate"` by default

---

### Rollback plan

Git revert is sufficient. Without `notify_mode` parameter, tool falls back to `"immediate"` default.

---

### Checklist
- [x] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure

Assisted by: Claude Code (Claude Opus 4.6)

