### PR TITLE
fix(onboarding): fix forking instructions for konflux/app-interface

### DIFF
--- a/presets/workflows/onboarding/CLAUDE.md
+++ b/presets/workflows/onboarding/CLAUDE.md
@@ -142,7 +142,16 @@ Wait for repo URL. Verify access via `/auto-fork`.
 
 **Note**: No `.tekton/` files — those come from Konflux Phase 2.
 
-Post scaffolding PR link. Link PR to Jira: `jira_create_remote_issue_link` on both the parent ticket and the Phase 1 sub-ticket. Apply `onboarding:scaffolding-pr`.
+Post scaffolding PR link as a Jira comment. Avoid nested square brackets in markdown links — they break the markdown-to-ADF conversion and the link won't render:
+```
+## Phase 1/3: Instance Setup — Scaffolding PR
+
+PR opened: [PR #<number> — Add instance scaffolding for <team_name> (<TICKET_KEY>)](<pr_url>)
+
+Please review and merge when ready. Phase 2 (Konflux CI/CD) will begin once this PR is merged.
+```
+
+Link PR to Jira: `jira_create_remote_issue_link` on both the parent ticket and the Phase 1 sub-ticket. Apply `onboarding:scaffolding-pr`.
 
 ---
 
@@ -159,20 +168,45 @@ Update metadata: `phase: 2`, `step: "konflux-info"`.
 
 ### `onboarding:konflux-info`
 
-Parse Konflux responses. Clone `konflux-release-data` fork → `/generate-konflux` → run `build-single.sh` → commit → push → open MR.
+Parse Konflux responses, then generate and submit the Konflux MR:
 
-After `/generate-konflux`, run `build-single.sh` to regenerate the `auto-generated/` directory:
-```bash
-cd <konflux_repo>/tenants-config
-./build-single.sh <tenant>
-```
-The script accepts the tenant name with or without the `-tenant` suffix. This runs `kustomize build` on the tenant directory and produces the `auto-generated/` files that CI requires.
+1. **Clone the existing fork** — do NOT attempt to fork the repo; the fork already exists. Look up `konflux-release-data` in `project-repos.json` for the fork and upstream URLs:
+   ```bash
+   git clone <project-repos.json url> /tmp/konflux-release-data
+   cd /tmp/konflux-release-data
+   git remote add upstream <project-repos.json upstream>
+   git fetch upstream main
+   git checkout -b bot/onboarding-<TICKET_KEY> upstream/main
+   ```
 
-Before committing, verify that `auto-generated/` changes are scoped to the target tenant only:
-```bash
-git diff --name-only -- tenants-config/auto-generated/ | grep -v "tenants/<tenant>"
-```
-If any auto-generated files for other tenants appear, discard them with `git checkout` before committing. Commit both the source files (tenant YAML, RPA, constraints, CODEOWNERS) and the scoped `auto-generated/` output.
+2. **Generate files**: Run `/generate-konflux` targeting `/tmp/konflux-release-data`.
+
+3. **Build auto-generated output**: Run `build-single.sh` to regenerate the `auto-generated/` directory:
+   ```bash
+   cd /tmp/konflux-release-data/tenants-config
+   ./build-single.sh <tenant>
+   ```
+   The script accepts the tenant name with or without the `-tenant` suffix. This runs `kustomize build` on the tenant directory and produces the `auto-generated/` files that CI requires.
+
+4. **Verify scope**: Confirm `auto-generated/` changes are scoped to the target tenant only:
+   ```bash
+   git diff --name-only -- tenants-config/auto-generated/ | grep -v "tenants/<tenant>"
+   ```
+   If any auto-generated files for other tenants appear, discard them with `git checkout` before committing.
+
+5. **Commit**: Stage and commit both the source files (tenant YAML, RPA, constraints, CODEOWNERS) and the scoped `auto-generated/` output.
+
+6. **Push and open MR**:
+   ```bash
+   git push origin bot/onboarding-<TICKET_KEY>
+   glab mr create \
+     --source-branch bot/onboarding-<TICKET_KEY> \
+     --target-branch main \
+     --repo releng/konflux-release-data \
+     --hostname gitlab.cee.redhat.com \
+     --title "Add Konflux config for <instance_name>" \
+     --description "Onboarding: adds Application, Component, ImageRepository, ReleasePlan, IntegrationTestScenario, and ReleasePlanAdmission for <instance_name>."
+   ```
 
 Post MR link. Link MR to Jira: `jira_create_remote_issue_link` on both the parent ticket and the Phase 2 sub-ticket. Apply `onboarding:konflux-mr`. Transition Phase 2 sub-ticket to "In Progress" (team needs to merge MR). Store Konflux info in metadata.
 
@@ -242,7 +276,32 @@ Wait for: pipelines merged, build ran, Quay image exists.
    team in JIRA or Slack and we'll help get one set up.
    ```
    If the team doesn't have an app-interface role, apply `onboarding:blocked`.
-3. Clone app-interface fork → discover infrastructure values at generation time → `/generate-app-interface` → commit → push → open MR. The MR includes:
+3. **Clone the existing app-interface fork** — do NOT attempt to fork; the fork already exists. Look up `app-interface` in `project-repos.json` for the fork and upstream URLs:
+   ```bash
+   git clone <project-repos.json url> /tmp/app-interface
+   cd /tmp/app-interface
+   git remote add upstream <project-repos.json upstream>
+   git fetch upstream master
+   git checkout -b bot/onboarding-<TICKET_KEY> upstream/master
+   ```
+
+4. **Discover and generate**: Discover infrastructure values at generation time, then run `/generate-app-interface` targeting `/tmp/app-interface`.
+
+5. **Commit**: Stage and commit all generated files.
+
+6. **Push and open MR**:
+   ```bash
+   git push origin bot/onboarding-<TICKET_KEY>
+   glab mr create \
+     --source-branch bot/onboarding-<TICKET_KEY> \
+     --target-branch master \
+     --repo service/app-interface \
+     --hostname gitlab.cee.redhat.com \
+     --title "[Phase 3/3] Add <instance_name> deployment (<TICKET_KEY>)" \
+     --description "Onboarding: adds SaaS deploy file, codeComponents entry, and self-service datafile for <instance_name>."
+   ```
+
+   The MR includes:
    - The deploy file (`<instance_name>-deploy.yml`)
    - A `codeComponents` entry in `app.yml` for the instance repo (if not already present)
    - A `self_service` datafile entry in the team's role file (`team_role_ref`) under the `saas-file-self-service` change type, pointing to the new deploy file. This gives the team self-service approval for future deploy config changes.

--- a/presets/workflows/onboarding/skills/generate-instance/generate_instance.py
+++ b/presets/workflows/onboarding/skills/generate-instance/generate_instance.py
@@ -126,11 +126,13 @@ def _build_project_repos(repos):
         elif host == "github":
             repo_basename = fork_repo_name or _parse_repo_basename(url, "github.com")
             entry["url"] = f"https://github.com/{fork_account}/{repo_basename}.git"
-            entry["upstream"] = url
+            upstream = url if url.endswith(".git") else f"{url.rstrip('/')}.git"
+            entry["upstream"] = upstream
         elif host == "gitlab":
             repo_basename = fork_repo_name or _parse_repo_basename(url, "gitlab.cee.redhat.com")
             entry["url"] = f"https://gitlab.cee.redhat.com/{fork_account}/{repo_basename}.git"
-            entry["upstream"] = url
+            upstream = url if url.endswith(".git") else f"{url.rstrip('/')}.git"
+            entry["upstream"] = upstream
             entry["host"] = "gitlab"
         else:
             entry["url"] = url


### PR DESCRIPTION
Description

  Fix the onboarding workflow so the bot correctly clones pre-existing GitLab forks (konflux-release-data, app-interface) instead of trying to fork the repos itself — which fails because the bot account doesn't have fork
  permissions.

  Three issues fixed:
  1. Phase 2 & 3 fork instructions: The CLAUDE.md had terse one-liners ("Clone fork → push → open MR") that didn't specify the fork URL, causing the bot to attempt forking. Replaced with explicit step-by-step instructions that
  reference project-repos.json for fork/upstream URLs, including full git clone, git remote add upstream, branch creation, and glab mr create commands.
  2. JIRA comment link rendering: Nested square brackets in markdown links (e.g., [PR: [Phase 1/3] text](url)) break the markdown-to-ADF conversion. Added a comment template that avoids nested brackets.
  3. Missing .git suffix on upstream URLs: generate_instance.py appended .git to fork URLs but not upstream URLs, causing git remote mismatches.

  REHOR-61 (https://issues.redhat.com/browse/REHOR-61)

  ---
  Blast radius
  
  - Onboarding workflow only — changes are scoped to presets/workflows/onboarding/
  - Affects any new onboarding run (Phase 1 comment, Phase 2 Konflux MR, Phase 3 app-interface MR)
  - No impact on existing jira-sprint, jira-kanban, or quality-monitor workflows
  - Tested against the rehor-onboarding-agent test instance (REHOR-61 onboarding run)

  ---
  Rollback plan
  
  Git revert is sufficient. These are instruction/template changes with no runtime dependencies.

  ---
  Checklist
  
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest

  AI disclosure

  Assisted by: Claude Code