### PR TITLE
fix(api): cycle run transcripts never stored — record_transcript posts to localhost (REHOR-102)

### DIFF
--- a/bot/transcripts.py
+++ b/bot/transcripts.py
@@ -18,7 +18,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CYCLE_RUNS_API = os.environ.get("CYCLE_RUNS_API_URL", f"{MEMORY_API_BASE}/cycle-runs")
+
+def _get_cycle_runs_url() -> str:
+    explicit = os.environ.get("CYCLE_RUNS_API_URL")
+    if explicit:
+        return explicit
+    costs_url = os.environ.get("COSTS_API_URL", "")
+    if costs_url:
+        return costs_url.rsplit("/costs", 1)[0] + "/cycle-runs"
+    return f"{MEMORY_API_BASE}/cycle-runs"
+
 
 _WORK_TYPE_TO_CYCLE_TYPE = {
     "new_ticket": "task_work",
@@ -121,10 +130,11 @@ def record_transcript(
         logger.debug("Transcript file not found for session %s", session_id)
 
     try:
-        resp = httpx.post(CYCLE_RUNS_API, json=body, timeout=10.0)
+        url = _get_cycle_runs_url()
+        resp = httpx.post(url, json=body, timeout=10.0)
         logger.info("Cycle run stored: id=%s status=%s", resp.json().get("id"), resp.status_code)
     except Exception:
-        logger.warning("Failed to push cycle run to %s", CYCLE_RUNS_API, exc_info=True)
+        logger.warning("Failed to push cycle run to %s", _get_cycle_runs_url(), exc_info=True)
 
 
 def post_orphan_cycle(
@@ -151,7 +161,8 @@ def post_orphan_cycle(
         },
     }
     try:
-        resp = httpx.post(CYCLE_RUNS_API, json=body, timeout=10.0)
+        url = _get_cycle_runs_url()
+        resp = httpx.post(url, json=body, timeout=10.0)
         logger.info("Orphan cycle posted: id=%s type=%s", resp.json().get("id"), cycle_type)
     except Exception:
-        logger.warning("Failed to post orphan cycle to %s", CYCLE_RUNS_API, exc_info=True)
+        logger.warning("Failed to post orphan cycle to %s", _get_cycle_runs_url(), exc_info=True)

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -1067,15 +1067,16 @@ async def api_cycle_runs_add(request: Request) -> JSONResponse:
     instance_id_val = body.get("instance_id")
     input_prompt = body.get("input_prompt")
 
-    # When uploading a transcript, attach it to the most recent cycle_run
-    # for this specific instance that has no transcript yet (created by
-    # progress_store during the same cycle).
+    # Attach metadata (and optional transcript) to the most recent cycle_run
+    # for this instance that has no transcript yet (created by progress_store
+    # during the same cycle). If no transcript is available, still merge the
+    # metadata so we don't create a duplicate cycle_run.
     row = None
-    if transcript_bytes and instance_id_val:
+    if instance_id_val:
         row = await pool.fetchrow(
             f"""
             UPDATE cycle_runs
-            SET transcript = $1,
+            SET transcript = COALESCE($1, transcript),
                 finished_at = COALESCE($2, finished_at, NOW()),
                 tool_calls = COALESCE($3, tool_calls),
                 tokens_used = COALESCE($4, tokens_used),

--- a/memory-server/tests/test_cycle_runs.py
+++ b/memory-server/tests/test_cycle_runs.py
@@ -82,6 +82,8 @@ def mock_pool():
 
 @pytest.mark.asyncio
 async def test_post_cycle_run_basic(mock_pool):
+    # UPDATE (no orphan found → None), then INSERT
+    mock_pool.fetchrow = AsyncMock(side_effect=[None, _fake_cycle_run_row(id=1, task_id=42)])
     body = {
         "task_id": 42,
         "cycle_type": "task_work",
@@ -97,7 +99,7 @@ async def test_post_cycle_run_basic(mock_pool):
     assert data["id"] == 1
     assert data["task_id"] == 42
     assert data["cycle_type"] == "task_work"
-    mock_pool.fetchrow.assert_called_once()
+    assert mock_pool.fetchrow.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -179,6 +181,8 @@ async def test_post_cycle_run_no_task(mock_pool):
 
 @pytest.mark.asyncio
 async def test_post_cycle_run_with_timestamps(mock_pool):
+    # UPDATE (no orphan found → None), then INSERT
+    mock_pool.fetchrow = AsyncMock(side_effect=[None, _fake_cycle_run_row(id=1, task_id=42)])
     body = {
         "task_id": 42,
         "cycle_type": "task_work",
@@ -193,9 +197,82 @@ async def test_post_cycle_run_with_timestamps(mock_pool):
         resp = await client.post("/api/cycle-runs", json=body)
 
     assert resp.status_code == 201
+    # call_args is from the INSERT call (UPDATE returned None, INSERT was second)
     call_args = mock_pool.fetchrow.call_args[0]
-    assert call_args[6] == 87  # tool_calls
-    assert call_args[7] == 150000  # tokens_used
+    assert call_args[6] == 87  # tool_calls ($6 in INSERT)
+    assert call_args[7] == 150000  # tokens_used ($7 in INSERT)
+
+
+# --- REST API: POST /api/cycle-runs — merge without transcript (REHOR-102) ---
+
+
+@pytest.mark.asyncio
+async def test_post_cycle_run_no_transcript_merges_into_orphan(mock_pool):
+    """REHOR-102: When record_transcript posts without a transcript (file not found),
+    it should still UPDATE the existing progress_store row instead of creating a duplicate."""
+    # UPDATE finds the orphan → returns updated row
+    mock_pool.fetchrow = AsyncMock(return_value=_fake_cycle_run_row(id=50, task_id=42, has_transcript=False))
+
+    body = {
+        "task_id": 42,
+        "cycle_type": "task_work",
+        "instance_id": "test-instance",
+        "tool_calls": 30,
+        "tokens_used": 80000,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/cycle-runs", json=body)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["id"] == 50
+    assert mock_pool.fetchrow.call_count == 1
+    query = mock_pool.fetchrow.call_args[0][0]
+    assert "UPDATE cycle_runs" in query
+    assert "COALESCE($1, transcript)" in query
+
+
+@pytest.mark.asyncio
+async def test_post_cycle_run_no_transcript_no_orphan_inserts(mock_pool):
+    """REHOR-102: When no orphan exists and no transcript provided, fall through to INSERT."""
+    mock_pool.fetchrow = AsyncMock(side_effect=[None, _fake_cycle_run_row(id=51, task_id=42)])
+
+    body = {
+        "task_id": 42,
+        "cycle_type": "task_work",
+        "instance_id": "test-instance",
+        "tool_calls": 25,
+        "tokens_used": 60000,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/cycle-runs", json=body)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["id"] == 51
+    assert mock_pool.fetchrow.call_count == 2
+    insert_query = mock_pool.fetchrow.call_args[0][0]
+    assert "INSERT INTO cycle_runs" in insert_query
+
+
+@pytest.mark.asyncio
+async def test_post_cycle_run_no_instance_id_skips_update(mock_pool):
+    """Without instance_id, skip the UPDATE path entirely and INSERT directly."""
+    mock_pool.fetchrow = AsyncMock(return_value=_fake_cycle_run_row(id=52, task_id=None, cycle_type="idle"))
+
+    body = {
+        "cycle_type": "idle",
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/api/cycle-runs", json=body)
+
+    assert resp.status_code == 201
+    assert mock_pool.fetchrow.call_count == 1
+    query = mock_pool.fetchrow.call_args[0][0]
+    assert "INSERT INTO cycle_runs" in query
 
 
 # --- REST API: GET /api/cycle-runs ---

--- a/memory-server/tests/test_cycle_runs_regression.py
+++ b/memory-server/tests/test_cycle_runs_regression.py
@@ -427,6 +427,210 @@ async def test_cycle_runs_filter_by_type(db):
     assert len(rows) == 2
 
 
+# --- REHOR-102: No-transcript merge into progress_store row ---
+
+
+@pytest.mark.asyncio
+async def test_no_transcript_merges_into_progress_store_row(db):
+    """REHOR-102: When record_transcript posts without a transcript (file not found),
+    the API should merge metadata into the existing progress_store row, not create a duplicate.
+
+    Simulates the real sequence:
+    1. progress_store creates a cycle_run (no transcript)
+    2. record_transcript posts tool_calls/tokens_used but no transcript_b64
+    Expected: single row with merged metadata, NOT two rows.
+    """
+    await _apply_schema(db)
+    task = await _insert_task(db, "REHOR-102")
+    task_id = task["id"]
+
+    # Step 1: progress_store creates the initial row
+    orphan = await _insert_cycle_run(
+        db,
+        task_id=task_id,
+        instance_id="bot-merge-test",
+        tool_calls=None,
+        tokens_used=None,
+        progress={"last_step": "implemented"},
+    )
+    assert orphan["has_transcript"] is False
+
+    # Step 2: record_transcript merges metadata (no transcript)
+    merged = await db.fetchrow(
+        """
+        UPDATE cycle_runs
+        SET transcript = COALESCE($1, transcript),
+            tool_calls = COALESCE($2, tool_calls),
+            tokens_used = COALESCE($3, tokens_used)
+        WHERE id = (
+            SELECT id FROM cycle_runs
+            WHERE instance_id = $4
+              AND transcript IS NULL
+              AND created_at > NOW() - INTERVAL '2 hours'
+            ORDER BY created_at DESC
+            LIMIT 1
+        )
+        RETURNING id, tool_calls, tokens_used,
+                  (transcript IS NOT NULL) AS has_transcript
+        """,
+        None,  # no transcript bytes
+        87,
+        150000,
+        "bot-merge-test",
+    )
+    assert merged is not None
+    assert merged["id"] == orphan["id"]
+    assert merged["tool_calls"] == 87
+    assert merged["tokens_used"] == 150000
+    assert merged["has_transcript"] is False
+
+    # Verify only one row exists
+    total = await db.fetchval(
+        "SELECT COUNT(*) FROM cycle_runs WHERE instance_id = $1",
+        "bot-merge-test",
+    )
+    assert total == 1
+
+
+@pytest.mark.asyncio
+async def test_transcript_merge_preserves_existing_transcript(db):
+    """REHOR-102: COALESCE($1, transcript) must not overwrite an existing transcript with NULL."""
+    await _apply_schema(db)
+
+    await _insert_cycle_run(
+        db,
+        instance_id="bot-preserve-test",
+        transcript=b"existing-transcript-data",
+        tool_calls=10,
+    )
+
+    result = await db.fetchrow(
+        """
+        UPDATE cycle_runs
+        SET transcript = COALESCE($1, transcript),
+            tool_calls = COALESCE($2, tool_calls)
+        WHERE id = (
+            SELECT id FROM cycle_runs
+            WHERE instance_id = $3
+              AND transcript IS NULL
+              AND created_at > NOW() - INTERVAL '2 hours'
+            ORDER BY created_at DESC
+            LIMIT 1
+        )
+        RETURNING id
+        """,
+        None,
+        99,
+        "bot-preserve-test",
+    )
+    # UPDATE should match nothing — the existing row already has a transcript
+    assert result is None
+
+    # Verify the existing transcript is untouched
+    row = await db.fetchrow(
+        "SELECT transcript, tool_calls FROM cycle_runs WHERE instance_id = $1",
+        "bot-preserve-test",
+    )
+    assert bytes(row["transcript"]) == b"existing-transcript-data"
+    assert row["tool_calls"] == 10
+
+
+@pytest.mark.asyncio
+async def test_no_transcript_no_orphan_creates_new_row(db):
+    """REHOR-102: When no orphan exists, the INSERT fallback creates a new row."""
+    await _apply_schema(db)
+
+    # No pre-existing rows for this instance — UPDATE will find nothing
+    result = await db.fetchrow(
+        """
+        UPDATE cycle_runs
+        SET transcript = COALESCE($1, transcript),
+            tool_calls = COALESCE($2, tool_calls)
+        WHERE id = (
+            SELECT id FROM cycle_runs
+            WHERE instance_id = $3
+              AND transcript IS NULL
+              AND created_at > NOW() - INTERVAL '2 hours'
+            ORDER BY created_at DESC
+            LIMIT 1
+        )
+        RETURNING id
+        """,
+        None,
+        50,
+        "bot-new-instance",
+    )
+    assert result is None  # nothing to merge into
+
+    # Fallback INSERT creates a new row
+    row = await _insert_cycle_run(
+        db,
+        instance_id="bot-new-instance",
+        tool_calls=50,
+        tokens_used=20000,
+    )
+    assert row["id"] is not None
+    assert row["tool_calls"] == 50
+
+    total = await db.fetchval(
+        "SELECT COUNT(*) FROM cycle_runs WHERE instance_id = $1",
+        "bot-new-instance",
+    )
+    assert total == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_cycle_runs_without_fix(db):
+    """REHOR-102: Reproduce the exact bug — progress_store + record_transcript
+    without transcript should NOT create two rows."""
+    await _apply_schema(db)
+    task = await _insert_task(db, "REHOR-102-DUPE")
+    task_id = task["id"]
+
+    # progress_store creates row #1
+    await _insert_cycle_run(
+        db,
+        task_id=task_id,
+        instance_id="bot-dupe-test",
+        progress={"last_step": "opened_pr"},
+    )
+
+    # record_transcript: attempt UPDATE first (the fix)
+    merged = await db.fetchrow(
+        """
+        UPDATE cycle_runs
+        SET transcript = COALESCE($1, transcript),
+            finished_at = COALESCE($2, finished_at, NOW()),
+            tool_calls = COALESCE($3, tool_calls),
+            tokens_used = COALESCE($4, tokens_used),
+            task_id = COALESCE(task_id, $5)
+        WHERE id = (
+            SELECT id FROM cycle_runs
+            WHERE instance_id = $6
+              AND transcript IS NULL
+              AND created_at > NOW() - INTERVAL '2 hours'
+            ORDER BY created_at DESC
+            LIMIT 1
+        )
+        RETURNING id
+        """,
+        None,  # no transcript
+        None,  # finished_at
+        45,
+        120000,
+        task_id,
+        "bot-dupe-test",
+    )
+    # The UPDATE should succeed — merged into row #1
+    assert merged is not None
+
+    total = await db.fetchval(
+        "SELECT COUNT(*) FROM cycle_runs WHERE instance_id = $1",
+        "bot-dupe-test",
+    )
+    assert total == 1
+
+
 # --- Costs POST with external_key ---
 
 


### PR DESCRIPTION
## Summary

Transcripts are missing for all bot instances running older images. Pod logs show every `record_transcript` call failing:

```
Failed to push cycle run to http://localhost:8080/api/cycle-runs
```

**Primary cause:** The deployed `constants.py` uses `os.environ.get("MEMORY_API_URL", "http://localhost:8080/api")`. `MEMORY_API_URL` is not set in any deployment — only `BOT_MEMORY_URL` and `COSTS_API_URL` are — so it falls through to `localhost:8080`. Meanwhile `progress_store` (MCP tool) works fine because it routes through `BOT_MEMORY_URL` via the MCP connection. Result: cycle_run rows exist (from `progress_store`) but never get transcripts attached.

Master already has `_derive_memory_api_base()` which reads `BOT_MEMORY_URL`, but the module-level `CYCLE_RUNS_API` constant was still evaluated at import time and couldn't be overridden. This PR replaces it with `_get_cycle_runs_url()` which checks `CYCLE_RUNS_API_URL` → derives from `COSTS_API_URL` → falls back to `MEMORY_API_BASE`, giving two reliable fallback paths.

**Secondary fix:** The UPDATE path in `POST /api/cycle-runs` (from `4108b69`) was guarded by `if transcript_bytes and instance_id_val`, so when no transcript was available the UPDATE was skipped and a duplicate INSERT created a second row. Changed to `if instance_id_val` with `COALESCE($1, transcript)`.

## Changes

- `bot/transcripts.py`: Replace module-level `CYCLE_RUNS_API` with `_get_cycle_runs_url()` callable that derives URL from available env vars at call time
- `memory-server/bot_memory_server/api.py`: Always attempt UPDATE when `instance_id` is present, not only when transcript bytes exist
- 3 new unit tests + 4 new integration tests covering the merge scenarios

## Test plan

- [x] Unit tests: 3 new tests in `test_cycle_runs.py` — no-transcript merge, no-orphan fallback, no-instance-id skip
- [x] Integration tests: 4 new tests in `test_cycle_runs_regression.py` — merge without transcript, transcript preservation, no-orphan INSERT, duplicate reproduction
- [x] All existing tests pass (29 bot, 25 memory-server unit)
- [ ] CI: regression tests require PostgreSQL
- [ ] Verify after deploy: pod logs should show `Cycle run stored` instead of `Failed to push`

Fixes [REHOR-102](https://redhat.atlassian.net/browse/REHOR-102)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)