### PR TITLE
fix(memory-server): fix upstream lint violations

### DIFF
--- a/memory-server/tests/test_instance_sleep.py
+++ b/memory-server/tests/test_instance_sleep.py
@@ -1,6 +1,6 @@
 """Tests for instance sleep heartbeat (last_seen column and wake-poll update)."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from bot_memory_server.api import _instance_row
@@ -39,7 +39,7 @@ async def test_last_seen_column_exists(db):
 async def test_last_seen_updated_on_wake_poll(db):
     await _apply_schema(db)
     await _insert_instance(db, "inst-2")
-    before = datetime.now(timezone.utc)
+    before = datetime.now(UTC)
     await db.execute(UPDATE_LAST_SEEN_SQL, "inst-2")
     row = await db.fetchrow("SELECT * FROM bot_instances WHERE instance_id = $1", "inst-2")
     assert row["last_seen"] is not None
@@ -49,7 +49,7 @@ async def test_last_seen_updated_on_wake_poll(db):
 @pytest.mark.asyncio
 async def test_last_seen_in_instance_row(db):
     await _apply_schema(db)
-    ts = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    ts = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
     await db.execute(
         """INSERT INTO bot_instances (instance_id, state, message, repo, last_seen)
            VALUES ($1, $2, $3, $4, $5)""",


### PR DESCRIPTION
Description

  Fix ruff UP017 lint violation introduced in #391 — timezone.utc → datetime.UTC alias in memory server/tests/test_instance_sleep.py. @petrsimon FYI

  CI runs ruff@0.16.0 which flags timezone.utc as deprecated in favor of the datetime.UTC alias (available since Python 3.11).

  ---
  Blast radius
  
  Test file only (memory-server/tests/test_instance_sleep.py). No runtime code changed.

  ---
  Rollback plan
  
  git revert is sufficient.

  ---
  Checklist
  
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest

  AI disclosure

  Assisted by: Claude Code