### PR TITLE
fix(instances): mirror runner status updates to bot_instances (REHOR-108)

### DIFF
--- a/bot/agent.py
+++ b/bot/agent.py
@@ -49,18 +49,22 @@ async def _push_status(
     message: str,
     jira_key: str | None = None,
     repo: str | None = None,
+    instance_id: str | None = None,
 ) -> None:
     """Push a status update to the dashboard banner via HTTP."""
     global _status_fail_count
     try:
+        payload: dict = {
+            "state": state,
+            "message": message,
+            "external_key": jira_key,
+            "repo": repo,
+        }
+        if instance_id:
+            payload["instance_id"] = instance_id
         await client.post(
             DASHBOARD_URL,
-            json={
-                "state": state,
-                "message": message,
-                "external_key": jira_key,
-                "repo": repo,
-            },
+            json=payload,
             timeout=2.0,
         )
         _status_fail_count = 0
@@ -215,7 +219,7 @@ async def run_cycle(
 
     async with httpx.AsyncClient() as http:
         # Signal cycle start to dashboard
-        await _push_status(http, "working", "Starting cycle...")
+        await _push_status(http, "working", "Starting cycle...", instance_id=instance_id)
 
         try:
             async for message in query(prompt=prompt, options=options):
@@ -240,7 +244,7 @@ async def run_cycle(
                                 # Log full text (truncated)
                                 logger.info("[agent] %s", text[:300])
                                 # Push to dashboard
-                                await _push_status(http, "working", text[:500])
+                                await _push_status(http, "working", text[:500], instance_id=instance_id)
                         elif isinstance(block, ToolResultBlock):
                             _extract_task_id_from_result(block, ctx)
                         elif hasattr(block, "name"):
@@ -261,18 +265,18 @@ async def run_cycle(
 
         except Exception:
             logger.exception("Agent cycle failed")
-            await _push_status(http, "error", "Cycle failed — check bot.log")
+            await _push_status(http, "error", "Cycle failed — check bot.log", instance_id=instance_id)
 
         # Determine work type from context
         result_text = getattr(result, "result", "") or ""
         if "NO_WORK_FOUND" in result_text:
             ctx.work_type = ctx.work_type or "idle"
-            await _push_status(http, "idle", "No work found. Sleeping...")
+            await _push_status(http, "idle", "No work found. Sleeping...", instance_id=instance_id)
         elif getattr(result, "subtype", "") != "success":
             ctx.work_type = ctx.work_type or "error"
-            await _push_status(http, "idle", "Cycle complete. Sleeping...")
+            await _push_status(http, "idle", "Cycle complete. Sleeping...", instance_id=instance_id)
         else:
-            await _push_status(http, "idle", "Cycle complete. Sleeping...")
+            await _push_status(http, "idle", "Cycle complete. Sleeping...", instance_id=instance_id)
 
         # Extract a short summary from the result text
         if not ctx.summary and result_text:

--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -532,6 +532,7 @@ async def api_bot_status_update(request: Request) -> JSONResponse:
 
     external_key = body.get("external_key")
     source_type = body.get("source_type") or ("jira" if external_key else None)
+    instance_id = body.get("instance_id")
     row = await pool.fetchrow(
         """
         UPDATE bot_status SET state = $1, message = $2, external_key = $3, source_type = $4,
@@ -540,6 +541,31 @@ async def api_bot_status_update(request: Request) -> JSONResponse:
             updated_at = NOW()
         WHERE id = 1 RETURNING *
         """,
+        state,
+        message,
+        external_key,
+        source_type,
+        repo,
+    )
+    await pool.execute(
+        """
+        INSERT INTO bot_instances (instance_id, state, message, external_key, source_type, repo,
+                                   cycle_start, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6,
+            CASE WHEN $2 = 'working' THEN NOW() ELSE NULL END,
+            NOW())
+        ON CONFLICT (instance_id) DO UPDATE SET
+            state = $2, message = $3,
+            external_key = COALESCE($4, bot_instances.external_key),
+            source_type = COALESCE($5, bot_instances.source_type),
+            repo = COALESCE($6, bot_instances.repo),
+            cycle_start = CASE
+                WHEN bot_instances.state = 'idle' AND $2 = 'working' THEN NOW()
+                ELSE bot_instances.cycle_start
+            END,
+            updated_at = NOW()
+        """,
+        instance_id,
         state,
         message,
         external_key,


### PR DESCRIPTION
## Summary

- `_push_status()` in `bot/agent.py` now passes `instance_id` to the `/api/bot-status` REST endpoint
- `api_bot_status_update()` in `api.py` upserts `bot_instances` with `COALESCE` on nullable fields (`external_key`, `source_type`, `repo`) to avoid wiping values set by the MCP tool

**Root cause:** Two code paths update bot status — the MCP tool (`tools/tasks.py`) mirrored to `bot_instances`, but the Python runner's `_push_status()` only wrote to the legacy `bot_status` singleton. The dashboard's `effectiveState()` saw stale `idle` + old `last_seen` and rendered `sleep` even when the instance had in-progress tasks.

Jira: [REHOR-108](https://issues.redhat.com/browse/REHOR-108)
Follow-up cleanup: [REHOR-109](https://issues.redhat.com/browse/REHOR-109) — remove stale `bot_status` singleton table

## Test plan

- [ ] Deploy to staging and verify instance cards show correct `working`/`idle` states
- [ ] Confirm `external_key`/`repo` are not wiped during mid-cycle status pushes
- [ ] Verify sleep state only appears when instance is genuinely idle and stale

---