### PR TITLE
fix(proxy): allow download.pytorch.org in egress allowlist

### DIFF
--- a/proxy/squid.conf
+++ b/proxy/squid.conf
@@ -25,6 +25,9 @@ acl allowed_domains dstdomain pypi.org
 acl allowed_domains dstdomain files.pythonhosted.org
 acl allowed_domains dstdomain pypi.python.org
 
+# Python / ML ecosystem (PyTorch index needed by uv lock)
+acl allowed_domains dstdomain download.pytorch.org
+
 # Go toolchain and modules
 acl allowed_domains dstdomain go.dev
 acl allowed_domains dstdomain dl.google.com


### PR DESCRIPTION
## Summary
- Adds `download.pytorch.org` to Squid egress proxy allowlist
- Needed by `uv lock` in rag-content — PyTorch is a transitive dep via llama-index/docling
- Without this, every Python dependency bump requires manual hash fetching

## Ref
REHOR-96

🤖 Generated with [Claude Code](https://claude.com/claude-code)