### PR TITLE
fix(preflight): merged prs no longer triggering state changes

### DIFF
--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -215,15 +215,9 @@ def main():
     for e in enriched:
         issues = e["issues"]
         if "merged" in issues:
-            if e["task"].get("last_addressed") and not has_new_feedback(e):
-                clean.append(e)
-            else:
-                merged.append(e)
+            merged.append(e)
         elif "closed" in issues:
-            if e["task"].get("last_addressed") and not has_new_feedback(e):
-                clean.append(e)
-            else:
-                closed.append(e)
+            closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
             ci_only = all(i.startswith(("ci_fail", "konflux_urls")) for i in issues)
             if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):

--- a/presets/shared/preflight/gl_mr_status.py
+++ b/presets/shared/preflight/gl_mr_status.py
@@ -182,15 +182,9 @@ def main():
     for e in enriched:
         issues = e["issues"]
         if "merged" in issues:
-            if e["task"].get("last_addressed") and not has_new_feedback(e):
-                clean.append(e)
-            else:
-                merged.append(e)
+            merged.append(e)
         elif "closed" in issues:
-            if e["task"].get("last_addressed") and not has_new_feedback(e):
-                clean.append(e)
-            else:
-                closed.append(e)
+            closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
             ci_fail.append(e)
         elif "conflict" in issues:


### PR DESCRIPTION
Description

  PR #408 introduced last_addressed suppression for merged/closed PRs in the shared GH/GL preflights to reduce wasteful idle cycles in the onboarding workflow. However, this also suppressed merged/closed PRs in jira-sprint and jira-kanban workflows, preventing the bot from running wrap-up (task cleanup, Jira transition, branch cleanup) when a PR is merged.

  This reverts the merged/closed suppression from gh_pr_status.py and gl_mr_status.py so terminal state changes are always treated as actionable. The common.py fix from #408 (adding mrs to get_task_prs) is preserved.

  A follow-up PR will harden the onboarding preflight to handle its specific case without relying on shared preflight suppression.

  ---
  Blast radius
  
  - Affected workflows: jira-sprint, jira-kanban (fixed), onboarding (will re-trigger on merged PRs until follow-up lands)
  - Affected preflights: presets/shared/preflight/gh_pr_status.py, presets/shared/preflight/gl_mr_status.py
  - Tested: all 298 bot tests pass

  ---
  Rollback plan
  
  git revert is sufficient.

  ---
  Checklist
  
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest

  AI disclosure
  
  Assisted by: Claude Code