### PR TITLE
fix(konflux-ec): fix scan failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ RUN ARCH=$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/') \
 
 # Headless Chromium via Playwright (avoids EPEL/CentOS RPMs)
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-RUN npx playwright install chromium
+RUN npx playwright install chromium \
+    && rm -rf /root/.npm
 
 # Make python3.12 the default
 RUN ln -sf /usr/bin/python3.12 /usr/bin/python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,7 @@ RUN ARCH=$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/') \
 
 # Headless Chromium via Playwright (avoids EPEL/CentOS RPMs)
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-RUN npx playwright install chromium \
-    && rm -rf /root/.npm
+RUN npx playwright install chromium
 
 # Make python3.12 the default
 RUN ln -sf /usr/bin/python3.12 /usr/bin/python3 \
@@ -152,6 +151,8 @@ COPY presets/ presets/
 
 # Run env preset install scripts (no-op until presets are extracted)
 RUN bash -c 'shopt -s nullglob; for script in presets/envs/*/install.sh; do bash "$script"; done'
+
+RUN rm -rf /root/.npm
 
 ENV HOME=/home/botuser
 USER botuser


### PR DESCRIPTION
Description

  ClamAV database 28084 (released Aug 6, 2026) added two new phishing signatures (Html.Phishing.SVGDecryption-10060408-0, Html.Phishing.SVGDynamicFunction-10060409-0) that false-positive on minified Playwright JavaScript bundles containing SVG rendering code and Function() constructors. These files exist only in the npm cache at /root/.npm/ left over from npx playwright install chromium and npm install -g during the Docker build — they are not needed at runtime (the container runs as botuser).

Adds RUN rm -rf /root/.npm after all npm/npx operations and before USER botuser to remove the cache from the final image.

Note: The memory-server EC may show as failing until this merges. The memory-server's own ClamAV scan passes clean, but the EC evaluates all components in a single application snapshot. While master's main image still contains the flagged npm cache files, the snapshot-level EC result is FAILURE — which blocks the memory-server component too.

  ---
  Blast radius
  
  - Affects the main platform-frontend-ai-dev container image only
  - /root/.npm is inaccessible at runtime (USER botuser) — removing it has no functional impact
  - Memory-server and proxy images are unaffected (no Playwright, multi-stage build discards npm cache)

  ---
  Rollback plan
  
  Git revert is sufficient. The npm cache is a build artifact with no runtime consumers.

  ---
  Checklist
  
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest

  AI disclosure
  
  Assisted by: Claude Code