### PR TITLE
feat: exit after single cycle for source=run_and_exit workflows

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -489,7 +489,7 @@ def main() -> None:
                         input_prompt=preflight_result.transcript,
                     )
                     error_sleep = min(config.interval * (2**consecutive_preflight_errors), 300)
-                    if instance_config.source == "scheduled":
+                    if instance_config.source == "keda_scheduled":
                         if consecutive_preflight_errors >= 3:
                             logger.error(
                                 "Scheduled source — giving up after %d preflight errors", consecutive_preflight_errors
@@ -525,7 +525,7 @@ def main() -> None:
                         idle_cycle_limit=instance_config.idle_cycle_limit,
                         cooldown_seconds=config.idle_reminder_cooldown_seconds,
                     )
-                    if instance_config.source == "scheduled":
+                    if instance_config.source == "keda_scheduled":
                         logger.info("Scheduled source — exiting after preflight skip")
                         cleanup_between_cycles(SCRIPT_DIR)
                         break
@@ -586,7 +586,7 @@ def main() -> None:
             else:
                 logger.warning("Cycle produced no result")
 
-            if instance_config.source == "scheduled":
+            if instance_config.source == "keda_scheduled":
                 logger.info("Scheduled source — exiting after cycle")
                 cleanup_between_cycles(SCRIPT_DIR)
                 break

--- a/bot/run.py
+++ b/bot/run.py
@@ -489,6 +489,10 @@ def main() -> None:
                         input_prompt=preflight_result.transcript,
                     )
                     error_sleep = min(config.interval * (2**consecutive_preflight_errors), 300)
+                    if instance_config.source == "scheduled":
+                        logger.info("Scheduled source — exiting after preflight error")
+                        cleanup_between_cycles(SCRIPT_DIR)
+                        break
                     _write_sleep_signal(error_sleep, "preflight_error")
                     _read_sleep_signal(config)
                     cleanup_between_cycles(SCRIPT_DIR)
@@ -511,6 +515,10 @@ def main() -> None:
                         idle_cycle_limit=instance_config.idle_cycle_limit,
                         cooldown_seconds=config.idle_reminder_cooldown_seconds,
                     )
+                    if instance_config.source == "scheduled":
+                        logger.info("Scheduled source — exiting after preflight skip")
+                        cleanup_between_cycles(SCRIPT_DIR)
+                        break
                     _write_sleep_signal(config.idle_interval, "preflight_skip")
                     _read_sleep_signal(config)
                     cleanup_between_cycles(SCRIPT_DIR)
@@ -567,6 +575,11 @@ def main() -> None:
                 )
             else:
                 logger.warning("Cycle produced no result")
+
+            if instance_config.source == "scheduled":
+                logger.info("Scheduled source — exiting after cycle")
+                cleanup_between_cycles(SCRIPT_DIR)
+                break
 
             _read_sleep_signal(config)
 

--- a/bot/run.py
+++ b/bot/run.py
@@ -489,7 +489,7 @@ def main() -> None:
                         input_prompt=preflight_result.transcript,
                     )
                     error_sleep = min(config.interval * (2**consecutive_preflight_errors), 300)
-                    if instance_config.source == "keda_scheduled":
+                    if instance_config.source == "run_to_completion":
                         if consecutive_preflight_errors >= 3:
                             logger.error(
                                 "Scheduled source — giving up after %d preflight errors", consecutive_preflight_errors
@@ -525,7 +525,7 @@ def main() -> None:
                         idle_cycle_limit=instance_config.idle_cycle_limit,
                         cooldown_seconds=config.idle_reminder_cooldown_seconds,
                     )
-                    if instance_config.source == "keda_scheduled":
+                    if instance_config.source == "run_to_completion":
                         logger.info("Scheduled source — exiting after preflight skip")
                         cleanup_between_cycles(SCRIPT_DIR)
                         break
@@ -586,7 +586,7 @@ def main() -> None:
             else:
                 logger.warning("Cycle produced no result")
 
-            if instance_config.source == "keda_scheduled":
+            if instance_config.source == "run_to_completion":
                 logger.info("Scheduled source — exiting after cycle")
                 cleanup_between_cycles(SCRIPT_DIR)
                 break

--- a/bot/run.py
+++ b/bot/run.py
@@ -489,7 +489,7 @@ def main() -> None:
                         input_prompt=preflight_result.transcript,
                     )
                     error_sleep = min(config.interval * (2**consecutive_preflight_errors), 300)
-                    if instance_config.source == "run_to_completion":
+                    if instance_config.source == "run_and_exit":
                         if consecutive_preflight_errors >= 3:
                             logger.error(
                                 "Scheduled source — giving up after %d preflight errors", consecutive_preflight_errors
@@ -525,7 +525,7 @@ def main() -> None:
                         idle_cycle_limit=instance_config.idle_cycle_limit,
                         cooldown_seconds=config.idle_reminder_cooldown_seconds,
                     )
-                    if instance_config.source == "run_to_completion":
+                    if instance_config.source == "run_and_exit":
                         logger.info("Scheduled source — exiting after preflight skip")
                         cleanup_between_cycles(SCRIPT_DIR)
                         break
@@ -586,7 +586,7 @@ def main() -> None:
             else:
                 logger.warning("Cycle produced no result")
 
-            if instance_config.source == "run_to_completion":
+            if instance_config.source == "run_and_exit":
                 logger.info("Scheduled source — exiting after cycle")
                 cleanup_between_cycles(SCRIPT_DIR)
                 break

--- a/bot/run.py
+++ b/bot/run.py
@@ -495,12 +495,11 @@ def main() -> None:
                                 "Scheduled source — giving up after %d preflight errors", consecutive_preflight_errors
                             )
                             cleanup_between_cycles(SCRIPT_DIR)
-                            break
-                        retry_delay = 30
+                            sys.exit(1)
                         logger.info(
-                            "Scheduled source — retrying in %ds (%d/3)", retry_delay, consecutive_preflight_errors
+                            "Scheduled source — retrying in %ds (%d/3)", error_sleep, consecutive_preflight_errors
                         )
-                        time.sleep(retry_delay)
+                        time.sleep(error_sleep)
                         cleanup_between_cycles(SCRIPT_DIR)
                         continue
                     _write_sleep_signal(error_sleep, "preflight_error")

--- a/bot/run.py
+++ b/bot/run.py
@@ -490,9 +490,19 @@ def main() -> None:
                     )
                     error_sleep = min(config.interval * (2**consecutive_preflight_errors), 300)
                     if instance_config.source == "scheduled":
-                        logger.info("Scheduled source — exiting after preflight error")
+                        if consecutive_preflight_errors >= 3:
+                            logger.error(
+                                "Scheduled source — giving up after %d preflight errors", consecutive_preflight_errors
+                            )
+                            cleanup_between_cycles(SCRIPT_DIR)
+                            break
+                        retry_delay = 30
+                        logger.info(
+                            "Scheduled source — retrying in %ds (%d/3)", retry_delay, consecutive_preflight_errors
+                        )
+                        time.sleep(retry_delay)
                         cleanup_between_cycles(SCRIPT_DIR)
-                        break
+                        continue
                     _write_sleep_signal(error_sleep, "preflight_error")
                     _read_sleep_signal(config)
                     cleanup_between_cycles(SCRIPT_DIR)

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bot.config import InstanceConfig
-from bot.preflight import PreflightResult, ScriptResult
+from bot.preflight import PreflightResult
 
 
 @pytest.fixture

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -53,13 +53,9 @@ def _run_loop(instance_config, mock_deps, preflight_action="start"):
     mock_deps["load_instance_config"].return_value = instance_config
 
     if preflight_action == "start":
-        mock_deps["run_preflight"].return_value = PreflightResult(
-            action="start", prompt="test data", scripts=[]
-        )
+        mock_deps["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])
     elif preflight_action == "skip":
-        mock_deps["run_preflight"].return_value = PreflightResult(
-            action="skip", transcript="nothing to do", scripts=[]
-        )
+        mock_deps["run_preflight"].return_value = PreflightResult(action="skip", transcript="nothing to do", scripts=[])
     elif preflight_action == "error":
         mock_deps["run_preflight"].return_value = PreflightResult(
             action="error", transcript="something broke", scripts=[]

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -1,5 +1,10 @@
-"""Tests for source=scheduled single-cycle exit behavior."""
+"""Tests for source=scheduled single-cycle exit behavior.
 
+Calls the actual main() function with mocked dependencies to verify
+the real production loop exits after one iteration for scheduled sources.
+"""
+
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,105 +13,127 @@ from bot.config import InstanceConfig
 from bot.preflight import PreflightResult
 
 
-@pytest.fixture
-def scheduled_config():
-    return InstanceConfig(workflow="quality-monitor", source="scheduled")
+def _mock_config():
+    config = MagicMock()
+    config.interval = 300
+    config.idle_interval = 3600
+    config.cycle_timeout = 600
+    config.idle_reminder_cooldown_seconds = 0
+    return config
+
+
+async def _fake_run_cycle(**kwargs):
+    result = MagicMock()
+    ctx = MagicMock()
+    ctx.work_type = "scan"
+    return result, ctx
 
 
 @pytest.fixture
-def jira_config():
-    return InstanceConfig(workflow="jira-sprint", source="jira")
+def main_patches():
+    """Patch all main() dependencies so it can run in a test."""
+    instance_config = InstanceConfig(workflow="quality-monitor", source="scheduled")
 
-
-@pytest.fixture
-def mock_loop_deps():
-    """Mock all heavy dependencies used inside the main loop."""
-    patches = {
+    all_patches = {
+        "argv": patch("sys.argv", ["dev-bot", "--label", "test", "--instance-id", "test-instance"]),
+        "dotenv": patch("bot.run.load_dotenv"),
+        "setup_git": patch("bot.run.setup_git"),
+        "setup_logging": patch("bot.run.setup_logging"),
+        "load_config": patch("bot.run.load_config", return_value=_mock_config()),
+        "load_mcp_servers": patch("bot.run.load_mcp_servers", return_value={}),
         "sync_config_repo": patch("bot.run.sync_config_repo", return_value=(None, None)),
-        "load_instance_config": patch("bot.run.load_instance_config"),
+        "apply_merged_config": patch("bot.run.apply_merged_config"),
+        "load_instance_config": patch("bot.run.load_instance_config", return_value=instance_config),
         "install_skills": patch("bot.run.install_skills"),
         "resolve_workflow_dir": patch("bot.run.resolve_workflow_dir"),
         "resolve_active_envs": patch("bot.run.resolve_active_envs", return_value=[]),
+        "validate_manifest": patch("bot.run.validate_manifest"),
+        "validate_instance_config": patch("bot.run.validate_instance_config"),
+        "sanitize_env": patch("bot.run.sanitize_env"),
+        "file_lock": patch("bot.run.FileLock"),
+        "signal": patch("bot.run.signal.signal"),
+        "metrics_server": patch("bot.run.start_http_server"),
         "assemble_claude_md": patch("bot.run.assemble_claude_md"),
         "run_preflight": patch("bot.run.run_preflight"),
-        "run_cycle": patch("bot.run.run_cycle"),
+        "run_cycle": patch("bot.run.run_cycle", side_effect=_fake_run_cycle),
         "cleanup": patch("bot.run.cleanup_between_cycles"),
         "sleep_signal": patch("bot.run._read_sleep_signal"),
         "write_signal": patch("bot.run._write_sleep_signal"),
         "post_orphan": patch("bot.run.post_orphan_cycle"),
-        "idle_skip": patch("bot.run.idle_reminder.on_preflight_skip"),
-        "idle_start": patch("bot.run.idle_reminder.on_preflight_start"),
+        "idle_reminder": patch("bot.run.idle_reminder"),
         "slack_digest": patch("bot.run._try_slack_digest"),
         "record_cost": patch("bot.run.record_cost"),
         "record_transcript": patch("bot.run.record_transcript"),
     }
     mocks = {}
-    for name, p in patches.items():
+    for name, p in all_patches.items():
         mocks[name] = p.start()
     yield mocks
-    for p in patches.values():
+    for p in all_patches.values():
         p.stop()
 
 
-def _run_loop(instance_config, mock_deps, preflight_action="start"):
-    """Run the main while-loop extracted from bot.run.main, counting iterations."""
-    mock_deps["load_instance_config"].return_value = instance_config
-
-    if preflight_action == "start":
-        mock_deps["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])
-    elif preflight_action == "skip":
-        mock_deps["run_preflight"].return_value = PreflightResult(action="skip", transcript="nothing to do", scripts=[])
-    elif preflight_action == "error":
-        mock_deps["run_preflight"].return_value = PreflightResult(
-            action="error", transcript="something broke", scripts=[]
-        )
-
-    iterations = 0
-    max_iterations = 3
-    config = MagicMock()
-    config.interval = 300
-    config.idle_interval = 3600
-    config.cycle_timeout = 600
-
-    while True:
-        iterations += 1
-        if iterations > max_iterations:
-            break
-
-        mock_deps["sync_config_repo"].return_value = (None, None)
-
-        preflight_result = mock_deps["run_preflight"].return_value
-
-        if preflight_result is not None:
-            if preflight_result.action == "error":
-                if instance_config.source == "scheduled":
-                    break
-                continue
-
-            if preflight_result.action == "skip":
-                if instance_config.source == "scheduled":
-                    break
-                continue
-
-        if instance_config.source == "scheduled":
-            break
-
-    return iterations
+def _loop_call_count(main_patches):
+    """Count how many times the loop body ran (sync_config_repo is called once
+    before the loop and once per iteration, so loop iterations = total - 1)."""
+    return main_patches["sync_config_repo"].call_count - 1
 
 
 class TestScheduledExit:
-    def test_exits_after_cycle_when_scheduled(self, scheduled_config, mock_loop_deps):
-        iterations = _run_loop(scheduled_config, mock_loop_deps, "start")
-        assert iterations == 1
+    """Verify main() exits after a single loop iteration when source=scheduled."""
 
-    def test_exits_after_skip_when_scheduled(self, scheduled_config, mock_loop_deps):
-        iterations = _run_loop(scheduled_config, mock_loop_deps, "skip")
-        assert iterations == 1
+    def test_exits_after_preflight_start(self, main_patches):
+        main_patches["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])
 
-    def test_exits_after_error_when_scheduled(self, scheduled_config, mock_loop_deps):
-        iterations = _run_loop(scheduled_config, mock_loop_deps, "error")
-        assert iterations == 1
+        from bot.run import main
 
-    def test_loops_when_not_scheduled(self, jira_config, mock_loop_deps):
-        iterations = _run_loop(jira_config, mock_loop_deps, "skip")
-        assert iterations > 1
+        main()
+
+        assert _loop_call_count(main_patches) == 1
+
+    def test_exits_after_preflight_skip(self, main_patches):
+        main_patches["run_preflight"].return_value = PreflightResult(
+            action="skip", transcript="nothing to do", scripts=[]
+        )
+
+        from bot.run import main
+
+        main()
+
+        assert _loop_call_count(main_patches) == 1
+
+    def test_exits_after_preflight_error(self, main_patches):
+        main_patches["run_preflight"].return_value = PreflightResult(
+            action="error", transcript="something broke", scripts=[]
+        )
+
+        from bot.run import main
+
+        main()
+
+        assert _loop_call_count(main_patches) == 1
+
+    def test_non_scheduled_loops(self, main_patches):
+        main_patches["load_instance_config"].return_value = InstanceConfig(workflow="jira-sprint", source="jira")
+        main_patches["run_preflight"].return_value = PreflightResult(
+            action="skip", transcript="nothing to do", scripts=[]
+        )
+
+        call_count = 0
+
+        def counting_sync(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 3:
+                raise SystemExit(0)
+            return (None, None)
+
+        main_patches["sync_config_repo"].side_effect = counting_sync
+
+        from bot.run import main
+
+        with pytest.raises(SystemExit):
+            main()
+
+        loop_iterations = call_count - 1
+        assert loop_iterations >= 2

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -31,7 +31,7 @@ async def _fake_run_cycle(**kwargs):
 @pytest.fixture
 def main_patches():
     """Patch all main() dependencies so it can run in a test."""
-    instance_config = InstanceConfig(workflow="quality-monitor", source="scheduled")
+    instance_config = InstanceConfig(workflow="quality-monitor", source="keda_scheduled")
 
     all_patches = {
         "argv": patch("sys.argv", ["dev-bot", "--label", "test", "--instance-id", "test-instance"]),
@@ -86,7 +86,7 @@ def _loop_call_count(main_patches):
 
 
 class TestScheduledExit:
-    """Verify main() exits after a single loop iteration when source=scheduled."""
+    """Verify main() exits after a single loop iteration when source=keda_scheduled."""
 
     def test_exits_after_preflight_start(self, main_patches):
         main_patches["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -110,11 +110,11 @@ class TestScheduledExit:
             action="error", transcript="something broke", scripts=[]
         )
 
-        _run_main()
+        with pytest.raises(SystemExit, match="1"):
+            _run_main()
 
         assert _loop_call_count(main_patches) == 3
         assert mock_sleep.call_count == 2
-        mock_sleep.assert_called_with(30)
 
     @patch("bot.run.time.sleep")
     def test_recovers_from_transient_preflight_error(self, mock_sleep, main_patches):
@@ -132,7 +132,7 @@ class TestScheduledExit:
         _run_main()
 
         assert _loop_call_count(main_patches) == 2
-        mock_sleep.assert_called_once_with(30)
+        mock_sleep.assert_called_once_with(300)
 
     def test_non_scheduled_loops(self, main_patches):
         main_patches["load_instance_config"].return_value = InstanceConfig(workflow="jira-sprint", source="jira")

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -10,6 +10,7 @@ import pytest
 
 from bot.config import InstanceConfig
 from bot.preflight import PreflightResult
+from bot.run import main
 
 
 def _mock_config():
@@ -84,8 +85,6 @@ class TestScheduledExit:
     def test_exits_after_preflight_start(self, main_patches):
         main_patches["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])
 
-        from bot.run import main
-
         main()
 
         assert _loop_call_count(main_patches) == 1
@@ -94,8 +93,6 @@ class TestScheduledExit:
         main_patches["run_preflight"].return_value = PreflightResult(
             action="skip", transcript="nothing to do", scripts=[]
         )
-
-        from bot.run import main
 
         main()
 
@@ -106,8 +103,6 @@ class TestScheduledExit:
         main_patches["run_preflight"].return_value = PreflightResult(
             action="error", transcript="something broke", scripts=[]
         )
-
-        from bot.run import main
 
         main()
 
@@ -127,8 +122,6 @@ class TestScheduledExit:
             return PreflightResult(action="skip", transcript="ok now", scripts=[])
 
         main_patches["run_preflight"].side_effect = error_then_skip
-
-        from bot.run import main
 
         main()
 

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -1,0 +1,116 @@
+"""Tests for source=scheduled single-cycle exit behavior."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bot.config import InstanceConfig
+from bot.preflight import PreflightResult, ScriptResult
+
+
+@pytest.fixture
+def scheduled_config():
+    return InstanceConfig(workflow="quality-monitor", source="scheduled")
+
+
+@pytest.fixture
+def jira_config():
+    return InstanceConfig(workflow="jira-sprint", source="jira")
+
+
+@pytest.fixture
+def mock_loop_deps():
+    """Mock all heavy dependencies used inside the main loop."""
+    patches = {
+        "sync_config_repo": patch("bot.run.sync_config_repo", return_value=(None, None)),
+        "load_instance_config": patch("bot.run.load_instance_config"),
+        "install_skills": patch("bot.run.install_skills"),
+        "resolve_workflow_dir": patch("bot.run.resolve_workflow_dir"),
+        "resolve_active_envs": patch("bot.run.resolve_active_envs", return_value=[]),
+        "assemble_claude_md": patch("bot.run.assemble_claude_md"),
+        "run_preflight": patch("bot.run.run_preflight"),
+        "run_cycle": patch("bot.run.run_cycle"),
+        "cleanup": patch("bot.run.cleanup_between_cycles"),
+        "sleep_signal": patch("bot.run._read_sleep_signal"),
+        "write_signal": patch("bot.run._write_sleep_signal"),
+        "post_orphan": patch("bot.run.post_orphan_cycle"),
+        "idle_skip": patch("bot.run.idle_reminder.on_preflight_skip"),
+        "idle_start": patch("bot.run.idle_reminder.on_preflight_start"),
+        "slack_digest": patch("bot.run._try_slack_digest"),
+        "record_cost": patch("bot.run.record_cost"),
+        "record_transcript": patch("bot.run.record_transcript"),
+    }
+    mocks = {}
+    for name, p in patches.items():
+        mocks[name] = p.start()
+    yield mocks
+    for p in patches.values():
+        p.stop()
+
+
+def _run_loop(instance_config, mock_deps, preflight_action="start"):
+    """Run the main while-loop extracted from bot.run.main, counting iterations."""
+    mock_deps["load_instance_config"].return_value = instance_config
+
+    if preflight_action == "start":
+        mock_deps["run_preflight"].return_value = PreflightResult(
+            action="start", prompt="test data", scripts=[]
+        )
+    elif preflight_action == "skip":
+        mock_deps["run_preflight"].return_value = PreflightResult(
+            action="skip", transcript="nothing to do", scripts=[]
+        )
+    elif preflight_action == "error":
+        mock_deps["run_preflight"].return_value = PreflightResult(
+            action="error", transcript="something broke", scripts=[]
+        )
+
+    iterations = 0
+    max_iterations = 3
+    config = MagicMock()
+    config.interval = 300
+    config.idle_interval = 3600
+    config.cycle_timeout = 600
+
+    while True:
+        iterations += 1
+        if iterations > max_iterations:
+            break
+
+        mock_deps["sync_config_repo"].return_value = (None, None)
+
+        preflight_result = mock_deps["run_preflight"].return_value
+
+        if preflight_result is not None:
+            if preflight_result.action == "error":
+                if instance_config.source == "scheduled":
+                    break
+                continue
+
+            if preflight_result.action == "skip":
+                if instance_config.source == "scheduled":
+                    break
+                continue
+
+        if instance_config.source == "scheduled":
+            break
+
+    return iterations
+
+
+class TestScheduledExit:
+    def test_exits_after_cycle_when_scheduled(self, scheduled_config, mock_loop_deps):
+        iterations = _run_loop(scheduled_config, mock_loop_deps, "start")
+        assert iterations == 1
+
+    def test_exits_after_skip_when_scheduled(self, scheduled_config, mock_loop_deps):
+        iterations = _run_loop(scheduled_config, mock_loop_deps, "skip")
+        assert iterations == 1
+
+    def test_exits_after_error_when_scheduled(self, scheduled_config, mock_loop_deps):
+        iterations = _run_loop(scheduled_config, mock_loop_deps, "error")
+        assert iterations == 1
+
+    def test_loops_when_not_scheduled(self, jira_config, mock_loop_deps):
+        iterations = _run_loop(jira_config, mock_loop_deps, "skip")
+        assert iterations > 1

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -31,7 +31,7 @@ async def _fake_run_cycle(**kwargs):
 @pytest.fixture
 def main_patches():
     """Patch all main() dependencies so it can run in a test."""
-    instance_config = InstanceConfig(workflow="quality-monitor", source="run_to_completion")
+    instance_config = InstanceConfig(workflow="quality-monitor", source="run_and_exit")
 
     all_patches = {
         "argv": patch("sys.argv", ["dev-bot", "--label", "test", "--instance-id", "test-instance"]),
@@ -86,7 +86,7 @@ def _loop_call_count(main_patches):
 
 
 class TestScheduledExit:
-    """Verify main() exits after a single loop iteration when source=run_to_completion."""
+    """Verify main() exits after a single loop iteration when source=run_and_exit."""
 
     def test_exits_after_preflight_start(self, main_patches):
         main_patches["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -10,7 +10,6 @@ import pytest
 
 from bot.config import InstanceConfig
 from bot.preflight import PreflightResult
-from bot.run import main
 
 
 def _mock_config():
@@ -73,6 +72,13 @@ def main_patches():
         p.stop()
 
 
+def _run_main():
+    """Import and call main() inside the patched context."""
+    from bot.run import main
+
+    main()
+
+
 def _loop_call_count(main_patches):
     """Count how many times the loop body ran (sync_config_repo is called once
     before the loop and once per iteration, so loop iterations = total - 1)."""
@@ -85,7 +91,7 @@ class TestScheduledExit:
     def test_exits_after_preflight_start(self, main_patches):
         main_patches["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])
 
-        main()
+        _run_main()
 
         assert _loop_call_count(main_patches) == 1
 
@@ -94,7 +100,7 @@ class TestScheduledExit:
             action="skip", transcript="nothing to do", scripts=[]
         )
 
-        main()
+        _run_main()
 
         assert _loop_call_count(main_patches) == 1
 
@@ -104,7 +110,7 @@ class TestScheduledExit:
             action="error", transcript="something broke", scripts=[]
         )
 
-        main()
+        _run_main()
 
         assert _loop_call_count(main_patches) == 3
         assert mock_sleep.call_count == 2
@@ -123,7 +129,7 @@ class TestScheduledExit:
 
         main_patches["run_preflight"].side_effect = error_then_skip
 
-        main()
+        _run_main()
 
         assert _loop_call_count(main_patches) == 2
         mock_sleep.assert_called_once_with(30)

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -4,7 +4,6 @@ Calls the actual main() function with mocked dependencies to verify
 the real production loop exits after one iteration for scheduled sources.
 """
 
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -102,7 +101,8 @@ class TestScheduledExit:
 
         assert _loop_call_count(main_patches) == 1
 
-    def test_exits_after_preflight_error(self, main_patches):
+    @patch("bot.run.time.sleep")
+    def test_retries_then_exits_after_preflight_errors(self, mock_sleep, main_patches):
         main_patches["run_preflight"].return_value = PreflightResult(
             action="error", transcript="something broke", scripts=[]
         )
@@ -111,7 +111,29 @@ class TestScheduledExit:
 
         main()
 
-        assert _loop_call_count(main_patches) == 1
+        assert _loop_call_count(main_patches) == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(30)
+
+    @patch("bot.run.time.sleep")
+    def test_recovers_from_transient_preflight_error(self, mock_sleep, main_patches):
+        call_count = 0
+
+        def error_then_skip(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return PreflightResult(action="error", transcript="transient", scripts=[])
+            return PreflightResult(action="skip", transcript="ok now", scripts=[])
+
+        main_patches["run_preflight"].side_effect = error_then_skip
+
+        from bot.run import main
+
+        main()
+
+        assert _loop_call_count(main_patches) == 2
+        mock_sleep.assert_called_once_with(30)
 
     def test_non_scheduled_loops(self, main_patches):
         main_patches["load_instance_config"].return_value = InstanceConfig(workflow="jira-sprint", source="jira")

--- a/bot/tests/test_scheduled_exit.py
+++ b/bot/tests/test_scheduled_exit.py
@@ -31,7 +31,7 @@ async def _fake_run_cycle(**kwargs):
 @pytest.fixture
 def main_patches():
     """Patch all main() dependencies so it can run in a test."""
-    instance_config = InstanceConfig(workflow="quality-monitor", source="keda_scheduled")
+    instance_config = InstanceConfig(workflow="quality-monitor", source="run_to_completion")
 
     all_patches = {
         "argv": patch("sys.argv", ["dev-bot", "--label", "test", "--instance-id", "test-instance"]),
@@ -86,7 +86,7 @@ def _loop_call_count(main_patches):
 
 
 class TestScheduledExit:
-    """Verify main() exits after a single loop iteration when source=keda_scheduled."""
+    """Verify main() exits after a single loop iteration when source=run_to_completion."""
 
     def test_exits_after_preflight_start(self, main_patches):
         main_patches["run_preflight"].return_value = PreflightResult(action="start", prompt="test data", scripts=[])

--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -91,7 +91,7 @@ envs:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `workflow` | string | `jira-sprint` | Workflow preset name (built-in) or `./path` (custom). See below. |
-| `source` | string | `jira` | Ticket source. `jira` = Jira sprint polling. `scheduled` = time-based. |
+| `source` | string | `jira` | Ticket source. `jira` = Jira sprint polling. `scheduled` = time-based (loops with sleep). `keda_scheduled` = KEDA-triggered (exits after one cycle). |
 | `envs` | list or null | `null` (all) | Env presets to activate. `null`/omitted = all available. `[]` = none. |
 | `claude_md.strategy` | string | `ignore` | How to handle instance CLAUDE.md: `ignore`, `append`, `replace`. |
 

--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -101,9 +101,9 @@ envs:
 |--------|--------------|----------|
 | `jira` | Runs continuously, sleeps between cycles, polls for new work | Your bot pulls tickets from a Jira board |
 | `scheduled` | Runs continuously, sleeps between cycles (same as `jira`) | Your bot runs on a timer but the pod stays alive between cycles |
-| `keda_scheduled` | Runs one cycle then exits | Your pod is scaled 0-to-1 by KEDA on a cron schedule. KEDA handles timing; the bot runs once and the pod scales back to zero. |
+| `run_to_completion` | Runs one cycle then exits | Your pod is scaled 0-to-1 by KEDA on a cron schedule. KEDA handles timing; the bot runs once and the pod scales back to zero. |
 
-Use `keda_scheduled` when KEDA (or a similar external scheduler) controls pod lifecycle. Use `scheduled` when the pod stays alive and the bot manages its own sleep interval between runs.
+Use `run_to_completion` when KEDA (or a similar external scheduler) controls pod lifecycle. Use `scheduled` when the pod stays alive and the bot manages its own sleep interval between runs.
 
 **Workflows:** The built-in `jira-sprint` workflow handles the full autonomous development loop (triage → implement → PR → maintain). For specialized use cases — monitoring, review-only, scheduled tasks — you can create custom workflows in your instance config repo using `workflow: ./workflows/<name>`. See [Creating Custom Workflows](presets/custom-workflows.md) for the full guide.
 

--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -101,9 +101,9 @@ envs:
 |--------|--------------|----------|
 | `jira` | Runs continuously, sleeps between cycles, polls for new work | Your bot pulls tickets from a Jira board |
 | `scheduled` | Runs continuously, sleeps between cycles (same as `jira`) | Your bot runs on a timer but the pod stays alive between cycles |
-| `run_to_completion` | Runs one cycle then exits | Your pod is scaled 0-to-1 by KEDA on a cron schedule. KEDA handles timing; the bot runs once and the pod scales back to zero. |
+| `run_and_exit` | Runs one cycle then exits | Your pod is scaled 0-to-1 by KEDA on a cron schedule. KEDA handles timing; the bot runs once and the pod scales back to zero. |
 
-Use `run_to_completion` when KEDA (or a similar external scheduler) controls pod lifecycle. Use `scheduled` when the pod stays alive and the bot manages its own sleep interval between runs.
+Use `run_and_exit` when KEDA (or a similar external scheduler) controls pod lifecycle. Use `scheduled` when the pod stays alive and the bot manages its own sleep interval between runs.
 
 **Workflows:** The built-in `jira-sprint` workflow handles the full autonomous development loop (triage → implement → PR → maintain). For specialized use cases — monitoring, review-only, scheduled tasks — you can create custom workflows in your instance config repo using `workflow: ./workflows/<name>`. See [Creating Custom Workflows](presets/custom-workflows.md) for the full guide.
 

--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -91,9 +91,19 @@ envs:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `workflow` | string | `jira-sprint` | Workflow preset name (built-in) or `./path` (custom). See below. |
-| `source` | string | `jira` | Ticket source. `jira` = Jira sprint polling. `scheduled` = time-based (loops with sleep). `keda_scheduled` = KEDA-triggered (exits after one cycle). |
+| `source` | string | `jira` | Work source. See **Source types** below. |
 | `envs` | list or null | `null` (all) | Env presets to activate. `null`/omitted = all available. `[]` = none. |
 | `claude_md.strategy` | string | `ignore` | How to handle instance CLAUDE.md: `ignore`, `append`, `replace`. |
+
+**Source types** control how the bot's main loop behaves between cycles:
+
+| Source | Loop behavior | Use when |
+|--------|--------------|----------|
+| `jira` | Runs continuously, sleeps between cycles, polls for new work | Your bot pulls tickets from a Jira board |
+| `scheduled` | Runs continuously, sleeps between cycles (same as `jira`) | Your bot runs on a timer but the pod stays alive between cycles |
+| `keda_scheduled` | Runs one cycle then exits | Your pod is scaled 0-to-1 by KEDA on a cron schedule. KEDA handles timing; the bot runs once and the pod scales back to zero. |
+
+Use `keda_scheduled` when KEDA (or a similar external scheduler) controls pod lifecycle. Use `scheduled` when the pod stays alive and the bot manages its own sleep interval between runs.
 
 **Workflows:** The built-in `jira-sprint` workflow handles the full autonomous development loop (triage → implement → PR → maintain). For specialized use cases — monitoring, review-only, scheduled tasks — you can create custom workflows in your instance config repo using `workflow: ./workflows/<name>`. See [Creating Custom Workflows](presets/custom-workflows.md) for the full guide.
 

--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -153,7 +153,7 @@ claude_md:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `workflow` | `jira-sprint` | Workflow name (built-in) or `./path` (custom) |
-| `source` | `jira` | Ticket source. `jira` = Jira sprint polling. `scheduled` = time-based (loops with sleep). `keda_scheduled` = KEDA-triggered (exits after one cycle). |
+| `source` | `jira` | Work source: `jira` (continuous polling), `scheduled` (continuous with sleep), `keda_scheduled` (run once then exit). See [Source types](../onboarding-new-instance.md#source-types). |
 | `envs` | `null` (all) | Env presets to activate. `null` = all available, `[]` = none. |
 | `claude_md.strategy` | `ignore` | How instance CLAUDE.md combines with workflow CLAUDE.md |
 

--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -153,7 +153,7 @@ claude_md:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `workflow` | `jira-sprint` | Workflow name (built-in) or `./path` (custom) |
-| `source` | `jira` | Work source: `jira` (continuous polling), `scheduled` (continuous with sleep), `run_to_completion` (run once then exit). See [Source types](../onboarding-new-instance.md#source-types). |
+| `source` | `jira` | Work source: `jira` (continuous polling), `scheduled` (continuous with sleep), `run_and_exit` (run once then exit). See [Source types](../onboarding-new-instance.md#source-types). |
 | `envs` | `null` (all) | Env presets to activate. `null` = all available, `[]` = none. |
 | `claude_md.strategy` | `ignore` | How instance CLAUDE.md combines with workflow CLAUDE.md |
 

--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -153,7 +153,7 @@ claude_md:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `workflow` | `jira-sprint` | Workflow name (built-in) or `./path` (custom) |
-| `source` | `jira` | Work source: `jira` (continuous polling), `scheduled` (continuous with sleep), `keda_scheduled` (run once then exit). See [Source types](../onboarding-new-instance.md#source-types). |
+| `source` | `jira` | Work source: `jira` (continuous polling), `scheduled` (continuous with sleep), `run_to_completion` (run once then exit). See [Source types](../onboarding-new-instance.md#source-types). |
 | `envs` | `null` (all) | Env presets to activate. `null` = all available, `[]` = none. |
 | `claude_md.strategy` | `ignore` | How instance CLAUDE.md combines with workflow CLAUDE.md |
 

--- a/docs/presets/custom-workflows.md
+++ b/docs/presets/custom-workflows.md
@@ -153,7 +153,7 @@ claude_md:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `workflow` | `jira-sprint` | Workflow name (built-in) or `./path` (custom) |
-| `source` | `jira` | Ticket source. `jira` = Jira sprint polling. `scheduled` = time-based. |
+| `source` | `jira` | Ticket source. `jira` = Jira sprint polling. `scheduled` = time-based (loops with sleep). `keda_scheduled` = KEDA-triggered (exits after one cycle). |
 | `envs` | `null` (all) | Env presets to activate. `null` = all available, `[]` = none. |
 | `claude_md.strategy` | `ignore` | How instance CLAUDE.md combines with workflow CLAUDE.md |
 


### PR DESCRIPTION
## Summary

- When `instance.yaml` sets `source: scheduled`, the runner now exits after completing one iteration instead of sleeping and looping
- This applies to all three preflight outcomes: `start` (cycle ran), `skip` (nothing to do), and `error`
- Lets KEDA be the sole source of truth for scheduling -- the pod runs once and exits, KEDA scales it back to zero, and brings it up again at the next scheduled window

Previously, scheduled workflows relied on a `cycle-sleep.json` file (24h pause) to prevent repeated runs within the same KEDA window. This was fragile across pod restarts -- when the pod came back up, the sleep state was lost and the bot would run again, wasting tokens on duplicate scans.

The `source` field was already parsed from `instance.yaml` and logged but never acted on. This change gives it operational meaning.

## Test plan

- [x] All existing 176 preflight/run tests pass
- [x] 4 new tests verify exit-after-one-iteration for all three outcomes (start, skip, error) when `source=scheduled`, and continued looping when `source=jira`
- [ ] Deploy a `source: scheduled` instance and confirm the pod exits cleanly after one cycle