### PR TITLE
fix(gh-pr-preflight): fix bot missing some comments in Github

### DIFF
--- a/bot/tests/test_preflight_shared.py
+++ b/bot/tests/test_preflight_shared.py
@@ -7,14 +7,16 @@ from unittest.mock import patch
 SHARED_DIR = Path(__file__).resolve().parent.parent.parent / "presets" / "shared" / "preflight"
 sys.path.insert(0, str(SHARED_DIR))
 
+from unittest.mock import MagicMock
+
 from common import (
     build_repo_lookup,
     fmt_comments,
     is_bot_author,
     upstream_repo,
 )
-from gh_pr_status import classify_gh, has_new_feedback
-from gl_mr_status import classify_gl
+from gh_pr_status import classify_gh, gh_pr_comments, has_new_feedback
+from gl_mr_status import classify_gl, gl_mr_notes
 from gl_mr_status import has_new_feedback as gl_has_new_feedback
 
 # --- upstream_repo ---
@@ -262,14 +264,19 @@ def _classify_bucket(enriched_list):
         elif "closed" in issues:
             closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
-            ci_only = all(i.startswith("ci_fail") for i in issues)
+            ci_only = all(i.startswith(("ci_fail", "konflux_urls")) for i in issues)
             if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):
                 clean.append(e)
             else:
                 ci_fail.append(e)
         elif "conflict" in issues:
             conflict.append(e)
-        elif any(i in ("changes_requested",) or i.startswith("review:") for i in issues) or has_new_feedback(e):
+        elif any(i in ("changes_requested",) or i.startswith("review:") for i in issues):
+            if has_new_feedback(e) or not e["task"].get("last_addressed"):
+                feedback.append(e)
+            else:
+                clean.append(e)
+        elif has_new_feedback(e):
             feedback.append(e)
         else:
             clean.append(e)
@@ -320,6 +327,17 @@ def test_ci_only_with_old_feedback_is_clean():
     result = _classify_bucket([e])
     assert len(result["clean"]) == 1
     assert len(result["ci_fail"]) == 0
+
+
+def test_ci_plus_changes_requested_is_actionable():
+    """CI failure + changes_requested should not be classified as CI-only."""
+    e = _make_ci_enriched(
+        last_addressed="2026-07-14T17:49",
+        extra_issues=["changes_requested"],
+    )
+    result = _classify_bucket([e])
+    assert len(result["ci_fail"]) == 1
+    assert len(result["clean"]) == 0
 
 
 # --- classify_gl ---
@@ -419,3 +437,65 @@ def test_gl_has_new_feedback_bot_ignored():
         "mr_notes": [{"a": "my-app[bot]", "t": "2026-07-01T10:00", "b": "automated check"}],
     }
     assert gl_has_new_feedback(enriched) is False
+
+
+# --- pagination (GH + GL) ---
+
+
+def test_gh_pr_comments_uses_paginate():
+    """gh api calls include --paginate to fetch all pages of comments."""
+    import json as json_mod
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json_mod.dumps({"a": "user", "t": "2026-07-01T10:00", "b": "hi"})
+
+    with patch("gh_pr_status.subprocess.run", return_value=mock_result) as mock_run:
+        gh_pr_comments("org/repo", 1)
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            assert "--paginate" in cmd, f"--paginate missing from command: {cmd}"
+
+
+def test_gl_mr_notes_uses_paginate():
+    """glab api calls include --paginate to fetch all pages of notes."""
+    import json as json_mod
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json_mod.dumps(
+        [
+            {"author": {"username": "reviewer"}, "created_at": "2026-07-01T10:00:00", "body": "note", "system": False},
+        ]
+    )
+
+    with patch("gl_mr_status.subprocess.run", return_value=mock_result) as mock_run:
+        notes = gl_mr_notes("team/project", 42)
+        cmd = mock_run.call_args[0][0]
+        assert "--paginate" in cmd, f"--paginate missing from command: {cmd}"
+        assert len(notes) == 1
+        assert notes[0]["a"] == "reviewer"
+
+
+def test_gl_mr_notes_filters_system():
+    """System notes are excluded from results."""
+    import json as json_mod
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json_mod.dumps(
+        [
+            {
+                "author": {"username": "reviewer"},
+                "created_at": "2026-07-01T10:00:00",
+                "body": "looks good",
+                "system": False,
+            },
+            {"author": {"username": "gitlab"}, "created_at": "2026-07-01T10:01:00", "body": "merged", "system": True},
+        ]
+    )
+
+    with patch("gl_mr_status.subprocess.run", return_value=mock_result):
+        notes = gl_mr_notes("team/project", 42)
+        assert len(notes) == 1
+        assert notes[0]["b"] == "looks good"

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -54,7 +54,7 @@ def gh_pr_comments(owner_repo, num):
     ]:
         try:
             r = subprocess.run(
-                ["gh", "api", ep, "--jq", ".[] | {a: .user.login, t: .created_at, b: .body}"],
+                ["gh", "api", "--paginate", ep, "--jq", ".[] | {a: .user.login, t: .created_at, b: .body}"],
                 capture_output=True,
                 text=True,
                 timeout=15,
@@ -225,7 +225,7 @@ def main():
             else:
                 closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
-            ci_only = all(i.startswith(("ci_fail", "konflux_urls", "changes_requested")) for i in issues)
+            ci_only = all(i.startswith(("ci_fail", "konflux_urls")) for i in issues)
             if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):
                 clean.append(e)
             else:

--- a/presets/shared/preflight/gl_mr_status.py
+++ b/presets/shared/preflight/gl_mr_status.py
@@ -45,6 +45,7 @@ def gl_mr_notes(project_path, num):
             [
                 "glab",
                 "api",
+                "--paginate",
                 f"projects/{encoded}/merge_requests/{num}/notes?per_page=50&sort=asc",
                 "--hostname",
                 "gitlab.cee.redhat.com",


### PR DESCRIPTION
###  Description

  Two bugs in gh_pr_status.py and one in gl_mr_status.py caused the bot to classify PRs/MRs with actionable human feedback as CLEAN, skipping them silently. See https://github.com/RedHatInsights/insights-chrome/pull/3616#issuecomment-5182748897

###   Bug 1: Missing --paginate on GH comment fetch (line 57)

  gh api repos/.../issues/{num}/comments returns at most 30 comments per page by default. PRs with 30+ comments (e.g. insights-chrome#3616 with 33 issue comments) had their newest comments silently dropped, causing has_new_feedback() to return False. Adding --paginate makes gh api
  follow GitHub's Link pagination headers automatically — the existing line-by-line JSON parser already handles multi-page output with no additional changes.

###   Bug 2: ci_only check treats changes_requested as a CI issue (line 228)

  The ci_only guard included "changes_requested" in its startswith tuple, so a PR with both CI failures and human-requested changes was classified as "CI only" and sent to CLEAN when last_addressed was set. Removed "changes_requested" from the tuple so it's correctly treated as
  human feedback.

###   Bug 3: Missing --paginate on GL notes fetch (gl_mr_status.py line 48)

  Same pagination bug as Bug 1 but for GitLab. glab api returns at most per_page (50) notes per request. MRs with 50+ notes had newer notes silently dropped. Added --paginate to follow GitLab's pagination headers — the existing json.loads() parser handles the merged array with no
  additional changes.

###   Tests

  - Synced the _classify_bucket() test helper to match the current production classification logic
  - Added test_ci_plus_changes_requested_is_actionable
  - Added test_gh_pr_comments_uses_paginate and test_gl_mr_notes_uses_paginate — mock subprocess.run and verify --paginate is in the command args
  - Added test_gl_mr_notes_filters_system — verifies system notes are still filtered after the change

  ---
###   Blast radius
  
  All bot instances running the jira-sprint, jira-kanban, or onboarding workflow presets — they all share presets/shared/preflight/gh_pr_status.py and presets/shared/preflight/gl_mr_status.py. The change makes preflight more sensitive (fewer false skips), so the risk is extra bot
  cycles on edge cases, not missed work.

  Here's the flow for a PR with both ci_fail and changes_requested:
  
  Line 227 matches first (elif any(i.startswith("ci_fail") ...)), so we enter the CI branch. With the fix, ci_only is False because "changes_requested" doesn't start with "ci_fail" or "konflux_urls". That means the if ci_only and ... guard on line 229 fails → falls to else: on line
  231 → goes into the ci_fail bucket → actionable.

  Line 235 (the standalone changes_requested handler) is never reached in this case because line 227's elif already matched. That branch only handles PRs that have changes_requested without CI failures — unchanged by our fix.

  So the only behavioral change is: PRs with ci_fail + changes_requested go from clean → ci_fail (actionable). No other code path is affected.

  ---
###   Rollback plan
  
  git revert is sufficient. No config, data, or schema changes.

  ---
  ### Checklist

  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest
  
###   AI disclosure

  Assisted by: Claude Code