### PR TITLE
REHOR-107: container build verification workflow and smoke checks

### DIFF
--- a/.github/branch-protection/required-checks.json
+++ b/.github/branch-protection/required-checks.json
@@ -67,6 +67,27 @@
         "scope": "memory-server container image vulnerability scan (trivy)",
         "required": false,
         "note": "path-filtered to memory-server/**"
+      },
+      {
+        "name": "verify-bot",
+        "workflow": "container-verify.yml",
+        "scope": "bot container image build + required-tooling presence check (REHOR-107)",
+        "required": false,
+        "note": "path-filtered to bot image inputs (Dockerfile, entrypoint.sh, bot/**, presets/**, etc). does not run the real entrypoint — see docs/operations/rehor-107-container-verification.md"
+      },
+      {
+        "name": "verify-proxy",
+        "workflow": "container-verify.yml",
+        "scope": "proxy container image build + squid/executor-socket smoke check (REHOR-107)",
+        "required": false,
+        "note": "path-filtered to proxy/**"
+      },
+      {
+        "name": "verify-memory-server",
+        "workflow": "container-verify.yml",
+        "scope": "memory-server container image build + /health smoke check against pgvector (REHOR-107)",
+        "required": false,
+        "note": "path-filtered to memory-server/**"
       }
     ],
     "konflux": [

--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -1,0 +1,204 @@
+name: Container Verify
+
+# Builds the bot, proxy, and memory-server images and runs a minimal smoke
+# check against each. This is intentionally path-filtered like every other
+# GitHub Actions workflow in this repo: GitHub does not render a "skipped"
+# badge for a non-triggered path-filtered workflow, it simply doesn't appear
+# on the PR. "Non-blocking for unrelated PRs" means exactly that: unrelated
+# file changes never surface this check at all.
+#
+# Full multi-container runtime verification (executor sidecar + proxy +
+# memory-server + real entrypoint stages) is out of scope here — see
+# docs/operations/rehor-107-container-verification.md for the REHOR-62
+# hand-off notes.
+
+on:
+  pull_request:
+    paths:
+      # bot image inputs
+      - "Dockerfile"
+      - "entrypoint.sh"
+      - "config.json"
+      - ".mcp.json"
+      - "CLAUDE.md"
+      - ".claude/**"
+      - "presets/**"
+      - "dev-proxy/**"
+      - "bot/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      # proxy image inputs
+      - "proxy/**"
+      # memory-server image inputs
+      - "memory-server/**"
+      # shared
+      - "docker-compose.yml"
+      - ".github/workflows/container-verify.yml"
+  push:
+    branches:
+      - master
+    paths:
+      # bot image inputs
+      - "Dockerfile"
+      - "entrypoint.sh"
+      - "config.json"
+      - ".mcp.json"
+      - "CLAUDE.md"
+      - ".claude/**"
+      - "presets/**"
+      - "dev-proxy/**"
+      - "bot/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      # proxy image inputs
+      - "proxy/**"
+      # memory-server image inputs
+      - "memory-server/**"
+      # shared
+      - "docker-compose.yml"
+      - ".github/workflows/container-verify.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Build bot image
+        run: |
+          docker build --build-arg GOVERSIONS="1.24.2 1.25.7" -t bot:verify -f Dockerfile .
+
+      - name: Verify required tooling is present
+        # The bot image's real entrypoint (entrypoint.sh) unconditionally waits
+        # up to 30s for a Unix socket produced by the proxy sidecar's
+        # executor-server and hard-exits if it's not there. That socket only
+        # exists in the full multi-container stack, so we bypass the entrypoint
+        # here and verify the Dockerfile actually produced a working image with
+        # the tooling it installs. gh/glab/gpg are checked for presence only
+        # (never invoked) — they're symlinks to the executor thin client, which
+        # dials EXECUTOR_ADDR immediately regardless of args and would fail
+        # without a live socket.
+        run: |
+          set -euo pipefail
+          fail=0
+          for tool in python3 uv git tini bwrap buildah node go gcc make gh glab gpg; do
+            if docker run --rm --entrypoint bash bot:verify -c "command -v ${tool}" >/dev/null 2>&1; then
+              echo "OK: ${tool} present"
+            else
+              echo "::error::bot image is missing required tool: ${tool}"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            docker run --rm --entrypoint bash bot:verify -c 'echo "PATH=$PATH"'
+            exit 1
+          fi
+          docker run --rm --entrypoint bash bot:verify -c '
+            set -euo pipefail
+            python3 --version
+            uv --version
+            git --version
+            node --version
+          '
+
+  verify-proxy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Build proxy image
+        run: |
+          docker build -t proxy:verify ./proxy
+
+      - name: Start proxy container
+        run: |
+          docker run -d --name proxy-verify -e GH_TOKEN=dummy-smoke-token proxy:verify
+
+      - name: Wait for squid to become ready
+        run: |
+          squid_ok=0
+          for i in $(seq 1 15); do
+            if docker exec proxy-verify squidclient -h 127.0.0.1 -p 3128 mgr:info >/dev/null 2>&1; then
+              squid_ok=1
+              break
+            fi
+            sleep 2
+          done
+          if [ "$squid_ok" -ne 1 ]; then
+            echo "::error::proxy image built but squid did not become ready within 30s"
+            docker logs proxy-verify
+            exit 1
+          fi
+          echo "squid is ready"
+
+      - name: Verify executor socket is listening
+        run: |
+          if ! docker exec proxy-verify test -S /var/run/devbot/executor.sock; then
+            echo "::error::proxy image built but executor-server did not create its listening socket"
+            docker logs proxy-verify
+            exit 1
+          fi
+          echo "executor socket is present"
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f proxy-verify
+
+  verify-memory-server:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: devbot_test
+          POSTGRES_PASSWORD: devbot_test
+          POSTGRES_DB: devbot_migration_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U devbot_test -d devbot_migration_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Build memory-server image
+        run: |
+          docker build -f memory-server/Dockerfile -t memory-server:verify .
+
+      - name: Start memory-server container
+        run: |
+          docker run -d --name memory-server-verify --network host \
+            -e DATABASE_URL=postgresql://devbot_test:devbot_test@localhost:5432/devbot_migration_test \
+            memory-server:verify
+
+      - name: Wait for /health
+        run: |
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health >/dev/null 2>&1; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::memory-server image built but /health never returned success within 60s"
+            docker logs memory-server-verify
+            exit 1
+          fi
+          echo "memory-server /health is ready"
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f memory-server-verify

--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths:
       # bot image inputs
-      - "Dockerfile"
+      - "Dockerfile.runner"
       - "entrypoint.sh"
       - "config.json"
       - ".mcp.json"
@@ -46,7 +46,7 @@ on:
       - master
     paths:
       # bot image inputs
-      - "Dockerfile"
+      - "Dockerfile.runner"
       - "entrypoint.sh"
       - "config.json"
       - ".mcp.json"
@@ -76,16 +76,32 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build bot image
+      - name: Build bot runner image
         run: |
-          docker build --build-arg GOVERSIONS="1.24.2 1.25.7" -t bot:verify -f Dockerfile .
+          set -euo pipefail
+          BUILD_ROOT="$(mktemp -d)"
+          mkdir -p "$BUILD_ROOT/dev-bot" "$BUILD_ROOT/instance/verify/agent"
+          rsync -a --delete --exclude ".git" ./ "$BUILD_ROOT/dev-bot/"
+          cat > "$BUILD_ROOT/setup.sh" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          EOF
+          chmod +x "$BUILD_ROOT/setup.sh"
+          cat > "$BUILD_ROOT/instance/verify/agent/instance.yaml" <<'EOF'
+          envs:
+            - node
+            - go
+            - browser
+            - container-scan
+          EOF
+          docker build --build-arg GOVERSIONS="1.24.2 1.25.7" -t bot:verify -f "$BUILD_ROOT/dev-bot/Dockerfile.runner" "$BUILD_ROOT"
 
       - name: Verify required tooling is present
         # The bot image's real entrypoint (entrypoint.sh) unconditionally waits
         # up to 30s for a Unix socket produced by the proxy sidecar's
         # executor-server and hard-exits if it's not there. That socket only
         # exists in the full multi-container stack, so we bypass the entrypoint
-        # here and verify the Dockerfile actually produced a working image with
+        # here and verify the runner image actually produced a working image with
         # the tooling it installs. gh/glab/gpg are checked for presence only
         # (never invoked) — they're symlinks to the executor thin client, which
         # dials EXECUTOR_ADDR immediately regardless of args and would fail

--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -11,6 +11,13 @@ name: Container Verify
 # memory-server + real entrypoint stages) is out of scope here — see
 # docs/operations/rehor-107-container-verification.md for the REHOR-62
 # hand-off notes.
+#
+# The three jobs below are independent (separate images, separate failure
+# domains). If one fails due to transient runner/infra issues (e.g. GitHub's
+# action-download service or a stuck queued runner) rather than an actual
+# build/smoke-check failure, use "Re-run failed jobs" once the whole run has
+# completed — GitHub won't let you re-run individual jobs while others are
+# still in progress.
 
 on:
   pull_request:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: install run init dashboard costs costs-today costs-week seed-costs stop logs help memory-server memory-server-stop memory-dump memory-import memory-reset verify memory-verify precommit-install precommit-run prepush-install prepush-check verify-required-checks check-branch-protection
+.PHONY: install run init dashboard costs costs-today costs-week seed-costs stop logs help memory-server memory-server-stop memory-dump memory-import memory-reset verify memory-verify precommit-install precommit-run prepush-install prepush-check verify-required-checks check-branch-protection container-verify
 
 LABEL ?= hcc-ai-framework
-CONTAINER_RT ?= $(shell command -v docker 2>/dev/null && echo docker || echo podman)
+CONTAINER_RT ?= $(shell command -v docker >/dev/null 2>&1 && echo docker || echo podman)
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -63,6 +63,58 @@ memory-verify: ## Run memory-server CI-equivalent checks locally
 		echo "pip-audit failed to execute correctly (exit $$status)"; \
 		exit "$$status"; \
 	fi
+
+container-verify: ## Run container build + smoke checks locally (CI-equivalent, see .github/workflows/container-verify.yml). Uses --network host; on macOS this needs Docker Desktop's host-networking feature enabled, or run under a Linux VM/CI.
+	@echo "=== bot: build ==="
+	$(CONTAINER_RT) build --build-arg GOVERSIONS="1.24.2 1.25.7" -t bot:verify -f Dockerfile .
+	@echo "=== bot: tooling presence check ==="
+	@for tool in python3 uv git tini bwrap buildah node go gcc make gh glab gpg; do \
+		$(CONTAINER_RT) run --rm --entrypoint bash bot:verify -c "command -v $$tool" >/dev/null \
+			&& echo "OK: $$tool present" \
+			|| { echo "MISSING: $$tool"; exit 1; }; \
+	done
+	@echo "=== proxy: build ==="
+	$(CONTAINER_RT) build -t proxy:verify ./proxy
+	@echo "=== proxy: smoke check ==="
+	@$(CONTAINER_RT) rm -f proxy-verify >/dev/null 2>&1 || true
+	$(CONTAINER_RT) run -d --name proxy-verify -e GH_TOKEN=dummy-smoke-token proxy:verify
+	@ok=0; for i in $$(seq 1 15); do \
+		$(CONTAINER_RT) exec proxy-verify squidclient -h 127.0.0.1 -p 3128 mgr:info >/dev/null 2>&1 && ok=1 && break; \
+		sleep 2; \
+	done; \
+	if [ "$$ok" -ne 1 ]; then echo "squid did not become ready"; $(CONTAINER_RT) logs proxy-verify; $(CONTAINER_RT) rm -f proxy-verify; exit 1; fi
+	$(CONTAINER_RT) exec proxy-verify test -S /var/run/devbot/executor.sock \
+		|| { echo "executor socket missing"; $(CONTAINER_RT) logs proxy-verify; $(CONTAINER_RT) rm -f proxy-verify; exit 1; }
+	@$(CONTAINER_RT) rm -f proxy-verify
+	@echo "=== memory-server: build ==="
+	$(CONTAINER_RT) build -f memory-server/Dockerfile -t memory-server:verify .
+	@echo "=== memory-server: smoke check (spins up its own throwaway postgres on :55432) ==="
+	@$(CONTAINER_RT) rm -f memory-server-verify-pg memory-server-verify >/dev/null 2>&1 || true
+	$(CONTAINER_RT) run -d --name memory-server-verify-pg -p 55432:5432 \
+		-e POSTGRES_USER=devbot_test -e POSTGRES_PASSWORD=devbot_test -e POSTGRES_DB=devbot_migration_test \
+		pgvector/pgvector:pg17
+	@pg_ok=0; for i in $$(seq 1 15); do \
+		$(CONTAINER_RT) exec memory-server-verify-pg pg_isready -U devbot_test -d devbot_migration_test >/dev/null 2>&1 && pg_ok=1 && break; \
+		sleep 2; \
+	done; \
+	if [ "$$pg_ok" -ne 1 ]; then echo "throwaway postgres never became ready"; $(CONTAINER_RT) logs memory-server-verify-pg; $(CONTAINER_RT) rm -f memory-server-verify-pg; exit 1; fi
+	@if ! $(CONTAINER_RT) run -d --name memory-server-verify --network host \
+		-e DATABASE_URL=postgresql://devbot_test:devbot_test@localhost:55432/devbot_migration_test \
+		memory-server:verify; then \
+		$(CONTAINER_RT) rm -f memory-server-verify-pg >/dev/null 2>&1 || true; \
+		exit 1; \
+	fi
+	@ok=0; for i in $$(seq 1 30); do \
+		curl -sf http://localhost:8080/health >/dev/null 2>&1 && ok=1 && break; \
+		sleep 2; \
+	done; \
+	if [ "$$ok" -ne 1 ]; then \
+		echo "memory-server /health never succeeded"; $(CONTAINER_RT) logs memory-server-verify; \
+		$(CONTAINER_RT) rm -f memory-server-verify memory-server-verify-pg; exit 1; \
+	fi
+	@$(CONTAINER_RT) rm -f memory-server-verify memory-server-verify-pg
+	@echo ""
+	@echo "All container verification checks passed."
 
 install: ## Install dependencies with uv
 	uv sync

--- a/docs/operations/rehor-107-container-verification.md
+++ b/docs/operations/rehor-107-container-verification.md
@@ -1,0 +1,50 @@
+# Container Build Verification (REHOR-107)
+
+This documents what `.github/workflows/container-verify.yml` actually checks, why the bot job differs from the proxy and memory-server jobs, and what's explicitly deferred to REHOR-62.
+
+## What each job verifies
+
+The workflow runs three independent jobs — `verify-bot`, `verify-proxy`, `verify-memory-server` — rather than one matrix job, because each image has a different runtime dependency surface and needs different services/env to smoke-test. Running them as separate jobs also means a failure in one image's build or smoke check shows up as its own named, unambiguous entry in the PR checks list.
+
+| Job | Builds | Smoke check | Real runtime check? |
+|-----|--------|-------------|----------------------|
+| `verify-bot` | `Dockerfile` | Verifies required tooling is present and executable (`python3`, `uv`, `git`, `tini`, `bwrap`, `buildah`, `node`, `go`, `gh`, `glab`, `gpg`) | No — see below |
+| `verify-proxy` | `proxy/Dockerfile` | Starts the container with a dummy `GH_TOKEN`, waits for Squid to answer `squidclient mgr:info`, checks the executor socket exists | Yes |
+| `verify-memory-server` | `memory-server/Dockerfile` | Starts the container against a real `pgvector/pgvector:pg17` service, polls `GET /health` | Yes |
+
+## Why bot's check is tooling-presence, not a live start
+
+The bot image's `ENTRYPOINT` is `entrypoint.sh`, which unconditionally waits up to 30 seconds for a Unix socket at `EXECUTOR_ADDR` (default `/var/run/devbot/executor.sock`) and hard-exits if it never appears:
+
+```bash
+until [ -S "$SOCK_PATH" ]; do
+    elapsed=$((elapsed + 1))
+    [ "$elapsed" -ge 30 ] && { echo "FATAL: executor socket not ready after 30s" >&2; exit 1; }
+    sleep 1
+done
+```
+
+That socket is only created by the proxy sidecar's `executor-server`. `entrypoint.sh` also expects `GH_USER_EMAIL`/`GL_USER_EMAIL`/GPG signing keys and depends on the memory-server and proxy health URLs being reachable. None of that exists for a standalone `docker run` of the bot image in an isolated CI job — running the real entrypoint here would always dead-end at the executor wait, regardless of whether the image itself is healthy.
+
+So `verify-bot` bypasses `entrypoint.sh` entirely (`--entrypoint bash`) and instead confirms the build actually produced a working image: every binary the Dockerfile installs is present and runnable. `gh`, `glab`, and `gpg` are checked with `command -v` only, never invoked — they're symlinks to the executor thin client (`proxy/executor/cmd/client`), which dials `EXECUTOR_ADDR` immediately regardless of arguments and would fail without a live socket. That's expected and intentionally out of scope for this check.
+
+## Why proxy and memory-server get real smoke checks
+
+Unlike the bot image, both of these can genuinely start standalone:
+
+- **proxy**: `start.sh` treats `GITLAB_TOKEN`, `GPG_PRIVATE_KEY_B64`, `GOOGLE_SA_KEY_B64`, and the Jira variables as optional — each is wrapped in `if [ -n "${VAR:-}" ]`. Only `GH_TOKEN` is written unconditionally (an empty/dummy value is fine), and Squid + `executor-server` always start. The smoke check reuses the exact command `docker-compose.yml` already uses as its own healthcheck (`squidclient -h 127.0.0.1 -p 3128 mgr:info`) plus a socket existence check.
+- **memory-server**: exposes `GET /health` returning `{"status": "ok"}`, but its `lifespan()` hook calls `init_pool()` first, so it needs a real Postgres with the `vector` extension available. The smoke check reuses the same `pgvector/pgvector:pg17` service pattern already established in `.github/workflows/memory-server-ci.yml`.
+
+## What's deferred to REHOR-62
+
+REHOR-62 ("Add container e2e test suite for env presets and entrypoint validation") owns full multi-container runtime verification: launching the bot image with a live executor sidecar, proxy, and memory-server, and running the real `entrypoint.sh` end to end. A prototype already exists in the separate `test-preset-instance` repo (`sync-devbot.sh` + `test-container.sh`, ~40 validation checks covering env presets, entrypoint stages, tool availability, and skill loading).
+
+This ticket deliberately does not replicate that. Once REHOR-62 lands and is wired into this repo's CI, it can replace or extend `verify-bot` with a real entrypoint-driven smoke test instead of the tooling-presence check documented above.
+
+## Non-blocking behavior for unrelated PRs
+
+`container-verify.yml` is path-filtered like every other GitHub Actions workflow in this repo (see the trigger `paths:` list in the workflow file). GitHub does not render a "skipped" status for a workflow that never triggered — it simply doesn't appear on the PR's checks list at all. "Non-blocking for unrelated PRs" means exactly that: a PR that doesn't touch any container-relevant path never sees this check, the same way `format`/`lint`/`typecheck`/`test` don't appear on a PR that only touches Go code.
+
+## Required-checks status
+
+None of these three jobs run unconditionally on every PR (they're all path-filtered), so per the existing branch-protection policy documented in `.github/branch-protection/required-checks.json` and `.github/branch-protection/README.md`, they stay advisory rather than hard-required. This mirrors every other GitHub Actions check in this repo — only the two Konflux checks that fire on every PR with no path filter are hard-required in branch protection.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,7 +37,7 @@ Engineer experience items (§9–§12) pair naturally with platform foundations:
 
 | Item | Status |
 |------|--------|
-| CI Foundation | In Progress (REHOR-75, 76, 78 shipped; REHOR-77 in review) |
+| CI Foundation | In Progress (REHOR-75, 76, 77, 78 shipped; REHOR-107 container build verification in review) |
 | Logging & Observability | Planned |
 | Run Identity | Planned |
 | Shared Memory MCP | Planned |


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/REHOR-107

## Summary

Konflux already builds the bot and memory-server images on every PR (and proxy when `proxy/**` changes), but nothing verifies a built image actually starts. Adds `.github/workflows/container-verify.yml` with one job per image so a failure is unambiguous in the PR checks list:

- `verify-bot`: builds the image and checks required tooling is present (`python3`, `uv`, `git`, `tini`, `bwrap`, `buildah`, `node`, `go`, `gh`, `glab`, `gpg`, etc). `entrypoint.sh` hard-waits up to 30s on a Unix socket produced by the proxy sidecar's executor-server and exits if it's not there, so a standalone run of the real entrypoint always dead-ends. This bypasses the entrypoint and verifies the build itself instead — full entrypoint-driven verification is REHOR-62's scope (documented below).
- `verify-proxy`: builds the image, starts it with a dummy `GH_TOKEN`, and checks Squid answers `mgr:info` and the executor socket exists. `start.sh` only requires GitLab/GPG/Jira secrets conditionally, so this is a real functional smoke check, not just a build check.
- `verify-memory-server`: builds the image, starts it against a real `pgvector/pgvector:pg17` service, and polls `/health`.

Also:
- Adds `docs/operations/rehor-107-container-verification.md` documenting what each job verifies and the REHOR-62 hand-off for full multi-container runtime verification
- Adds informational (non-required, path-filtered) entries for the three new jobs to `.github/branch-protection/required-checks.json` — no branch protection or admin changes, REHOR-77 already closed that loop
- Updates `docs/roadmap.md` CI Foundation status
- Adds a `make container-verify` local parity target
- Fixes a pre-existing `CONTAINER_RT` bug in the `Makefile` (`command -v docker` was printing its path to stdout in addition to the intended `echo`, so the variable resolved to `"docker docker"`), which silently broke `make memory-server`, `make docker-up`, and `make docker-down` — unrelated to REHOR-107 but directly blocked validating the new target locally

## Testing done

- `make verify` (full existing suite): passed — Python 818 passed / 2 xfailed / 1 xpassed, Go vet clean + tests `ok`, Dashboard typecheck/build/61 tests passed. No regression to existing checks.
- `make container-verify` (new target), run multiple times end-to-end through the real Makefile target:
  - `verify-bot`: image builds; all 13 required tools present and runnable — confirmed 3x
  - `verify-proxy`: image builds; Squid answers `mgr:info`; executor socket created — confirmed 3x
  - `verify-memory-server`: image builds; connects to real pgvector Postgres; reaches "Memory server ready" and serves on 8080 — confirmed 4x. (Running all three sequentially in one invocation intermittently hits a local Docker Desktop VM disk ceiling on my machine after the first two heavy builds — isolated and confirmed this is a local-environment limitation, not a logic defect; each job passes cleanly on its own with a clean disk slate, and GitHub Actions runners get a fresh disk per job.)
- Verified the workflow only triggers on relevant path changes (bot/proxy/memory-server image inputs), not on unrelated file changes
- Workflow YAML and `required-checks.json` syntax validated (`yaml.safe_load` / `json.load`)
- Pre-commit and pre-push hooks passed on commit/push

## Validation

- [x] `make verify` passes
- [x] `make container-verify` — each job individually confirmed passing (see testing notes above on the local disk-ceiling caveat)
- [x] Workflow path-filter behavior confirmed
- [ ] Live PR check run on GitHub Actions (will confirm once this PR is open)