### PR TITLE
fix(preflights): allow preflight configuration for onboarding use case

### DIFF
--- a/bot/tests/test_onboarding_preflight.py
+++ b/bot/tests/test_onboarding_preflight.py
@@ -12,9 +12,11 @@ sys.path.insert(0, str(SHARED_DIR))
 sys.path.insert(0, str(SKILLS_DIR))
 
 from onboarding_preflight import (
+    _any_pr_mr_merged,
     _get_onboarding_label,
     _has_new_jira_feedback,
     _is_blocked,
+    _phase_ticket_done,
     main,
 )
 
@@ -293,7 +295,7 @@ def test_auto_advance_label_merged_returns_start(env_vars, monkeypatch, capsys):
     monkeypatch.setattr("onboarding_preflight.get_capacity", lambda: (1, 10))
     monkeypatch.setattr("onboarding_preflight._jira_issue", lambda key: issue)
     monkeypatch.setattr("onboarding_preflight._get_candidates", lambda: [])
-    monkeypatch.setattr("onboarding_preflight._any_pr_mr_merged", lambda t: True)
+    monkeypatch.setattr("onboarding_preflight._any_pr_mr_merged", lambda t, s: True)
     monkeypatch.setattr("onboarding_preflight.jira_cleanup", lambda: None)
 
     main()
@@ -322,7 +324,7 @@ def test_auto_advance_label_not_merged_returns_skip(env_vars, monkeypatch, capsy
     monkeypatch.setattr("onboarding_preflight.get_capacity", lambda: (1, 10))
     monkeypatch.setattr("onboarding_preflight._jira_issue", lambda key: issue)
     monkeypatch.setattr("onboarding_preflight._get_candidates", lambda: [])
-    monkeypatch.setattr("onboarding_preflight._any_pr_mr_merged", lambda t: False)
+    monkeypatch.setattr("onboarding_preflight._any_pr_mr_merged", lambda t, s: False)
     monkeypatch.setattr("onboarding_preflight.jira_cleanup", lambda: None)
 
     main()
@@ -361,3 +363,223 @@ def test_jira_unavailable_still_works(env_vars, monkeypatch, capsys):
     out = json.loads(capsys.readouterr().out.strip())
     assert out["status"] == "skip"
     assert "jira unavailable" in out["content"]
+
+
+# --- _phase_ticket_done ---
+
+
+def test_phase_ticket_done_returns_true(monkeypatch):
+    task = {"metadata": {"phase_tickets": {"phase1": "REHOR-101"}}}
+    monkeypatch.setattr(
+        "onboarding_preflight._jira_issue",
+        lambda key: {"status": {"name": "Done"}},
+    )
+    assert _phase_ticket_done(task, "scaffolding-pr") is True
+
+
+def test_phase_ticket_open_returns_false(monkeypatch):
+    task = {"metadata": {"phase_tickets": {"phase2": "REHOR-102"}}}
+    monkeypatch.setattr(
+        "onboarding_preflight._jira_issue",
+        lambda key: {"status": {"name": "In Progress"}},
+    )
+    assert _phase_ticket_done(task, "konflux-mr") is False
+
+
+def test_phase_ticket_done_unknown_step():
+    task = {"metadata": {"phase_tickets": {"phase1": "REHOR-101"}}}
+    assert _phase_ticket_done(task, "unknown-step") is False
+
+
+def test_phase_ticket_done_no_phase_tickets():
+    task = {"metadata": {}}
+    assert _phase_ticket_done(task, "scaffolding-pr") is False
+
+
+def test_phase_ticket_done_jira_unavailable(monkeypatch):
+    task = {"metadata": {"phase_tickets": {"phase1": "REHOR-101"}}}
+    monkeypatch.setattr("onboarding_preflight._jira_issue", lambda key: None)
+    assert _phase_ticket_done(task, "scaffolding-pr") is False
+
+
+# --- _any_pr_mr_merged (phase-aware) ---
+
+
+def test_merged_skipped_when_phase_ticket_done(monkeypatch):
+    """Old merged PR ignored when its phase ticket is already Done."""
+    task = {
+        "metadata": {
+            "phase_tickets": {"phase1": "REHOR-101"},
+            "prs": [{"repo": "org/repo", "number": 1, "host": "github"}],
+        }
+    }
+    monkeypatch.setattr(
+        "onboarding_preflight._jira_issue",
+        lambda key: {"status": {"name": "Done"}},
+    )
+    assert _any_pr_mr_merged(task, "scaffolding-pr") is False
+
+
+def test_konflux_mr_ignores_old_github_pr(monkeypatch):
+    """At konflux-mr step, only GitLab MRs are checked, not old GitHub PRs."""
+    task = {
+        "metadata": {
+            "phase_tickets": {"phase2": "REHOR-102"},
+            "prs": [{"repo": "org/repo", "number": 1, "host": "github"}],
+            "mrs": [],
+        }
+    }
+    monkeypatch.setattr(
+        "onboarding_preflight._jira_issue",
+        lambda key: {"status": {"name": "In Progress"}},
+    )
+    assert _any_pr_mr_merged(task, "konflux-mr") is False
+
+
+def test_app_interface_mr_checks_latest_gitlab_mr(monkeypatch):
+    """At app-interface-mr step, only the latest GitLab MR is checked."""
+    task = {
+        "metadata": {
+            "phase_tickets": {"phase3": "REHOR-103"},
+            "prs": [{"repo": "org/scaffolding", "number": 1, "host": "github"}],
+            "mrs": [
+                {"repo": "releng/konflux-release-data", "number": 10, "host": "gitlab"},
+                {"repo": "service/app-interface", "number": 20, "host": "gitlab"},
+            ],
+        }
+    }
+    monkeypatch.setattr(
+        "onboarding_preflight._jira_issue",
+        lambda key: {"status": {"name": "In Progress"}},
+    )
+    monkeypatch.setattr(
+        "onboarding_preflight.upstream_repo",
+        lambda r: ("service/app-interface", None),
+    )
+    monkeypatch.setattr(
+        "onboarding_preflight.subprocess",
+        type(
+            "FakeSP",
+            (),
+            {"run": staticmethod(lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": '{"state": "merged"}'})())},
+        )(),
+    )
+    assert _any_pr_mr_merged(task, "app-interface-mr") is True
+
+
+def test_app_interface_mr_ignores_old_merged_konflux_mr(monkeypatch):
+    """At app-interface-mr step, old merged Konflux MR doesn't false-positive."""
+    task = {
+        "metadata": {
+            "phase_tickets": {"phase3": "REHOR-103"},
+            "prs": [{"repo": "org/scaffolding", "number": 1, "host": "github"}],
+            "mrs": [
+                {"repo": "releng/konflux-release-data", "number": 10, "host": "gitlab"},
+                {"repo": "service/app-interface", "number": 20, "host": "gitlab"},
+            ],
+        }
+    }
+    monkeypatch.setattr(
+        "onboarding_preflight._jira_issue",
+        lambda key: {"status": {"name": "In Progress"}},
+    )
+    monkeypatch.setattr(
+        "onboarding_preflight.upstream_repo",
+        lambda r: ("service/app-interface", None),
+    )
+    monkeypatch.setattr(
+        "onboarding_preflight.subprocess",
+        type(
+            "FakeSP",
+            (),
+            {"run": staticmethod(lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": '{"state": "opened"}'})())},
+        )(),
+    )
+    # Latest MR (app-interface) is not merged — should return False
+    # even though the older Konflux MR (index 0) is merged
+    assert _any_pr_mr_merged(task, "app-interface-mr") is False
+
+
+def test_tekton_setup_does_not_trigger_merge_check(env_vars, monkeypatch, capsys):
+    """tekton-setup is not in labels_with_auto_advance — no merge check."""
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "REHOR-60",
+                "status": "in_progress",
+                "repo": "",
+                "last_addressed": "2026-07-01T12:00:00",
+                "metadata": {
+                    "step": "tekton-setup",
+                    "prs": [{"repo": "org/repo", "number": 1, "host": "github"}],
+                    "mrs": [{"repo": "releng/konflux-release-data", "number": 10, "host": "gitlab"}],
+                },
+            }
+        ]
+    )
+    issue = {
+        "labels": ["rehor-ai-onboarding-bot", "onboarding:tekton-setup"],
+        "comments": [],
+    }
+    monkeypatch.setattr("onboarding_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("onboarding_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("onboarding_preflight._jira_issue", lambda key: issue)
+    monkeypatch.setattr("onboarding_preflight._get_candidates", lambda: [])
+    monkeypatch.setattr("onboarding_preflight.jira_cleanup", lambda: None)
+    # _any_pr_mr_merged should NOT be called — if it were, this would fail
+    monkeypatch.setattr(
+        "onboarding_preflight._any_pr_mr_merged",
+        lambda t, s: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "skip"
+    assert "PR/MR MERGED" not in out["content"]
+
+
+def test_konflux_mr_merged_with_phase_open_returns_start(env_vars, monkeypatch, capsys):
+    """At konflux-mr step, merged MR with open phase ticket triggers start."""
+    tasks = _mock_tasks(
+        active=[
+            {
+                "external_key": "REHOR-70",
+                "status": "pr_open",
+                "repo": "",
+                "last_addressed": "2026-07-01T12:00:00",
+                "metadata": {
+                    "step": "konflux-mr",
+                    "phase_tickets": {"phase2": "REHOR-702"},
+                    "mrs": [{"repo": "releng/konflux-release-data", "number": 10, "host": "gitlab"}],
+                },
+            }
+        ]
+    )
+
+    def _fake_jira(key):
+        if key == "REHOR-702":
+            return {"status": {"name": "In Progress"}}
+        return {
+            "labels": ["rehor-ai-onboarding-bot", "onboarding:konflux-mr"],
+            "comments": [],
+        }
+
+    monkeypatch.setattr("onboarding_preflight.get_tasks", lambda: tasks)
+    monkeypatch.setattr("onboarding_preflight.get_capacity", lambda: (1, 10))
+    monkeypatch.setattr("onboarding_preflight._jira_issue", _fake_jira)
+    monkeypatch.setattr("onboarding_preflight._get_candidates", lambda: [])
+    monkeypatch.setattr("onboarding_preflight.jira_cleanup", lambda: None)
+    monkeypatch.setattr("onboarding_preflight.upstream_repo", lambda r: ("releng/konflux-release-data", None))
+    monkeypatch.setattr(
+        "onboarding_preflight.subprocess",
+        type(
+            "FakeSP",
+            (),
+            {"run": staticmethod(lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": '{"state": "merged"}'})())},
+        )(),
+    )
+
+    main()
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "start"
+    assert "PR/MR MERGED" in out["content"]

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -192,7 +192,7 @@ def fmt_task(enriched):
     return "\n".join(lines)
 
 
-def main():
+def main(suppress_terminal_if_addressed=False):
     if not INSTANCE_ID:
         output_result("error", "BOT_INSTANCE_ID not set")
         return
@@ -215,9 +215,15 @@ def main():
     for e in enriched:
         issues = e["issues"]
         if "merged" in issues:
-            merged.append(e)
+            if suppress_terminal_if_addressed and e["task"].get("last_addressed") and not has_new_feedback(e):
+                clean.append(e)
+            else:
+                merged.append(e)
         elif "closed" in issues:
-            closed.append(e)
+            if suppress_terminal_if_addressed and e["task"].get("last_addressed") and not has_new_feedback(e):
+                clean.append(e)
+            else:
+                closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
             ci_only = all(i.startswith(("ci_fail", "konflux_urls")) for i in issues)
             if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):

--- a/presets/shared/preflight/gl_mr_status.py
+++ b/presets/shared/preflight/gl_mr_status.py
@@ -159,7 +159,7 @@ def fmt_task(enriched):
     return "\n".join(lines)
 
 
-def main():
+def main(suppress_terminal_if_addressed=False):
     if not INSTANCE_ID:
         output_result("error", "BOT_INSTANCE_ID not set")
         return
@@ -182,9 +182,15 @@ def main():
     for e in enriched:
         issues = e["issues"]
         if "merged" in issues:
-            merged.append(e)
+            if suppress_terminal_if_addressed and e["task"].get("last_addressed") and not has_new_feedback(e):
+                clean.append(e)
+            else:
+                merged.append(e)
         elif "closed" in issues:
-            closed.append(e)
+            if suppress_terminal_if_addressed and e["task"].get("last_addressed") and not has_new_feedback(e):
+                clean.append(e)
+            else:
+                closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
             ci_fail.append(e)
         elif "conflict" in issues:

--- a/presets/shared/preflight/onboarding_preflight.py
+++ b/presets/shared/preflight/onboarding_preflight.py
@@ -83,6 +83,12 @@ def _get_candidates():
 
 BLOCKED_LABEL = "onboarding:blocked"
 
+STEP_TO_PHASE = {
+    "scaffolding-pr": "phase1",
+    "konflux-mr": "phase2",
+    "app-interface-mr": "phase3",
+}
+
 
 def _is_blocked(issue):
     if not issue:
@@ -101,47 +107,81 @@ def _get_onboarding_label(issue):
     return None
 
 
-def _any_pr_mr_merged(task):
-    """Check if any tracked PR/MR on this task has been merged."""
+def _phase_ticket_done(task, step):
+    """Check if the phase sub-ticket for the given step is already Done."""
+    phase_key = STEP_TO_PHASE.get(step)
+    if not phase_key:
+        return False
+    meta = task.get("metadata") or {}
+    ticket_key = meta.get("phase_tickets", {}).get(phase_key)
+    if not ticket_key:
+        return False
+    issue = _jira_issue(ticket_key)
+    if not issue:
+        return False
+    status = issue.get("status", {})
+    name = (status.get("name", "") if isinstance(status, dict) else str(status)).lower()
+    return name in ("done", "closed", "resolved")
+
+
+def _any_pr_mr_merged(task, step):
+    """Check if the PR/MR for the current phase step has been merged.
+
+    Uses the phase sub-ticket as source of truth: if the sub-ticket is
+    already Done, the merge was handled in a prior cycle.  Only checks
+    the most recent PR/MR matching the step's host to avoid false
+    positives from earlier phases' merged PRs/MRs.
+    """
+    if _phase_ticket_done(task, step):
+        return False
+
     prs = get_task_prs(task)
-    for p in prs:
-        host = p.get("host", "github")
-        num = p.get("number")
-        repo = p.get("repo", "")
-        if not num or not repo:
-            continue
-        try:
-            if host == "github":
-                up, _ = upstream_repo(repo)
-                if not up:
-                    continue
-                r = subprocess.run(
-                    ["gh", "pr", "view", str(num), "--repo", up, "--json", "state"],
-                    capture_output=True,
-                    text=True,
-                    timeout=15,
-                )
-                if r.returncode == 0:
-                    data = json.loads(r.stdout)
-                    if data.get("state") == "MERGED":
-                        return True
-            else:
-                up, _ = upstream_repo(repo)
-                if not up:
-                    continue
-                encoded = up.replace("/", "%2F")
-                r = subprocess.run(
-                    ["glab", "api", f"projects/{encoded}/merge_requests/{num}", "--hostname", "gitlab.cee.redhat.com"],
-                    capture_output=True,
-                    text=True,
-                    timeout=15,
-                )
-                if r.returncode == 0:
-                    data = json.loads(r.stdout)
-                    if data.get("state") == "merged":
-                        return True
-        except Exception:
-            continue
+    if not prs:
+        return False
+
+    if step == "scaffolding-pr":
+        candidates = [p for p in prs if p.get("host", "github") == "github"]
+    else:
+        candidates = [p for p in prs if p.get("host") == "gitlab"]
+
+    if not candidates:
+        return False
+
+    target = candidates[-1]
+    host = target.get("host", "github")
+    num = target.get("number")
+    repo = target.get("repo", "")
+    if not num or not repo:
+        return False
+
+    try:
+        if host == "github":
+            up, _ = upstream_repo(repo)
+            if not up:
+                return False
+            r = subprocess.run(
+                ["gh", "pr", "view", str(num), "--repo", up, "--json", "state"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if r.returncode == 0:
+                return json.loads(r.stdout).get("state") == "MERGED"
+        else:
+            up, _ = upstream_repo(repo)
+            if not up:
+                return False
+            encoded = up.replace("/", "%2F")
+            r = subprocess.run(
+                ["glab", "api", f"projects/{encoded}/merge_requests/{num}", "--hostname", "gitlab.cee.redhat.com"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if r.returncode == 0:
+                return json.loads(r.stdout).get("state") == "merged"
+    except Exception:
+        pass
     return False
 
 
@@ -210,7 +250,7 @@ def main():
 
         labels_with_auto_advance = ("scaffolding-pr", "konflux-mr", "app-interface-mr")
         if step_from_label in labels_with_auto_advance:
-            if _any_pr_mr_merged(task):
+            if _any_pr_mr_merged(task, step_from_label):
                 task_lines.append(f"  *** PR/MR MERGED — ADVANCE PHASE (current: {step_from_label}) ***")
                 has_work = True
             else:

--- a/presets/workflows/onboarding/preflight/01-gh-pr-status.py
+++ b/presets/workflows/onboarding/preflight/01-gh-pr-status.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 from gh_pr_status import main
 
-main()
+main(suppress_terminal_if_addressed=True)

--- a/presets/workflows/onboarding/preflight/02-gl-mr-status.py
+++ b/presets/workflows/onboarding/preflight/02-gl-mr-status.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 from gl_mr_status import main
 
-main()
+main(suppress_terminal_if_addressed=True)


### PR DESCRIPTION
Description

  PR #408 suppressed merged/closed PRs in the shared GH/GL preflights to reduce wasteful idle cycles in the onboarding workflow, but this also broke jira-sprint and jira-kanban workflows (merged PRs skipped wrap-up).

  This PR makes two fixes:

  1. Shared preflights: Adds a suppress_terminal_if_addressed parameter to main() in gh_pr_status.py and gl_mr_status.py, defaulting to False (merged/closed always actionable). The onboarding wrappers opt in with True, preserving the suppression they need without affecting other workflows.
  2. Onboarding preflight: Makes _any_pr_mr_merged() phase-aware to fix a pre-existing false-positive bug. Previously it checked ALL tracked PRs/MRs on a task — an old merged scaffolding PR would re-trigger at the konflux-mr or app-interface-mr steps. Now it:
    2a. Uses the phase sub-ticket (from metadata.phase_tickets) as source of truth — if the sub-ticket is Done, the merge was already handled
    2b. Only checks PRs/MRs matching the current step's host (GitHub for scaffolding-pr, GitLab for konflux-mr/app-interface-mr)
    2c. Checks only the most recent candidate to avoid cross-phase false positives

  Companion to #414 which reverted the blanket suppression.

  ---
  Blast radius
  
  - jira-sprint / jira-kanban: Default suppress_terminal_if_addressed=False preserves the fix from #414
  - onboarding: Wrappers pass suppress_terminal_if_addressed=True; phase-aware merge detection prevents re-triggering across phase boundaries
  - Tested: all 309 bot tests pass (11 new), ruff lint + format clean

  ---
  Rollback plan
  
  git revert is sufficient. Onboarding would see extra idle cycles on already-addressed merged PRs (the pre-#408 behavior) but nothing breaks.

  ---
  Checklist
  
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest

  AI disclosure

  Assisted by: Claude Code