### PR TITLE
fix(onboarding): final pass at onboarding instance code review

### DIFF
--- a/bot/tests/test_onboarding_preflight.py
+++ b/bot/tests/test_onboarding_preflight.py
@@ -273,7 +273,7 @@ def test_blocked_task_skipped(env_vars, monkeypatch, capsys):
     assert "BLOCKED" in out["content"]
 
 
-def test_auto_advance_label_returns_start(env_vars, monkeypatch, capsys):
+def test_auto_advance_label_merged_returns_start(env_vars, monkeypatch, capsys):
     tasks = _mock_tasks(
         active=[
             {
@@ -293,12 +293,42 @@ def test_auto_advance_label_returns_start(env_vars, monkeypatch, capsys):
     monkeypatch.setattr("onboarding_preflight.get_capacity", lambda: (1, 10))
     monkeypatch.setattr("onboarding_preflight._jira_issue", lambda key: issue)
     monkeypatch.setattr("onboarding_preflight._get_candidates", lambda: [])
+    monkeypatch.setattr("onboarding_preflight._any_pr_mr_merged", lambda t: True)
     monkeypatch.setattr("onboarding_preflight.jira_cleanup", lambda: None)
 
     main()
     out = json.loads(capsys.readouterr().out.strip())
     assert out["status"] == "start"
-    assert "CHECK FOR PHASE ADVANCE" in out["content"]
+    assert "PR/MR MERGED" in out["content"]
+
+
+def test_auto_advance_label_not_merged_returns_skip(env_vars, monkeypatch, capsys):
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "REHOR-40",
+                "status": "in_progress",
+                "repo": "",
+                "last_addressed": "2026-07-01T12:00:00",
+                "metadata": {"step": "scaffolding-pr"},
+            }
+        ]
+    )
+    issue = {
+        "labels": ["rehor-ai-onboarding-bot", "onboarding:scaffolding-pr"],
+        "comments": [],
+    }
+    monkeypatch.setattr("onboarding_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("onboarding_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("onboarding_preflight._jira_issue", lambda key: issue)
+    monkeypatch.setattr("onboarding_preflight._get_candidates", lambda: [])
+    monkeypatch.setattr("onboarding_preflight._any_pr_mr_merged", lambda t: False)
+    monkeypatch.setattr("onboarding_preflight.jira_cleanup", lambda: None)
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "skip"
+    assert "waiting for PR/MR merge" in out["content"]
 
 
 def test_missing_instance_id_returns_error(monkeypatch, capsys):

--- a/presets/shared/preflight/onboarding_preflight.py
+++ b/presets/shared/preflight/onboarding_preflight.py
@@ -8,8 +8,10 @@ Returns start when there's actionable work:
   - Nothing actionable → skip
 """
 
+import json
 import os
 import re
+import subprocess
 
 from common import (
     INSTANCE_ID,
@@ -20,6 +22,7 @@ from common import (
     get_tasks,
     output_result,
     save_state,
+    upstream_repo,
 )
 from jira_mcp import jira_call, jira_cleanup
 
@@ -98,6 +101,50 @@ def _get_onboarding_label(issue):
     return None
 
 
+def _any_pr_mr_merged(task):
+    """Check if any tracked PR/MR on this task has been merged."""
+    prs = get_task_prs(task)
+    for p in prs:
+        host = p.get("host", "github")
+        num = p.get("number")
+        repo = p.get("repo", "")
+        if not num or not repo:
+            continue
+        try:
+            if host == "github":
+                up, _ = upstream_repo(repo)
+                if not up:
+                    continue
+                r = subprocess.run(
+                    ["gh", "pr", "view", str(num), "--repo", up, "--json", "state"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+                if r.returncode == 0:
+                    data = json.loads(r.stdout)
+                    if data.get("state") == "MERGED":
+                        return True
+            else:
+                up, _ = upstream_repo(repo)
+                if not up:
+                    continue
+                encoded = up.replace("/", "%2F")
+                r = subprocess.run(
+                    ["glab", "api", f"projects/{encoded}/merge_requests/{num}", "--hostname", "gitlab.cee.redhat.com"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+                if r.returncode == 0:
+                    data = json.loads(r.stdout)
+                    if data.get("state") == "merged":
+                        return True
+        except Exception:
+            continue
+    return False
+
+
 def _fmt_candidate(issue):
     key = issue.get("key", "?")
     fields = issue.get("fields", {})
@@ -163,8 +210,11 @@ def main():
 
         labels_with_auto_advance = ("scaffolding-pr", "konflux-mr", "app-interface-mr")
         if step_from_label in labels_with_auto_advance:
-            task_lines.append(f"  *** CHECK FOR PHASE ADVANCE (current: {step_from_label}) ***")
-            has_work = True
+            if _any_pr_mr_merged(task):
+                task_lines.append(f"  *** PR/MR MERGED — ADVANCE PHASE (current: {step_from_label}) ***")
+                has_work = True
+            else:
+                task_lines.append(f"  waiting for PR/MR merge (current: {step_from_label})")
 
         lines.append("\n".join(task_lines))
 

--- a/presets/workflows/onboarding/CLAUDE.md
+++ b/presets/workflows/onboarding/CLAUDE.md
@@ -106,7 +106,7 @@ Parse team responses from comments.
 The slug for `bot_name`, `bot_label`, and `config_name` is derived from team/project context, not from `instance_name`. These are all independently settable.
 
 When all gathered:
-1. `git clone --depth 1` target repos
+1. `git clone` target repos (full clone — do NOT use `--depth 1`)
 2. `/detect-tech-stack` on each
 3. `needs_team_review` → tag Rehor team (unsupported stack), apply `onboarding:blocked`
 4. `/post-plan` w/ config
@@ -196,17 +196,20 @@ Parse Konflux responses, then generate and submit the Konflux MR:
 
 5. **Commit**: Stage and commit both the source files (tenant YAML, RPA, constraints, CODEOWNERS) and the scoped `auto-generated/` output.
 
-6. **Push and open MR**:
+6. **Push and open MR** — do NOT use `glab mr create` (doesn't work for cross-fork MRs). Use the API:
    ```bash
    git push origin bot/onboarding-<TICKET_KEY>
-   glab mr create \
-     --source-branch bot/onboarding-<TICKET_KEY> \
-     --target-branch main \
-     --repo releng/konflux-release-data \
-     --hostname gitlab.cee.redhat.com \
-     --title "Add Konflux config for <instance_name>" \
-     --description "Onboarding: adds Application, Component, ImageRepository, ReleasePlan, IntegrationTestScenario, and ReleasePlanAdmission for <instance_name>."
+   glab api projects/releng%2Fkonflux-release-data/merge_requests -X POST \
+     -f source_branch="bot/onboarding-<TICKET_KEY>" \
+     -f target_branch="main" \
+     -f title="Add Konflux config for <instance_name>" \
+     -f description="$(cat <<'EOF'
+   Onboarding: adds Application, Component, ImageRepository, ReleasePlan, IntegrationTestScenario, and ReleasePlanAdmission for <instance_name>.
+   EOF
+   )" \
+     --hostname gitlab.cee.redhat.com
    ```
+   Parse the MR number and URL from the JSON response.
 
 Post MR link. Link MR to Jira: `jira_create_remote_issue_link` on both the parent ticket and the Phase 2 sub-ticket. Apply `onboarding:konflux-mr`. Transition Phase 2 sub-ticket to "In Progress" (team needs to merge MR). Store Konflux info in metadata.
 
@@ -289,17 +292,20 @@ Wait for: pipelines merged, build ran, Quay image exists.
 
 5. **Commit**: Stage and commit all generated files.
 
-6. **Push and open MR**:
+6. **Push and open MR** — do NOT use `glab mr create` (doesn't work for cross-fork MRs). Use the API:
    ```bash
    git push origin bot/onboarding-<TICKET_KEY>
-   glab mr create \
-     --source-branch bot/onboarding-<TICKET_KEY> \
-     --target-branch master \
-     --repo service/app-interface \
-     --hostname gitlab.cee.redhat.com \
-     --title "[Phase 3/3] Add <instance_name> deployment (<TICKET_KEY>)" \
-     --description "Onboarding: adds SaaS deploy file, codeComponents entry, and self-service datafile for <instance_name>."
+   glab api projects/service%2Fapp-interface/merge_requests -X POST \
+     -f source_branch="bot/onboarding-<TICKET_KEY>" \
+     -f target_branch="master" \
+     -f title="[Phase 3/3] Add <instance_name> deployment (<TICKET_KEY>)" \
+     -f description="$(cat <<'EOF'
+   Onboarding: adds SaaS deploy file, codeComponents entry, and self-service datafile for <instance_name>.
+   EOF
+   )" \
+     --hostname gitlab.cee.redhat.com
    ```
+   Parse the MR number and URL from the JSON response.
 
    The MR includes:
    - The deploy file (`<instance_name>-deploy.yml`)
@@ -439,6 +445,7 @@ All skills MUST use these field names. No aliases.
 | `gcp_region` | generate-app-interface | GCP region (default: `global`) |
 | `bot_name` | generate-instance, generate-app-interface | OpenShift deployment name |
 | `bot_label` | generate-instance, generate-app-interface, post-manual-steps | Jira label the bot filters on |
+| `board_name` | generate-app-interface | Jira board name or ID (`BOT_BOARD_NAME`). Required for jira-sprint and jira-kanban workflows. |
 | `dedicated_proxy` | post-plan, post-manual-steps | Whether team needs own proxy (dedicated infra) |
 | `service_tree` | generate-app-interface | Path under `data/services/` for separate pattern (e.g., `my-platform/my-team`). Required for `separate`, not used for `shared`. |
 | `app_ref` | generate-app-interface | `$ref` to app.yml (default: shared service tree). Override for separate pattern. |
@@ -460,6 +467,7 @@ All skills MUST use these field names. No aliases.
 - After completion: `memory_store` category `learning` tags `onboarding`
 - Use runtime env vars: `GH_USER_NAME`, `BOT_JIRA_EMAIL`, `BOT_CONFIG_PATH`
 - No emojis in Jira comments or PR/MR descriptions — keep tone professional and plain
+- Never use `--depth 1` when cloning repos you need to push to — shallow clones cannot push to a remote
 
 ---
 

--- a/presets/workflows/onboarding/skills/create-phase-tickets/create_phase_tickets.py
+++ b/presets/workflows/onboarding/skills/create-phase-tickets/create_phase_tickets.py
@@ -68,7 +68,7 @@ def _detect_parent_type(issue_key):
     )
     if not result:
         return None
-    issuetype = result.get("issuetype") or result.get("fields", {}).get("issuetype")
+    issuetype = result.get("issue_type") or result.get("issuetype") or result.get("fields", {}).get("issuetype")
     if isinstance(issuetype, dict):
         return issuetype.get("name")
     return None
@@ -106,7 +106,7 @@ def create_tickets(epic_key, project_key, team_name):
             print(f"ERROR: Failed to create ticket for {phase['key']}", file=sys.stderr)
             return None
 
-        ticket_key = result.get("key")
+        ticket_key = result.get("key") or (result.get("issue") or {}).get("key")
         if not ticket_key:
             print(f"ERROR: No key returned for {phase['key']}: {result}", file=sys.stderr)
             return None

--- a/presets/workflows/onboarding/skills/create-phase-tickets/tests/test_create_phase_tickets.py
+++ b/presets/workflows/onboarding/skills/create-phase-tickets/tests/test_create_phase_tickets.py
@@ -14,25 +14,25 @@ from create_phase_tickets import PHASES, create_tickets
 
 def _mock_story_parent(tool_name, arguments):
     if tool_name == "jira_get_issue":
-        return {"fields": {"issuetype": {"name": "Story"}}}
+        return {"issue_type": {"name": "Story"}}
     if tool_name == "jira_create_issue":
         summary = arguments.get("summary", "")
         for i, phase in enumerate(PHASES):
             if phase["summary"] in summary:
-                return {"key": f"RHCLOUD-10{i}"}
-        return {"key": "RHCLOUD-999"}
+                return {"message": "Issue created", "issue": {"key": f"RHCLOUD-10{i}"}}
+        return {"message": "Issue created", "issue": {"key": "RHCLOUD-999"}}
     return None
 
 
 def _mock_epic_parent(tool_name, arguments):
     if tool_name == "jira_get_issue":
-        return {"fields": {"issuetype": {"name": "Epic"}}}
+        return {"issue_type": {"name": "Epic"}}
     if tool_name == "jira_create_issue":
         summary = arguments.get("summary", "")
         for i, phase in enumerate(PHASES):
             if phase["summary"] in summary:
-                return {"key": f"RHCLOUD-10{i}"}
-        return {"key": "RHCLOUD-999"}
+                return {"message": "Issue created", "issue": {"key": f"RHCLOUD-10{i}"}}
+        return {"message": "Issue created", "issue": {"key": "RHCLOUD-999"}}
     return None
 
 
@@ -40,7 +40,7 @@ def _mock_unknown_parent(tool_name, arguments):
     if tool_name == "jira_get_issue":
         return None
     if tool_name == "jira_create_issue":
-        return {"key": "RHCLOUD-100"}
+        return {"message": "Issue created", "issue": {"key": "RHCLOUD-100"}}
     return None
 
 

--- a/presets/workflows/onboarding/skills/generate-app-interface/generate_app_interface.py
+++ b/presets/workflows/onboarding/skills/generate-app-interface/generate_app_interface.py
@@ -315,11 +315,9 @@ def _add_code_component(cfg, repo_path):
     if not isinstance(data, dict) or "codeComponents" not in data:
         return None
 
-    if not isinstance(data["codeComponents"], list):
-        data["codeComponents"] = []
-
-    data["codeComponents"].append({"name": instance_name, "resource": "upstream", "url": repo_url})
-    app_path.write_text("---\n" + yaml.dump(data, default_flow_style=False, sort_keys=False))
+    new_entry = f"- name: {instance_name}\n  resource: upstream\n  url: {repo_url}"
+    content = content.rstrip("\n")
+    app_path.write_text(content + "\n" + new_entry + "\n")
     return str(app_path.relative_to(repo_path))
 
 
@@ -355,25 +353,40 @@ def _add_self_service_datafile(cfg, repo_path):
     if not isinstance(data, dict):
         return None
 
-    if "self_service" not in data or not isinstance(data["self_service"], list):
-        data["self_service"] = []
+    new_datafile_line = f"  - $ref: {deploy_ref}"
 
-    ss_entry = None
-    for entry in data["self_service"]:
-        ct = entry.get("change_type", {})
-        if isinstance(ct, dict) and ct.get("$ref") == SAAS_SELF_SERVICE_REF:
-            ss_entry = entry
-            break
+    ss_ref_pattern = re.escape(SAAS_SELF_SERVICE_REF)
+    ss_match = re.search(rf"\$ref:\s*{ss_ref_pattern}", content)
+    if ss_match:
+        datafiles_match = re.search(r"datafiles:\s*\n", content[ss_match.end() :])
+        if datafiles_match:
+            block_start = ss_match.end() + datafiles_match.end()
+            last_ref_end = block_start
+            for m in re.finditer(r"  - \$ref:\s*\S+[^\n]*\n?", content[block_start:]):
+                last_ref_end = block_start + m.end()
+            if content[last_ref_end - 1 : last_ref_end] != "\n":
+                new_datafile_line = "\n" + new_datafile_line
+            updated = (
+                content[:last_ref_end].rstrip("\n")
+                + "\n"
+                + new_datafile_line
+                + "\n"
+                + content[last_ref_end:].lstrip("\n")
+            )
+            role_path.write_text(updated)
+            return str(role_path.relative_to(repo_path))
 
-    if ss_entry is None:
-        ss_entry = {"change_type": {"$ref": SAAS_SELF_SERVICE_REF}, "datafiles": []}
-        data["self_service"].append(ss_entry)
+    new_ct_block = f"- change_type:\n    $ref: {SAAS_SELF_SERVICE_REF}\n  datafiles:\n{new_datafile_line}\n"
 
-    if "datafiles" not in ss_entry or not isinstance(ss_entry["datafiles"], list):
-        ss_entry["datafiles"] = []
+    if "self_service:" in content:
+        ss_line_match = re.search(r"^self_service:\s*$", content, re.MULTILINE)
+        if ss_line_match:
+            insert_pos = ss_line_match.end()
+            role_path.write_text(content[:insert_pos] + "\n" + new_ct_block + content[insert_pos:])
+            return str(role_path.relative_to(repo_path))
 
-    ss_entry["datafiles"].append({"$ref": deploy_ref})
-    role_path.write_text("---\n" + yaml.dump(data, default_flow_style=False, sort_keys=False))
+    content = content.rstrip("\n") + "\n\nself_service:\n" + new_ct_block
+    role_path.write_text(content)
     return str(role_path.relative_to(repo_path))
 
 


### PR DESCRIPTION
Description

  Fixes 6 issues discovered during the REHOR-63 onboarding test run.

  1. board_name missing from canonical field names — generate-app-interface consumes board_name but it wasn't in the canonical table, so the bot omitted it from generated configs for jira-sprint/kanban workflows.
  2. create_phase_tickets.py Jira response parsing crash — jira_create_issue via MCP returns {"message": "...", "issue": {"key": "..."}}, not {"key": "..."}. Also jira_get_issue returns issue_type (underscore), not issuetype. Both
  caused the claim script to crash and the bot to work around it manually.
  3. generate_app_interface.py YAML roundtrip reformats entire file — yaml.dump() on app.yml and role files destroyed comments, quoting styles, and formatting. Bot had to git checkout and redo edits manually each time. Replaced
  with text-based insertion (keeps yaml.safe_load for validation only).
  4. Shallow clone blocks push — Phase 1 used git clone --depth 1, which can't push to a remote. Changed to full clone and added a general rule.
  5. Cross-fork GitLab MR creation fails — glab mr create doesn't work for cross-fork MRs. Replaced with glab api calls matching the pattern already used by jira-sprint/kanban workflows.
  6. Preflight auto-advance wastes ~$20 on idle polling — Auto-advance labels (scaffolding-pr, konflux-mr, app-interface-mr) unconditionally returned "start", triggering a full AI session ($0.20-$0.37) every 5 minutes even when
  nothing changed. Now checks actual PR/MR merge status via gh/glab CLI before returning "start".

  REHOR-63 (https://issues.redhat.com/browse/REHOR-63)

  ---
  Blast radius
  
  - Onboarding workflow only — all changes scoped to onboarding skills, onboarding CLAUDE.md, and onboarding preflight
  - create_phase_tickets.py is the only caller of jira_call("jira_create_issue") in the repo; non-onboarding workflows use Claude Code's native MCP integration
  - _any_pr_mr_merged() follows the same subprocess.run / upstream_repo() / timeout=15 patterns used by gh_pr_status.py and gl_mr_status.py
  - glab api pattern matches jira-sprint and jira-kanban CLAUDE.md exactly
  - Tested: all 171 affected tests pass (create-phase-tickets 8, generate-app-interface 81, generate-instance 60, onboarding-preflight 22). Ruff 0.16.0 format + lint clean.

  ---
  Rollback plan

  Git revert is sufficient. No schema changes, no new env vars, no infrastructure changes.
  
  ---
  Checklist

  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest

  AI disclosure

  Assisted by: Claude Code