### PR TITLE
fix(onboarding): fix onboarding agent missing some JIRA comments

### DIFF
--- a/bot/tests/test_onboarding_preflight.py
+++ b/bot/tests/test_onboarding_preflight.py
@@ -13,6 +13,8 @@ sys.path.insert(0, str(SKILLS_DIR))
 
 from onboarding_preflight import (
     _any_pr_mr_merged,
+    _comments_may_be_truncated,
+    _get_comments,
     _get_onboarding_label,
     _has_new_jira_feedback,
     _is_blocked,
@@ -25,62 +27,89 @@ from onboarding_preflight import (
 
 def test_feedback_detected_with_comments_field():
     """The fix: when MCP returns comments at top-level, feedback is detected."""
-    issue = {
-        "comments": [
-            {
-                "created": "2026-07-01T10:00:00",
-                "body": "Here are the answers to your questions",
-                "author": {"displayName": "Human"},
-            }
-        ]
-    }
-    task = {"last_addressed": "2026-06-30T10:00:00"}
-    assert _has_new_jira_feedback(task, issue) is True
+    comments = [
+        {
+            "created": "2026-07-01T10:00:00",
+            "body": "Here are the answers to your questions",
+            "author": {"displayName": "Human"},
+        }
+    ]
+    assert _has_new_jira_feedback(comments, "2026-06-30T10:00:00") is True
 
 
 def test_feedback_detected_first_comment_no_last_addressed():
     """First human comment on a ticket with no prior addressing."""
-    issue = {
-        "comments": [
-            {
-                "created": "2026-07-01T10:00:00",
-                "body": "Hello",
-                "author": {"displayName": "Human"},
-            }
-        ]
-    }
-    task = {}
-    assert _has_new_jira_feedback(task, issue) is True
+    comments = [
+        {
+            "created": "2026-07-01T10:00:00",
+            "body": "Hello",
+            "author": {"displayName": "Human"},
+        }
+    ]
+    assert _has_new_jira_feedback(comments, "") is True
 
 
 def test_no_feedback_when_comment_is_old():
-    issue = {
-        "comments": [
-            {
-                "created": "2026-06-29T10:00:00",
-                "body": "Old comment",
-                "author": {"displayName": "Human"},
-            }
-        ]
-    }
-    task = {"last_addressed": "2026-06-30T10:00:00"}
-    assert _has_new_jira_feedback(task, issue) is False
+    comments = [
+        {
+            "created": "2026-06-29T10:00:00",
+            "body": "Old comment",
+            "author": {"displayName": "Human"},
+        }
+    ]
+    assert _has_new_jira_feedback(comments, "2026-06-30T10:00:00") is False
 
 
 def test_no_feedback_when_no_comments():
-    issue = {"comments": []}
-    task = {"last_addressed": "2026-06-30T10:00:00"}
-    assert _has_new_jira_feedback(task, issue) is False
+    assert _has_new_jira_feedback([], "2026-06-30T10:00:00") is False
 
 
 def test_no_feedback_when_issue_is_none():
-    assert _has_new_jira_feedback({}, None) is False
+    assert _has_new_jira_feedback([], "") is False
 
 
 def test_no_feedback_when_comments_key_missing():
     issue = {"fields": {"summary": "test"}}
-    task = {"last_addressed": "2026-06-30T10:00:00"}
-    assert _has_new_jira_feedback(task, issue) is False
+    assert _get_comments(issue) == []
+    assert _has_new_jira_feedback([], "2026-06-30T10:00:00") is False
+
+
+# --- _get_comments ---
+
+
+def test_get_comments_top_level():
+    issue = {"comments": [{"body": "a"}]}
+    assert _get_comments(issue) == [{"body": "a"}]
+
+
+def test_get_comments_nested():
+    issue = {"fields": {"comment": {"comments": [{"body": "b"}]}}}
+    assert _get_comments(issue) == [{"body": "b"}]
+
+
+def test_get_comments_none():
+    assert _get_comments(None) == []
+
+
+# --- _comments_may_be_truncated ---
+
+
+def test_truncation_detected():
+    issue = {"updated": "2026-07-02T10:00:00"}
+    comments = [{"body": f"c{i}"} for i in range(100)]
+    assert _comments_may_be_truncated(issue, comments, "2026-07-01T10:00:00") is True
+
+
+def test_no_truncation_under_limit():
+    issue = {"updated": "2026-07-02T10:00:00"}
+    comments = [{"body": "c"}]
+    assert _comments_may_be_truncated(issue, comments, "2026-07-01T10:00:00") is False
+
+
+def test_no_truncation_when_not_updated():
+    issue = {"updated": "2026-06-30T10:00:00"}
+    comments = [{"body": f"c{i}"} for i in range(100)]
+    assert _comments_may_be_truncated(issue, comments, "2026-07-01T10:00:00") is False
 
 
 # --- _is_blocked ---

--- a/presets/shared/preflight/onboarding_preflight.py
+++ b/presets/shared/preflight/onboarding_preflight.py
@@ -31,28 +31,43 @@ if BOT_LABEL and not re.match(r"^[a-zA-Z0-9:_-]+$", BOT_LABEL):
     raise ValueError(f"Invalid BOT_LABEL: {BOT_LABEL!r}")
 BOT_JIRA_EMAIL = os.environ.get("BOT_JIRA_EMAIL", "")
 
+# MCP tool returns oldest-first, no pagination: https://github.com/sooperset/mcp-atlassian/issues/1215
+JIRA_COMMENT_LIMIT = 100
+
 
 def _jira_issue(key):
     return jira_call(
         "jira_get_issue",
         {
             "issue_key": key,
-            "fields": "summary,status,assignee,labels,issuelinks,comment",
-            "comment_limit": 10,
+            "fields": "summary,status,assignee,labels,issuelinks,comment,updated",
+            "comment_limit": JIRA_COMMENT_LIMIT,
         },
     )
 
 
-def _has_new_jira_feedback(task, issue):
+def _get_comments(issue):
     if not issue:
-        return False
-    comments = issue.get("comments", [])
+        return []
+    return issue.get("comments") or (issue.get("fields") or {}).get("comment", {}).get("comments") or []
+
+
+def _has_new_jira_feedback(comments, last_addressed):
     if not comments:
         return False
-    last_addressed = task.get("last_addressed", "")
     if not last_addressed:
         return bool(comments)
     return any((c.get("created", "") or c.get("t", ""))[:16] > last_addressed[:16] for c in comments)
+
+
+def _comments_may_be_truncated(issue, all_comments, last_addressed):
+    """Detect when the MCP tool's oldest-first comment limit hid newer comments."""
+    if not issue or not last_addressed:
+        return False
+    if len(all_comments) < JIRA_COMMENT_LIMIT:
+        return False
+    updated = issue.get("updated") or (issue.get("fields") or {}).get("updated", "")
+    return updated[:16] > last_addressed[:16] if updated else False
 
 
 def _jira_search(jql, limit=10):
@@ -234,12 +249,16 @@ def main():
             task_lines.append(f"  phase_tickets: P1={p1} P2={p2} P3={p3}")
 
         if issue:
-            new_feedback = _has_new_jira_feedback(task, issue)
+            all_comments = _get_comments(issue)
+            last_addr = task.get("last_addressed", "")
+            jira_comments = all_comments[-10:]
+            new_feedback = _has_new_jira_feedback(jira_comments, last_addr)
+            if not new_feedback and _comments_may_be_truncated(issue, all_comments, last_addr):
+                new_feedback = True
             if new_feedback:
                 task_lines.append("  *** HAS NEW JIRA FEEDBACK ***")
                 has_work = True
-            comments = issue.get("comments", [])
-            task_lines.append(fmt_comments(comments, "jira_comments", task.get("last_addressed")))
+            task_lines.append(fmt_comments(jira_comments, "jira_comments", last_addr))
         else:
             task_lines.append("  [jira unavailable]")
 


### PR DESCRIPTION
 Description

  Port the Jira comment limit fix from kanban/sprint preflights (0bc431b) to the onboarding preflight.

  The mcp-atlassian Jira MCP tool returns comments oldest-first with no pagination (sooperset/mcp-atlassian#1215 (https://github.com/sooperset/mcp-atlassian/issues/1215)). With the previous comment_limit: 10, tickets with 10+ comments silently dropped the newest ones. This caused the bot to miss Jakub's comment on REHOR-103 (which has 24 comments — the 10 oldest from Aug 5 were returned, but his Aug 10 comment was the 24th and was dropped).

  Fix: raise comment_limit to 100, request the updated field, and add _comments_may_be_truncated() to detect when the limit ceiling hides newer comments — identical to the approach in 0bc431b.

  ---
  Blast radius
  
  - Only affects onboarding_preflight.py (used by the 03-onboarding-jira.py wrapper in the onboarding workflow)
  - No other workflows or consumers are affected — kanban/sprint preflights already have this fix
  - Tested via updated unit tests covering _get_comments, _has_new_jira_feedback, and _comments_may_be_truncated

  ---
  Rollback plan
  
  git revert is sufficient. The previous behavior (10-comment limit) would return, which is incorrect but not destructive — the bot would continue missing newer comments on high-comment tickets.

  ---
  Checklist
  
  - [x] Tested against at least one consuming repo/service
  - [x] No breaking changes to existing consumers (or migration path documented)
  - [x] No hardcoded secrets, tokens, or passwords
  - [x] Container images pinned to specific tags, not latest

  AI disclosure

  Assisted by: Claude Code