### PR TITLE
REHOR-77: branch protection enforcement and required check governance

### DIFF
--- a/.github/branch-protection/README.md
+++ b/.github/branch-protection/README.md
@@ -1,0 +1,46 @@
+# Branch Protection Configuration
+
+This directory contains versioned branch protection policy for the `master` branch of `OpenShift-Fleet/rehor`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `required-checks.json` | Canonical list of required status checks with scope notes |
+| `master-protection.json` | Full branch protection policy (GitHub API shape) |
+
+## Required Checks
+
+Check names are extracted from real PR runs using `gh pr checks <number> --repo OpenShift-Fleet/rehor`. The names must match exactly what GitHub reports, including Konflux prefixes.
+
+### Path-scoping caveat
+
+GitHub Actions workflows in this repo use path filters. A PR touching only Python code won't trigger Go or Dashboard checks. If branch protection requires a check that doesn't run, the PR will be blocked.
+
+**Current approach:** require only the two Konflux container build checks that always run on every PR (main bot + memory-server). Path-filtered checks (all GitHub Actions workflows + proxy Konflux) are trusted to pass when they fire but not listed as hard requirements in branch protection.
+
+### Updating required checks
+
+When adding a new CI workflow or renaming a job:
+
+1. Open a PR that exercises the new check
+2. Run `gh pr checks <number> --repo OpenShift-Fleet/rehor` to capture the exact reported name
+3. Update `required-checks.json` with the new entry
+4. Update `master-protection.json` if the check should be a hard merge gate
+5. Ask an admin to re-apply protection via `scripts/apply_branch_protection.sh`
+
+## Applying protection
+
+Branch protection changes require **admin** access to the repository.
+
+`dismiss_stale_reviews` is set to `true` in the versioned policy as the current recommended default, and can be adjusted by maintainers if team review behavior changes.
+
+```bash
+# verify current state matches policy
+scripts/check_branch_protection.sh
+
+# apply policy (admin only)
+scripts/apply_branch_protection.sh
+```
+
+See `docs/operations/rehor-77-branch-protection-rollout.md` for the full rollout runbook.

--- a/.github/branch-protection/master-protection.json
+++ b/.github/branch-protection/master-protection.json
@@ -1,0 +1,20 @@
+{
+  "$comment": "GitHub branch protection policy for PUT /repos/{owner}/{repo}/branches/{branch}/protection. Apply with scripts/apply_branch_protection.sh.",
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Red Hat Konflux / platform-frontend-ai-dev-on-pull-request",
+      "Red Hat Konflux / platform-frontend-ai-dev-memory-server-on-pull-request"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}

--- a/.github/branch-protection/required-checks.json
+++ b/.github/branch-protection/required-checks.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Required status checks for master branch protection on OpenShift-Fleet/rehor",
+  "version": "1.0.0",
+  "branch": "master",
+  "checks": {
+    "github_actions": [
+      {
+        "name": "format",
+        "workflow": "ruff-format.yml",
+        "scope": "python code formatting (ruff)",
+        "required": false,
+        "note": "path-filtered to **.py, pyproject.toml, uv.lock. not a hard branch protection requirement."
+      },
+      {
+        "name": "lint",
+        "workflow": "ruff-format.yml",
+        "scope": "python linting (ruff)",
+        "required": false,
+        "note": "path-filtered to **.py, pyproject.toml, uv.lock"
+      },
+      {
+        "name": "typecheck",
+        "workflow": "ruff-format.yml",
+        "scope": "python type checking (mypy)",
+        "required": false,
+        "note": "path-filtered to **.py, pyproject.toml, uv.lock"
+      },
+      {
+        "name": "test",
+        "workflow": "ruff-format.yml",
+        "scope": "python unit tests with coverage gate",
+        "required": false,
+        "note": "path-filtered. job name collides across ruff-format.yml, go-tests.yml, dashboard-tests.yml, and memory-server-ci.yml."
+      },
+      {
+        "name": "python-audit",
+        "workflow": "dependency-audit.yml",
+        "scope": "python dependency vulnerability scan (pip-audit)",
+        "required": false,
+        "note": "path-filtered to pyproject.toml, uv.lock"
+      },
+      {
+        "name": "go-audit",
+        "workflow": "dependency-audit.yml",
+        "scope": "go dependency vulnerability scan (govulncheck)",
+        "required": false,
+        "note": "path-filtered to proxy/executor/go.mod, go.sum. currently report-only for findings."
+      },
+      {
+        "name": "node-audit",
+        "workflow": "dependency-audit.yml",
+        "scope": "node dependency vulnerability scan (npm audit)",
+        "required": false,
+        "note": "path-filtered to dashboard/package-lock.json. currently report-only for findings."
+      },
+      {
+        "name": "security",
+        "workflow": "memory-server-ci.yml",
+        "scope": "memory-server lock drift + pip-audit",
+        "required": false,
+        "note": "path-filtered to memory-server/**"
+      },
+      {
+        "name": "container-scan",
+        "workflow": "memory-server-ci.yml",
+        "scope": "memory-server container image vulnerability scan (trivy)",
+        "required": false,
+        "note": "path-filtered to memory-server/**"
+      }
+    ],
+    "konflux": [
+      {
+        "name": "Red Hat Konflux / platform-frontend-ai-dev-on-pull-request",
+        "scope": "main bot container build and integration pipeline",
+        "required": true,
+        "note": "runs on every PR (no path filter)"
+      },
+      {
+        "name": "Red Hat Konflux / platform-frontend-ai-dev-memory-server-on-pull-request",
+        "scope": "memory-server container build pipeline",
+        "required": true,
+        "note": "runs on every PR (no path filter)"
+      },
+      {
+        "name": "Red Hat Konflux / platform-frontend-ai-dev-proxy-on-pull-request",
+        "scope": "proxy/executor container build pipeline",
+        "required": false,
+        "note": "path-filtered to proxy/** changes only; cannot be a hard required check"
+      }
+    ],
+    "konflux_enterprise_contract": [
+      {
+        "name": "Red Hat Konflux / platform-frontend-ai-dev-enterprise-contract / pr group",
+        "scope": "enterprise contract validation group",
+        "required": false,
+        "note": "reports as 'skipping' on most PRs; only runs when EC policy triggers. staged for future required status."
+      }
+    ]
+  },
+  "path_scoping_notes": {
+    "description": "All GitHub Actions workflows use path filters. Only the main bot and memory-server Konflux pipelines run on every PR (no path filter in CEL expression). The proxy Konflux pipeline is path-filtered to proxy/** changes.",
+    "required_in_branch_protection": "Only checks that fire on EVERY PR can be hard-required in branch protection. Currently that is the two non-path-filtered Konflux build checks. Path-filtered checks (all GitHub Actions + proxy Konflux) are trusted to pass when they fire, but not enforced as branch protection gates.",
+    "future": "If a lightweight always-running gate workflow is added (e.g. a status-aggregator that reports success/neutral for path-filtered checks that didn't fire), more checks can be promoted to required."
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install run init dashboard costs costs-today costs-week seed-costs stop logs help memory-server memory-server-stop memory-dump memory-import memory-reset verify memory-verify precommit-install precommit-run prepush-install prepush-check
+.PHONY: install run init dashboard costs costs-today costs-week seed-costs stop logs help memory-server memory-server-stop memory-dump memory-import memory-reset verify memory-verify precommit-install precommit-run prepush-install prepush-check verify-required-checks check-branch-protection
 
 LABEL ?= hcc-ai-framework
 CONTAINER_RT ?= $(shell command -v docker 2>/dev/null && echo docker || echo podman)
@@ -40,6 +40,13 @@ prepush-install: ## Install pre-push git hook
 
 prepush-check: ## Run pre-push quality checks manually
 	bash scripts/prepush_check.sh
+
+verify-required-checks: ## Verify required CI checks on a PR (usage: make verify-required-checks PR=123)
+	@if [ -z "$(PR)" ]; then echo "usage: make verify-required-checks PR=<number>"; exit 1; fi
+	bash scripts/verify_required_checks.sh "$(PR)"
+
+check-branch-protection: ## Check branch protection drift against versioned policy
+	bash scripts/check_branch_protection.sh
 
 memory-verify: ## Run memory-server CI-equivalent checks locally
 	cd memory-server && uv sync --frozen --extra test

--- a/docs/operations/rehor-77-branch-protection-rollout.md
+++ b/docs/operations/rehor-77-branch-protection-rollout.md
@@ -1,0 +1,141 @@
+# Branch Protection Rollout (REHOR-77)
+
+This runbook documents how to apply, verify, and roll back branch protection on the `master` branch of `OpenShift-Fleet/rehor`.
+
+## Prerequisites
+
+- **Admin access** to `OpenShift-Fleet/rehor` on GitHub
+- `gh` CLI installed and authenticated (`gh auth status`)
+- `jq` installed
+- Repository cloned with latest `master`
+
+## Policy overview
+
+The versioned policy lives at `.github/branch-protection/master-protection.json`. It enforces:
+
+| Setting | Value |
+|---------|-------|
+| Required approving reviews | 1 |
+| Dismiss stale reviews | yes |
+| Require branch up-to-date | yes |
+| Allow force push | no |
+| Allow deletions | no |
+| Enforce for admins | yes |
+
+`dismiss_stale_reviews: true` is the recommended default for this repo right now. Martin can adjust this if team review flow changes.
+
+### Required status checks
+
+These checks must pass before a PR can merge:
+
+**Always-running (hard required in branch protection):**
+
+- `Red Hat Konflux / platform-frontend-ai-dev-on-pull-request`
+- `Red Hat Konflux / platform-frontend-ai-dev-memory-server-on-pull-request`
+
+**Path-filtered (not required in branch protection):**
+
+These run only when their path filters match. They are not enforced in branch protection to avoid blocking unrelated PRs, but they must pass when they do run:
+
+- `format` / `lint` / `typecheck` / `test` (Python CI, triggered by `**.py`/`pyproject.toml`/`uv.lock`)
+- `python-audit` / `go-audit` / `node-audit` (Dependency audit, triggered by lock/dep files)
+- `security` / `container-scan` (Memory Server CI, triggered by `memory-server/**`)
+- `Red Hat Konflux / platform-frontend-ai-dev-proxy-on-pull-request` (triggered by `proxy/**`)
+
+## Applying protection
+
+```bash
+# 1. verify no protection exists yet (or check current state)
+make check-branch-protection
+
+# 2. review what will be applied
+cat .github/branch-protection/master-protection.json | jq .
+
+# 3. apply (interactive confirmation prompt)
+scripts/apply_branch_protection.sh
+
+# 4. verify applied correctly
+make check-branch-protection
+```
+
+## Verifying on a live PR
+
+After applying protection, verify enforcement works on an open PR:
+
+```bash
+# check a specific PR
+make verify-required-checks PR=408
+
+# expected output: all required checks listed with PASS/MISSING/FAILED
+```
+
+Try merging a PR with a failing or missing check via the GitHub UI to confirm it's blocked.
+
+## Validation evidence (authoring phase, before admin apply)
+
+The following dry-runs were executed while implementing REHOR-77:
+
+- `make verify-required-checks PR=403` -> PASS, both required Konflux checks passed
+- `make verify-required-checks PR=407` -> FAIL, merge conflicts detected (`mergeable=CONFLICTING`, `mergeStateStatus=DIRTY`)
+- `make verify-required-checks PR=392` -> FAIL, merge conflicts detected (`mergeable=CONFLICTING`, `mergeStateStatus=DIRTY`)
+
+Current pre-apply state check:
+
+- `make check-branch-protection` -> reports no branch protection configured on `master` yet (expected before admin apply)
+
+This validates script behavior before policy rollout:
+
+- required checks are read from versioned JSON
+- PR check lookup works for real historical PRs
+- PR base/draft/state/merge-conflict readiness is validated before success is reported
+- missing branch protection is detected and reported clearly
+
+## Rollback
+
+If protection is causing unexpected merge blocks:
+
+### Emergency: disable all protection
+
+```bash
+gh api --method DELETE "/repos/OpenShift-Fleet/rehor/branches/master/protection"
+```
+
+This removes all branch protection immediately. Re-apply later with `scripts/apply_branch_protection.sh`.
+
+### Partial: remove a specific required check
+
+If one check is flaky or misconfigured:
+
+1. Edit `.github/branch-protection/master-protection.json` and remove the check from `required_status_checks.contexts`
+2. Re-run `scripts/apply_branch_protection.sh`
+3. Open a follow-up ticket to fix the check and re-add it
+
+### Adding a new required check
+
+1. Verify the check name from a real PR: `gh pr checks <number> --repo OpenShift-Fleet/rehor`
+2. Add to `required-checks.json` and `master-protection.json`
+3. Re-apply protection
+4. Verify with `make check-branch-protection`
+
+## Post-rollout verification checklist
+
+- [ ] `make check-branch-protection` reports no drift
+- [ ] `make verify-required-checks PR=<recent_pr>` shows all required checks passing
+- [ ] GitHub UI shows branch protection badge on master
+- [ ] A PR without required checks cannot be merged (test with a draft PR if needed)
+- [ ] Admin enforcement behavior is confirmed (enforce_admins is true)
+
+## Incident response
+
+If branch protection is blocking legitimate merges:
+
+1. Check if the blocking check is in the required list: `make check-branch-protection`
+2. If the check is failing due to a flaky issue, update policy JSON to remove or relax the requirement, then re-apply protection as admin
+3. If the check shouldn't be required, follow the rollback procedure above
+4. File a ticket for root cause if a check is consistently failing
+
+## Ownership
+
+- **Policy authoring**: any contributor (via PR to update JSON files)
+- **Policy application**: repository admin (Martin or equivalent)
+- **Ticket**: REHOR-77

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,7 +37,7 @@ Engineer experience items (§9–§12) pair naturally with platform foundations:
 
 | Item | Status |
 |------|--------|
-| CI Foundation | Planned |
+| CI Foundation | In Progress (REHOR-75, 76, 78 shipped; REHOR-77 in review) |
 | Logging & Observability | Planned |
 | Run Identity | Planned |
 | Shared Memory MCP | Planned |
@@ -284,4 +284,3 @@ Despite this, the system has no infrastructure for error analysis: errors are st
 **First slice:** Normalize deterministic error signatures, count occurrences by repository and workflow, and link each signature to recent examples and an optional human-maintained workaround. Add an error breakdown to the dashboard (replacing the current single error count).
 
 **Guardrail:** Never hide the original error or automatically apply a fix from a fingerprint. Success means repeated incidents are diagnosed faster and the platform team can prioritize the most common failure classes.
-

--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# apply branch protection policy from versioned config.
+# requires admin access to the repository.
+# usage: scripts/apply_branch_protection.sh [repo] [branch]
+set -euo pipefail
+
+REPO="${1:-OpenShift-Fleet/rehor}"
+BRANCH="${2:-master}"
+POLICY_FILE=".github/branch-protection/master-protection.json"
+
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "error: policy file not found at $POLICY_FILE"
+  exit 1
+fi
+
+if ! command -v gh &>/dev/null; then
+  echo "error: gh CLI is required but not installed"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is required but not installed"
+  exit 1
+fi
+
+echo "=== Applying branch protection to ${REPO}:${BRANCH} ==="
+echo "Policy file: $POLICY_FILE"
+echo ""
+
+# strip the $comment field before sending to the API
+payload=$(jq 'del(."$comment")' "$POLICY_FILE")
+
+echo "Required status checks:"
+echo "$payload" | jq -r '.required_status_checks.contexts[]' | sed 's/^/  - /'
+echo ""
+echo "PR reviews required: $(echo "$payload" | jq '.required_pull_request_reviews.required_approving_review_count')"
+echo "Dismiss stale reviews: $(echo "$payload" | jq '.required_pull_request_reviews.dismiss_stale_reviews')"
+echo "Strict (up-to-date): $(echo "$payload" | jq '.required_status_checks.strict')"
+echo ""
+
+read -r -p "Apply this policy to ${REPO}:${BRANCH}? [y/N] " confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+echo ""
+echo "Applying..."
+
+gh api \
+  --method PUT \
+  "/repos/${REPO}/branches/${BRANCH}/protection" \
+  --input <(echo "$payload") \
+  --silent
+
+echo "Branch protection applied successfully."
+echo ""
+echo "Run 'scripts/check_branch_protection.sh' to verify."

--- a/scripts/check_branch_protection.sh
+++ b/scripts/check_branch_protection.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# check current branch protection against versioned policy and report drift.
+# usage: scripts/check_branch_protection.sh [repo] [branch]
+set -euo pipefail
+
+REPO="${1:-OpenShift-Fleet/rehor}"
+BRANCH="${2:-master}"
+POLICY_FILE=".github/branch-protection/master-protection.json"
+
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "error: policy file not found at $POLICY_FILE"
+  exit 1
+fi
+
+if ! command -v gh &>/dev/null; then
+  echo "error: gh CLI is required but not installed"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is required but not installed"
+  exit 1
+fi
+
+echo "=== Checking branch protection for ${REPO}:${BRANCH} ==="
+echo ""
+
+# fetch live protection settings
+live_json=$(gh api "/repos/${REPO}/branches/${BRANCH}/protection" 2>/dev/null || true)
+
+if [ -z "$live_json" ] || echo "$live_json" | jq -e '.message' &>/dev/null; then
+  error_msg=$(echo "$live_json" | jq -r '.message // "unknown error"')
+  if echo "$error_msg" | grep -qi "not found"; then
+    echo "STATUS: no branch protection is currently configured on ${BRANCH}."
+    echo ""
+    echo "To apply the versioned policy, run:"
+    echo "  scripts/apply_branch_protection.sh"
+    exit 1
+  else
+    echo "error: could not read branch protection: $error_msg"
+    echo "this may require admin access or the branch may not exist."
+    exit 1
+  fi
+fi
+
+echo "Branch protection IS configured. Checking for drift..."
+echo ""
+
+# compare required status checks
+policy_checks=$(jq -r 'del(."$comment") | .required_status_checks.contexts | sort | .[]' "$POLICY_FILE")
+live_checks=$(echo "$live_json" | jq -r '.required_status_checks.contexts // [] | sort | .[]')
+
+drift=0
+
+compare_bool_setting() {
+  local label="$1"
+  local policy_expr="$2"
+  local live_expr="$3"
+  local policy_value
+  local live_value
+
+  policy_value=$(jq -r "$policy_expr" "$POLICY_FILE")
+  live_value=$(echo "$live_json" | jq -r "$live_expr")
+
+  if [ "$policy_value" = "$live_value" ]; then
+    echo "  OK:      ${label} = ${live_value}"
+  else
+    echo "  DRIFT:   ${label}: policy=${policy_value}, live=${live_value}"
+    drift=1
+  fi
+}
+
+echo "--- Required Status Checks ---"
+while IFS= read -r check; do
+  if echo "$live_checks" | grep -qxF "$check"; then
+    echo "  OK:      $check"
+  else
+    echo "  MISSING: $check (in policy but not enforced)"
+    drift=1
+  fi
+done <<< "$policy_checks"
+
+# check for extra checks in live that aren't in policy
+while IFS= read -r check; do
+  [ -z "$check" ] && continue
+  if ! echo "$policy_checks" | grep -qxF "$check"; then
+    echo "  EXTRA:   $check (enforced but not in policy)"
+    drift=1
+  fi
+done <<< "$live_checks"
+
+echo ""
+echo "--- PR Review Settings ---"
+compare_bool_setting \
+  "required approvals" \
+  '.required_pull_request_reviews.required_approving_review_count // 0' \
+  '.required_pull_request_reviews.required_approving_review_count // 0'
+compare_bool_setting \
+  "dismiss stale reviews" \
+  '.required_pull_request_reviews.dismiss_stale_reviews // false' \
+  '.required_pull_request_reviews.dismiss_stale_reviews // false'
+compare_bool_setting \
+  "require code owner reviews" \
+  '.required_pull_request_reviews.require_code_owner_reviews // false' \
+  '.required_pull_request_reviews.require_code_owner_reviews // false'
+
+echo ""
+echo "--- Branch Up-to-Date Requirement ---"
+compare_bool_setting \
+  "require up-to-date" \
+  '.required_status_checks.strict // false' \
+  '.required_status_checks.strict // false'
+
+echo ""
+echo "--- Repository Protection Controls ---"
+compare_bool_setting \
+  "enforce for admins" \
+  '.enforce_admins // false' \
+  '.enforce_admins.enabled // false'
+compare_bool_setting \
+  "allow force pushes" \
+  '.allow_force_pushes // false' \
+  '.allow_force_pushes.enabled // false'
+compare_bool_setting \
+  "allow deletions" \
+  '.allow_deletions // false' \
+  '.allow_deletions.enabled // false'
+compare_bool_setting \
+  "required linear history" \
+  '.required_linear_history // false' \
+  '.required_linear_history.enabled // false'
+
+policy_restrictions=$(jq -c '.restrictions // null' "$POLICY_FILE")
+live_restrictions=$(echo "$live_json" | jq -c '.restrictions // null')
+if [ "$policy_restrictions" = "$live_restrictions" ]; then
+  echo "  OK:      restrictions = $live_restrictions"
+else
+  echo "  DRIFT:   restrictions: policy=$policy_restrictions, live=$live_restrictions"
+  drift=1
+fi
+
+echo ""
+if [ "$drift" -eq 0 ]; then
+  echo "OK: live branch protection matches versioned policy."
+  exit 0
+else
+  echo "DRIFT DETECTED: live settings do not match policy."
+  echo "Run 'scripts/apply_branch_protection.sh' to reconcile (admin required)."
+  exit 1
+fi

--- a/scripts/verify_required_checks.sh
+++ b/scripts/verify_required_checks.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# verify that all required status checks have passed on a given PR.
+# usage: scripts/verify_required_checks.sh <pr_number> [repo]
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+REPO="${2:-OpenShift-Fleet/rehor}"
+CHECKS_FILE=".github/branch-protection/required-checks.json"
+
+if [ -z "$PR_NUMBER" ]; then
+  echo "usage: $0 <pr_number> [repo]"
+  echo "  pr_number: GitHub PR number to verify"
+  echo "  repo:      owner/repo (default: OpenShift-Fleet/rehor)"
+  exit 1
+fi
+
+if [ ! -f "$CHECKS_FILE" ]; then
+  echo "error: required checks manifest not found at $CHECKS_FILE"
+  exit 1
+fi
+
+if ! command -v gh &>/dev/null; then
+  echo "error: gh CLI is required but not installed"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is required but not installed"
+  exit 1
+fi
+
+echo "=== Verifying required checks for PR #${PR_NUMBER} on ${REPO} ==="
+echo ""
+
+# validate target branch and basic merge readiness before check-state evaluation
+expected_branch=$(jq -r '.branch // "master"' "$CHECKS_FILE")
+pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+  --json state,isDraft,baseRefName,mergeable,mergeStateStatus,reviewDecision 2>/dev/null || true)
+
+if [ -z "$pr_meta" ] || [ "$pr_meta" = "null" ]; then
+  echo "error: could not load PR metadata for #${PR_NUMBER}."
+  echo "verify the PR exists and gh is authenticated."
+  exit 1
+fi
+
+pr_state=$(echo "$pr_meta" | jq -r '.state // "UNKNOWN"')
+pr_draft=$(echo "$pr_meta" | jq -r '.isDraft // false')
+pr_base=$(echo "$pr_meta" | jq -r '.baseRefName // ""')
+pr_mergeable=$(echo "$pr_meta" | jq -r '.mergeable // "UNKNOWN"')
+pr_merge_status=$(echo "$pr_meta" | jq -r '.mergeStateStatus // "UNKNOWN"')
+pr_review_decision=$(echo "$pr_meta" | jq -r '.reviewDecision // "UNKNOWN"')
+
+if [ "$pr_base" != "$expected_branch" ]; then
+  echo "error: PR base branch is '$pr_base', expected '$expected_branch'."
+  echo "this check only reports merge readiness for the protected target branch."
+  exit 1
+fi
+
+if [ "$pr_state" != "OPEN" ]; then
+  echo "error: PR #${PR_NUMBER} is in state '$pr_state' (expected OPEN)."
+  exit 1
+fi
+
+if [ "$pr_draft" = "true" ]; then
+  echo "error: PR #${PR_NUMBER} is still a draft and not merge-ready."
+  exit 1
+fi
+
+if [ "$pr_mergeable" = "CONFLICTING" ] || [ "$pr_merge_status" = "DIRTY" ]; then
+  echo "error: PR #${PR_NUMBER} has merge conflicts (mergeable=$pr_mergeable, mergeStateStatus=$pr_merge_status)."
+  exit 1
+fi
+
+if [ "$pr_merge_status" = "BEHIND" ]; then
+  echo "error: PR #${PR_NUMBER} is behind its base branch and must be updated."
+  exit 1
+fi
+
+if [ "$pr_review_decision" != "APPROVED" ]; then
+  echo "error: PR #${PR_NUMBER} has review decision '$pr_review_decision' (expected APPROVED)."
+  exit 1
+fi
+
+if [ "$pr_mergeable" = "UNKNOWN" ] || [ "$pr_merge_status" = "UNKNOWN" ]; then
+  echo "warning: GitHub reports merge readiness as UNKNOWN"
+  echo "         (mergeable=$pr_mergeable, mergeStateStatus=$pr_merge_status)."
+  echo "         continuing with required check validation."
+fi
+
+# extract required check names from manifest (github_actions + konflux, where required=true)
+required_checks=$(jq -r '
+  (
+    [.checks.github_actions[] | select(.required == true) | .name] +
+    [.checks.konflux[] | select(.required == true) | .name]
+  ) | .[]
+' "$CHECKS_FILE")
+
+required_check_count=$(jq -r '
+  (
+    [.checks.github_actions[] | select(.required == true) | .name] +
+    [.checks.konflux[] | select(.required == true) | .name]
+  ) | length
+' "$CHECKS_FILE")
+
+if [ "$required_check_count" -eq 0 ]; then
+  echo "error: no required checks were found in $CHECKS_FILE."
+  echo "fail-closed: at least one required check must be configured."
+  exit 1
+fi
+
+# get current PR check statuses
+pr_checks_json=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state 2>/dev/null || true)
+
+if [ -z "$pr_checks_json" ] || [ "$pr_checks_json" = "[]" ]; then
+  echo "error: could not retrieve checks for PR #${PR_NUMBER}. verify the PR exists and gh is authenticated."
+  exit 1
+fi
+
+failures=0
+missing=0
+pending=0
+passed=0
+
+while IFS= read -r check_name; do
+  # look up all states for this check name. some names (e.g. "test")
+  # can appear in multiple workflows, so we evaluate the worst state.
+  states=$(echo "$pr_checks_json" | jq -r --arg name "$check_name" '
+    [.[] | select(.name == $name) | .state // empty] | .[]
+  ')
+
+  if [ -z "$states" ]; then
+    echo "  MISSING:  $check_name"
+    missing=$((missing + 1))
+  else
+    worst_state="SUCCESS"
+    while IFS= read -r state; do
+      case "$state" in
+        FAILURE|ERROR|TIMED_OUT|ACTION_REQUIRED|CANCELLED|STALE)
+          worst_state="FAILURE"
+          break
+          ;;
+        PENDING|EXPECTED|QUEUED|IN_PROGRESS|WAITING|REQUESTED)
+          if [ "$worst_state" != "FAILURE" ]; then
+            worst_state="PENDING"
+          fi
+          ;;
+        SUCCESS|NEUTRAL|SKIPPED)
+          ;;
+        *)
+          if [ "$worst_state" = "SUCCESS" ]; then
+            worst_state="PENDING"
+          fi
+          ;;
+      esac
+    done <<< "$states"
+
+    if [ "$worst_state" = "SUCCESS" ]; then
+      echo "  PASS:     $check_name"
+      passed=$((passed + 1))
+    elif [ "$worst_state" = "PENDING" ]; then
+      echo "  PENDING:  $check_name"
+      pending=$((pending + 1))
+    else
+      echo "  FAILED:   $check_name"
+      failures=$((failures + 1))
+    fi
+  fi
+done <<< "$required_checks"
+
+echo ""
+echo "--- Summary ---"
+echo "  passed:  $passed"
+echo "  pending: $pending"
+echo "  missing: $missing"
+echo "  failed:  $failures"
+echo ""
+
+total_issues=$((failures + missing))
+if [ "$pending" -gt 0 ]; then
+  echo "WARN: $pending check(s) still pending. re-run once complete."
+  exit 2
+fi
+
+if [ "$total_issues" -gt 0 ]; then
+  echo "FAIL: $total_issues required check(s) missing or failed. PR is NOT ready to merge."
+  exit 1
+fi
+
+echo "OK: all required checks passed. PR #${PR_NUMBER} is ready to merge."
+exit 0


### PR DESCRIPTION
## Jira
- [REHOR-77](https://redhat.atlassian.net/browse/REHOR-77)

## Summary
- add versioned branch protection policy artifacts under `.github/branch-protection/`
- add `verify_required_checks.sh`, `check_branch_protection.sh`, and `apply_branch_protection.sh` plus Makefile targets for repeatable verification
- add rollout/rollback runbook at `docs/operations/rehor-77-branch-protection-rollout.md` and update roadmap status context
- enforce admin branch protection in policy and tighten merge-readiness gating (`approved`, not behind, not conflicting) in required-check verification

## Validation
- [x] ran `make verify`
- [x] ran `shellcheck` on all new scripts
- [x] validated policy and required-check JSON with `jq`
- [x] ran strict docs build with `mkdocs build --strict`
- [x] validated `verify_required_checks.sh` behavior on live PRs (passing and failing cases)

## Notes
- container build verification scope is split to [REHOR-107](https://redhat.atlassian.net/browse/REHOR-107)
- branch protection apply step requires repo admin execution