### PR TITLE
Rhcloud 48014 digest redesign

### DIFF
--- a/docs/onboarding-new-instance.md
+++ b/docs/onboarding-new-instance.md
@@ -507,7 +507,7 @@ After deploying, verify in order:
 | `BOT_SPRINT_PREFIX` | no | Sprint name prefix filter (for sprint assignment only) |
 | `BOT_INCLUDE_BACKLOG` | no | `'true'` to include backlog tickets |
 | `SLACK_WEBHOOK_URL` | no | Slack webhook — Incoming (`/services/`, recommended) or Workflow Builder (`/triggers/`) |
-| `SLACK_NOTIFY_MODE` | no | `immediate` (default) or `daily_digest`. In digest mode, notifications queue instead of sending immediately. Requires `SLACK_DIGEST_HOUR` to be set. |
+| `SLACK_NOTIFY_MODE` | no | `immediate` (default) or `daily_digest`. In digest mode, individual notifications are suppressed and a daily snapshot of open PRs is sent instead. Requires `SLACK_DIGEST_HOUR` to be set. |
 | `SLACK_DIGEST_HOUR` | no | UTC hour (0-23) when daily digest is sent. Opt-in — digest is disabled unless this is set. |
 | `PROXY_IMAGE` | no | Proxy container image (only needed if `PROXY_REPLICAS=1`) |
 | `PROXY_IMAGE_TAG` | no | Proxy image tag (default: `latest`) |

--- a/docs/presets/envs.md
+++ b/docs/presets/envs.md
@@ -175,10 +175,10 @@ Adds the Slack notification skill. The bot sends alerts when PRs are created, ti
 The payload key is auto-detected from the URL: `{"text": ...}` for Incoming Webhooks, `{"msg": ...}` for Workflow Builder.
 
 **Optional env vars**:
-- `SLACK_NOTIFY_MODE` — `immediate` (default) or `daily_digest`. In immediate mode, each event sends a separate Slack message with 48h cooldown. In daily digest mode, events queue and are sent as a single summary message at the configured hour.
+- `SLACK_NOTIFY_MODE` — `immediate` (default) or `daily_digest`. In immediate mode, each event sends a separate Slack message with 48h cooldown. In daily digest mode, individual notifications are suppressed and a daily snapshot of open PRs (from the tasks table) is sent at the configured hour.
 - `SLACK_DIGEST_HOUR` — UTC hour (0-23) when the daily digest is sent. Opt-in: digest is disabled unless this is set. The bot runner triggers it automatically after each cycle — zero LLM tokens spent.
 
-Both `SLACK_NOTIFY_MODE=daily_digest` and `SLACK_DIGEST_HOUR` must be set to enable digest mode. Without `SLACK_DIGEST_HOUR`, notifications fall back to immediate mode.
+Both `SLACK_NOTIFY_MODE=daily_digest` and `SLACK_DIGEST_HOUR` must be set to enable digest mode. Without `SLACK_DIGEST_HOUR`, digest is disabled (notifications still suppressed but no digest is sent).
 
 **Depends on**: nothing
 

--- a/memory-server/bot_memory_server/tools/slack.py
+++ b/memory-server/bot_memory_server/tools/slack.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from datetime import UTC, datetime, timedelta
@@ -11,7 +12,6 @@ from ..events import Event, bus
 logger = logging.getLogger(__name__)
 
 COOLDOWN_HOURS = 48
-PR_EVENT_TYPES = {"pr_created", "review_reminder"}
 
 
 def register_slack_tools(mcp: FastMCP):
@@ -24,15 +24,10 @@ def register_slack_tools(mcp: FastMCP):
         source_type: str = "jira",
         instance_id: str | None = None,
         notify_mode: str = "immediate",
-        pr_url: str | None = None,
-        pr_number: int | None = None,
-        repo: str | None = None,
-        title: str | None = None,
     ) -> dict:
         """Send a Slack notification. Deduplicates by external_key (48h cooldown per ticket, any event type).
 
-        In daily_digest mode, queues the notification instead of sending immediately.
-        Use slack_send_digest to send the digest.
+        In daily_digest mode, suppresses the notification (digest reads from tasks table directly).
 
         external_key: The external identifier (e.g. Jira key 'RHCLOUD-12345').
         source_type: Source system — 'jira', 'github', etc.
@@ -41,49 +36,19 @@ def register_slack_tools(mcp: FastMCP):
         webhook_url: Slack webhook URL. Defaults to SLACK_WEBHOOK_URL env var on the memory server.
         instance_id: Bot instance identifier (optional, used for digest grouping).
         notify_mode: 'immediate' (default) or 'daily_digest'. Passed by the caller from its env.
-        pr_url: PR URL (optional, used for richer digest formatting).
-        pr_number: PR number (optional, used for richer digest formatting).
-        repo: Repository name (optional, used for richer digest formatting).
-        title: PR/issue title (optional, used for richer digest formatting).
 
-        Returns {"sent": true/false, "reason": "..."} or {"queued": true} in digest mode."""
+        Returns {"sent": true/false, "reason": "..."} or {"suppressed": true} in digest mode."""
         pool = get_pool()
 
         if not webhook_url:
             return {"sent": False, "reason": "SLACK_WEBHOOK_URL not configured"}
 
         if notify_mode == "daily_digest":
-            existing = await pool.fetchrow(
-                """
-                SELECT id FROM slack_digest_queue
-                WHERE jira_key = $1 AND event_type = $2 AND sent = FALSE
-                """,
-                external_key,
-                event_type,
-            )
-            if existing:
-                return {
-                    "sent": False,
-                    "queued": False,
-                    "reason": f"Already queued: {event_type} for {external_key}",
-                }
-
-            await pool.execute(
-                """
-                INSERT INTO slack_digest_queue
-                    (instance_id, jira_key, event_type, pr_url, pr_number, repo, title, message)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                """,
-                instance_id,
-                external_key,
-                event_type,
-                pr_url,
-                pr_number,
-                repo,
-                title,
-                message,
-            )
-            return {"sent": False, "queued": True, "reason": "Queued for daily digest"}
+            return {
+                "sent": False,
+                "suppressed": True,
+                "reason": "Suppressed — daily digest mode active",
+            }
 
         cutoff = datetime.now(UTC) - timedelta(hours=COOLDOWN_HOURS)
         recent = await pool.fetchrow(
@@ -147,16 +112,17 @@ def register_slack_tools(mcp: FastMCP):
         webhook_url: str | None = os.environ.get("SLACK_WEBHOOK_URL"),
         digest_key: str | None = None,
     ) -> dict:
-        """Send a daily digest of queued Slack notifications.
+        """Send a daily digest of open PRs from the tasks table.
 
-        Groups events by jira_key, formats a single summary message, and sends
-        to the webhook. Skips silently when the queue is empty.
+        Queries tasks with status pr_open or pr_changes and formats a
+        snapshot summary. This is NOT event-based — it always reflects the
+        current state of open PRs.
 
         Timing and weekend checks are handled by the caller (bot runner).
         This tool handles sent-today deduplication via digest_key in
         slack_notifications table.
 
-        instance_id: Filter queued items by bot instance (optional).
+        instance_id: Filter tasks by bot instance (optional).
         webhook_url: Slack webhook URL. Defaults to SLACK_WEBHOOK_URL env var.
         digest_key: Deterministic key (e.g. digest-instance-2026-07-28) for
             sent-today deduplication. If already in slack_notifications, skips.
@@ -178,23 +144,28 @@ def register_slack_tools(mcp: FastMCP):
         if instance_id:
             rows = await pool.fetch(
                 """
-                SELECT * FROM slack_digest_queue
-                WHERE sent = FALSE AND instance_id = $1
-                ORDER BY queued_at ASC
+                SELECT external_key, status, title, repo, artifacts, metadata, created_at
+                FROM tasks
+                WHERE status = ANY($1::task_status[])
+                AND instance_id = $2
+                ORDER BY created_at ASC
                 """,
+                ["pr_open", "pr_changes"],
                 instance_id,
             )
         else:
             rows = await pool.fetch(
                 """
-                SELECT * FROM slack_digest_queue
-                WHERE sent = FALSE
-                ORDER BY queued_at ASC
+                SELECT external_key, status, title, repo, artifacts, metadata, created_at
+                FROM tasks
+                WHERE status = ANY($1::task_status[])
+                ORDER BY created_at ASC
                 """,
+                ["pr_open", "pr_changes"],
             )
 
         if not rows:
-            return {"sent": False, "count": 0, "reason": "No items to digest"}
+            return {"sent": False, "count": 0, "reason": "No open PRs to report"}
 
         now = datetime.now(UTC)
         digest_message = _format_digest(instance_id, rows, now)
@@ -206,12 +177,6 @@ def register_slack_tools(mcp: FastMCP):
         except Exception as e:
             logger.error("Slack digest webhook failed: %s", e)
             return {"sent": False, "count": len(rows), "reason": f"Webhook error: {e}"}
-
-        row_ids = [r["id"] for r in rows]
-        await pool.execute(
-            "UPDATE slack_digest_queue SET sent = TRUE WHERE id = ANY($1::int[])",
-            row_ids,
-        )
 
         if digest_key:
             await pool.execute(
@@ -237,35 +202,62 @@ def register_slack_tools(mcp: FastMCP):
 
 def _format_digest(instance_id: str | None, rows: list, now: datetime) -> str:
     date_str = now.strftime("%Y-%m-%d")
-    instance_label = f"Instance: `{instance_id}`" if instance_id else "All instances"
-    lines = [f"*Daily Bot Digest* — {instance_label} | {date_str}", ""]
+    instance_label = f"Instance: {instance_id}" if instance_id else "All instances"
+    lines = [f"Daily Bot Digest — {instance_label} | {date_str}", ""]
 
-    pr_items = [r for r in rows if r["event_type"] in PR_EVENT_TYPES]
-    other_items = [r for r in rows if r["event_type"] not in PR_EVENT_TYPES]
-
-    if pr_items:
-        lines.append(f"*PR events ({len(pr_items)}):*")
-        for r in pr_items:
-            pr_label = _format_pr_label(r)
-            title_part = f" — {r['title']}" if r["title"] else ""
-            lines.append(f"• {pr_label}{title_part}")
-            lines.append(f"  {r['jira_key']} | {r['event_type']}")
-        lines.append("")
-
-    if other_items:
-        lines.append(f"*Other events ({len(other_items)}):*")
-        for r in other_items:
-            lines.append(f"• {r['jira_key']}: {r['event_type']} — {r['message']}")
-        lines.append("")
+    lines.append(f"Open PRs ({len(rows)}):")
+    for r in rows:
+        pr_label = _format_pr_label(r)
+        title_part = f" — {r['title']}" if r.get("title") else ""
+        age_days = (now - r["created_at"]).days
+        status_label = _status_label(r["status"])
+        lines.append(f"• {pr_label}{title_part} - {r['external_key']} · {status_label} {age_days}d")
+    lines.append("")
 
     return "\n".join(lines)
 
 
+_STATUS_LABELS = {
+    "pr_open": "open for",
+    "pr_changes": "changes requested ·",
+}
+
+
+def _status_label(status: str) -> str:
+    return _STATUS_LABELS.get(status, status)
+
+
+def _parse_artifacts(raw) -> list:
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return []
+    if isinstance(raw, list):
+        return raw
+    return []
+
+
 def _format_pr_label(row) -> str:
-    if row["pr_url"] and row["pr_number"] and row["repo"]:
-        return f"<{row['pr_url']}|{row['repo']}#{row['pr_number']}>"
-    if row["pr_url"] and row["pr_number"]:
-        return f"<{row['pr_url']}|#{row['pr_number']}>"
-    if row["pr_url"]:
-        return f"<{row['pr_url']}|PR>"
-    return "PR"
+    artifacts = _parse_artifacts(row.get("artifacts"))
+    for art in artifacts:
+        art_type = art.get("type", "")
+        if art_type in ("pull_request", "merge_request") and art.get("url"):
+            name = art.get("name", "PR")
+            return f"{name} ({art['url']})"
+
+    metadata = row.get("metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except (json.JSONDecodeError, TypeError):
+            metadata = {}
+    if isinstance(metadata, dict):
+        prs = metadata.get("prs", [])
+        if prs and isinstance(prs, list) and prs[0].get("url"):
+            pr = prs[0]
+            repo = row.get("repo", "")
+            number = pr.get("number", "?")
+            return f"{repo}#{number} ({pr['url']})"
+
+    return "PR (no link)"

--- a/memory-server/tests/test_slack_digest.py
+++ b/memory-server/tests/test_slack_digest.py
@@ -10,7 +10,11 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from bot_memory_server.tools.slack import _format_digest, _format_pr_label, register_slack_tools
+from bot_memory_server.tools.slack import (
+    _format_digest,
+    _format_pr_label,
+    register_slack_tools,
+)
 
 # ---------------------------------------------------------------------------
 # Fixture: extract tool functions from FastMCP registration
@@ -47,19 +51,21 @@ def _make_pool(fetchrow_return=None, fetch_return=None):
     return pool
 
 
-def _make_row(**kwargs):
+def _make_task_row(**kwargs):
     defaults = {
-        "id": 1,
-        "instance_id": "test-instance",
-        "jira_key": "RHCLOUD-100",
-        "event_type": "pr_created",
-        "pr_url": "https://github.com/org/repo/pull/42",
-        "pr_number": 42,
-        "repo": "org/repo",
+        "external_key": "RHCLOUD-100",
+        "status": "pr_open",
         "title": "Fix navigation dropdown",
-        "message": "New PR created: #42",
-        "queued_at": datetime.now(UTC),
-        "sent": False,
+        "repo": "org/repo",
+        "artifacts": [
+            {
+                "name": "PR #42",
+                "url": "https://github.com/org/repo/pull/42",
+                "type": "pull_request",
+            }
+        ],
+        "metadata": {},
+        "created_at": datetime.now(UTC) - timedelta(days=3),
     }
     defaults.update(kwargs)
     return defaults
@@ -163,15 +169,15 @@ class TestSlackNotifyImmediate:
 
 
 # ---------------------------------------------------------------------------
-# slack_notify — digest mode
+# slack_notify — digest mode (suppressed)
 # ---------------------------------------------------------------------------
 
 
 class TestSlackNotifyDigest:
     @pytest.mark.asyncio
-    async def test_digest_mode_queues_instead_of_sending(self, slack_tools):
+    async def test_digest_mode_suppresses_notification(self, slack_tools):
         slack_notify = slack_tools["slack_notify"]
-        pool = _make_pool(fetchrow_return=None)
+        pool = _make_pool()
 
         with patch("bot_memory_server.tools.slack.get_pool", return_value=pool):
             result = await slack_notify(
@@ -180,90 +186,42 @@ class TestSlackNotifyDigest:
                 message="New PR: #99",
                 webhook_url="https://hooks.slack.com/test",
                 notify_mode="daily_digest",
-                instance_id="framework-1",
-                pr_url="https://github.com/org/repo/pull/99",
-                pr_number=99,
-                repo="org/repo",
-                title="Fix bug",
             )
 
         assert result["sent"] is False
-        assert result["queued"] is True
-        assert "daily digest" in result["reason"]
-
-        pool.execute.assert_called_once()
-        call_args = pool.execute.call_args
-        assert "slack_digest_queue" in call_args[0][0]
-        assert call_args[0][1] == "framework-1"
-        assert call_args[0][2] == "RHCLOUD-200"
-        assert call_args[0][3] == "pr_created"
-
-    @pytest.mark.asyncio
-    async def test_digest_different_event_types_both_queued(self, slack_tools):
-        """Different event types for the same key are both queued."""
-        slack_notify = slack_tools["slack_notify"]
-        pool = _make_pool(fetchrow_return=None)
-
-        with patch("bot_memory_server.tools.slack.get_pool", return_value=pool):
-            r1 = await slack_notify(
-                external_key="RHCLOUD-300",
-                event_type="pr_created",
-                message="First",
-                webhook_url="https://hooks.slack.com/test",
-                notify_mode="daily_digest",
-            )
-            r2 = await slack_notify(
-                external_key="RHCLOUD-300",
-                event_type="review_reminder",
-                message="Second",
-                webhook_url="https://hooks.slack.com/test",
-                notify_mode="daily_digest",
-            )
-
-        assert r1["queued"] is True
-        assert r2["queued"] is True
-        assert pool.execute.call_count == 2
-
-    @pytest.mark.asyncio
-    async def test_digest_duplicate_event_rejected(self, slack_tools):
-        """Same (jira_key, event_type) already in queue is rejected."""
-        slack_notify = slack_tools["slack_notify"]
-        pool = _make_pool(fetchrow_return={"id": 99})
-
-        with patch("bot_memory_server.tools.slack.get_pool", return_value=pool):
-            result = await slack_notify(
-                external_key="RHCLOUD-300",
-                event_type="pr_created",
-                message="Duplicate",
-                webhook_url="https://hooks.slack.com/test",
-                notify_mode="daily_digest",
-            )
-
-        assert result["queued"] is False
-        assert "Already queued" in result["reason"]
+        assert result["suppressed"] is True
         pool.execute.assert_not_called()
+        pool.fetchrow.assert_not_called()
+        pool.fetch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# slack_send_digest
+# slack_send_digest — task-based
 # ---------------------------------------------------------------------------
 
 
 class TestSlackSendDigest:
     @pytest.mark.asyncio
-    async def test_send_digest_success(self, slack_tools):
+    async def test_send_digest_with_open_prs(self, slack_tools):
         slack_send_digest = slack_tools["slack_send_digest"]
         rows = [
-            _make_row(id=1, jira_key="RHCLOUD-100", event_type="pr_created"),
-            _make_row(
-                id=2,
-                jira_key="RHCLOUD-101",
-                event_type="needs_help",
-                pr_url=None,
-                pr_number=None,
-                repo=None,
-                title=None,
-                message="Blocked on missing API endpoint",
+            _make_task_row(
+                external_key="RHCLOUD-100",
+                status="pr_open",
+                title="Fix navigation dropdown",
+            ),
+            _make_task_row(
+                external_key="RHCLOUD-101",
+                status="pr_changes",
+                title="Add drag handle",
+                artifacts=[
+                    {
+                        "name": "PR #15",
+                        "url": "https://github.com/org/repo/pull/15",
+                        "type": "pull_request",
+                    }
+                ],
+                created_at=datetime.now(UTC) - timedelta(days=7),
             ),
         ]
         pool = _make_pool(fetch_return=rows)
@@ -292,9 +250,10 @@ class TestSlackSendDigest:
         assert "Daily Bot Digest" in payload["msg"]
         assert "RHCLOUD-100" in payload["msg"]
         assert "RHCLOUD-101" in payload["msg"]
+        assert "Open PRs (2)" in payload["msg"]
 
     @pytest.mark.asyncio
-    async def test_send_digest_empty_queue_skips(self, slack_tools):
+    async def test_send_digest_no_open_prs(self, slack_tools):
         slack_send_digest = slack_tools["slack_send_digest"]
         pool = _make_pool(fetch_return=[])
 
@@ -305,7 +264,7 @@ class TestSlackSendDigest:
 
         assert result["sent"] is False
         assert result["count"] == 0
-        assert "No items" in result["reason"]
+        assert "No open PRs" in result["reason"]
 
     @pytest.mark.asyncio
     async def test_send_digest_no_webhook(self, slack_tools):
@@ -327,8 +286,8 @@ class TestSlackSendDigest:
             )
 
         fetch_call = pool.fetch.call_args
-        assert "instance_id = $1" in fetch_call[0][0]
-        assert fetch_call[0][1] == "framework-1"
+        assert "instance_id = $2" in fetch_call[0][0]
+        assert fetch_call[0][2] == "framework-1"
 
     @pytest.mark.asyncio
     async def test_send_digest_no_instance_fetches_all(self, slack_tools):
@@ -345,20 +304,7 @@ class TestSlackSendDigest:
         assert "instance_id" not in fetch_call[0][0]
 
     @pytest.mark.asyncio
-    async def test_send_digest_idempotent(self, slack_tools):
-        """Second call after all items sent returns empty."""
-        slack_send_digest = slack_tools["slack_send_digest"]
-        pool = _make_pool(fetch_return=[])
-
-        with patch("bot_memory_server.tools.slack.get_pool", return_value=pool):
-            result = await slack_send_digest(webhook_url="https://hooks.slack.com/test")
-
-        assert result["sent"] is False
-        assert result["count"] == 0
-
-    @pytest.mark.asyncio
-    async def test_send_digest_already_sent_today_skips(self, slack_tools):
-        """Digest with same digest_key already sent is skipped."""
+    async def test_send_digest_already_sent_today(self, slack_tools):
         slack_send_digest = slack_tools["slack_send_digest"]
         pool = _make_pool(fetchrow_return={"id": 1})
 
@@ -372,9 +318,9 @@ class TestSlackSendDigest:
         assert "already sent" in result["reason"]
 
     @pytest.mark.asyncio
-    async def test_send_digest_webhook_error_does_not_mark_sent(self, slack_tools):
+    async def test_send_digest_webhook_error(self, slack_tools):
         slack_send_digest = slack_tools["slack_send_digest"]
-        rows = [_make_row(id=1)]
+        rows = [_make_task_row()]
         pool = _make_pool(fetch_return=rows)
 
         with (
@@ -391,8 +337,35 @@ class TestSlackSendDigest:
 
         assert result["sent"] is False
         assert "Webhook error" in result["reason"]
-        for call in pool.execute.call_args_list:
-            assert "UPDATE" not in call[0][0]
+        pool.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_digest_records_digest_key(self, slack_tools):
+        slack_send_digest = slack_tools["slack_send_digest"]
+        rows = [_make_task_row()]
+        pool = _make_pool(fetchrow_return=None, fetch_return=rows)
+
+        with (
+            patch("bot_memory_server.tools.slack.get_pool", return_value=pool),
+            patch("bot_memory_server.tools.slack.httpx.AsyncClient") as mock_client_class,
+            patch("bot_memory_server.tools.slack.bus", new_callable=AsyncMock),
+        ):
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_client.post.return_value = mock_resp
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await slack_send_digest(
+                webhook_url="https://hooks.slack.com/test",
+                digest_key="digest-framework-1-2026-08-13",
+            )
+
+        assert result["sent"] is True
+        pool.execute.assert_called_once()
+        insert_call = pool.execute.call_args
+        assert "slack_notifications" in insert_call[0][0]
+        assert insert_call[0][1] == "digest-framework-1-2026-08-13"
 
 
 # ---------------------------------------------------------------------------
@@ -401,78 +374,136 @@ class TestSlackSendDigest:
 
 
 class TestFormatDigest:
-    def test_format_digest_with_pr_and_other_events(self):
+    def test_format_with_artifacts(self):
         rows = [
-            _make_row(
-                id=1,
-                jira_key="RHCLOUD-100",
-                event_type="pr_created",
-                pr_url="https://github.com/org/repo/pull/42",
-                pr_number=42,
-                repo="org/repo",
+            _make_task_row(
+                external_key="RHCLOUD-100",
+                status="pr_open",
                 title="Fix nav dropdown",
-            ),
-            _make_row(
-                id=2,
-                jira_key="RHCLOUD-101",
-                event_type="needs_help",
-                pr_url=None,
-                pr_number=None,
-                repo=None,
-                title=None,
-                message="Blocked on missing API",
+                artifacts=[
+                    {
+                        "name": "PR #42",
+                        "url": "https://github.com/org/repo/pull/42",
+                        "type": "pull_request",
+                    }
+                ],
+                created_at=datetime(2026, 8, 10, 9, 0, tzinfo=UTC),
             ),
         ]
-        now = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+        now = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
 
         result = _format_digest("framework-1", rows, now)
 
-        assert "*Daily Bot Digest*" in result
+        assert "Daily Bot Digest" in result
         assert "framework-1" in result
-        assert "2026-07-15" in result
-        assert "*PR events (1):*" in result
-        assert "*Other events (1):*" in result
-        assert "RHCLOUD-100" in result
-        assert "RHCLOUD-101" in result
-        assert "Blocked on missing API" in result
+        assert "2026-08-13" in result
+        assert "Open PRs (1):" in result
+        assert "PR #42 (https://github.com/org/repo/pull/42) — Fix nav dropdown - RHCLOUD-100 · open for 3d" in result
 
-    def test_format_digest_only_pr_events(self):
+    def test_format_with_metadata_prs_fallback(self):
         rows = [
-            _make_row(id=1, event_type="pr_created"),
-            _make_row(id=2, event_type="review_reminder", jira_key="RHCLOUD-101", title="Add tests"),
+            _make_task_row(
+                external_key="RHCLOUD-200",
+                status="pr_changes",
+                title="Add drag handle",
+                repo="org/frontend",
+                artifacts=[],
+                metadata={"prs": [{"url": "https://github.com/org/frontend/pull/15", "number": 15}]},
+                created_at=datetime(2026, 8, 6, 9, 0, tzinfo=UTC),
+            ),
         ]
-        now = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+        now = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
+
+        result = _format_digest("framework-1", rows, now)
+
+        assert "org/frontend#15 (https://github.com/org/frontend/pull/15)" in result
+        assert "7d" in result
+
+    def test_format_no_pr_info(self):
+        rows = [
+            _make_task_row(
+                external_key="RHCLOUD-300",
+                status="pr_open",
+                title="Something",
+                artifacts=[],
+                metadata={},
+                created_at=datetime(2026, 8, 13, 9, 0, tzinfo=UTC),
+            ),
+        ]
+        now = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
 
         result = _format_digest(None, rows, now)
 
-        assert "*PR events (2):*" in result
-        assert "*Other events" not in result
+        assert "PR (no link)" in result
         assert "All instances" in result
 
-    def test_format_digest_only_other_events(self):
+    def test_format_pr_age(self):
         rows = [
-            _make_row(id=1, event_type="needs_help", message="Help needed"),
-            _make_row(id=2, event_type="release_pending", jira_key="RHCLOUD-102", message="PR merged"),
+            _make_task_row(
+                created_at=datetime(2026, 8, 3, 9, 0, tzinfo=UTC),
+            ),
         ]
-        now = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+        now = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
 
         result = _format_digest("bot-1", rows, now)
 
-        assert "*Other events (2):*" in result
-        assert "*PR events" not in result
+        assert "10d" in result
 
-    def test_format_pr_label_full_info(self):
-        row = _make_row(pr_url="https://github.com/org/repo/pull/42", pr_number=42, repo="org/repo")
-        assert _format_pr_label(row) == "<https://github.com/org/repo/pull/42|org/repo#42>"
 
-    def test_format_pr_label_no_repo(self):
-        row = _make_row(pr_url="https://github.com/org/repo/pull/42", pr_number=42, repo=None)
-        assert _format_pr_label(row) == "<https://github.com/org/repo/pull/42|#42>"
+# ---------------------------------------------------------------------------
+# _format_pr_label
+# ---------------------------------------------------------------------------
 
-    def test_format_pr_label_only_url(self):
-        row = _make_row(pr_url="https://github.com/org/repo/pull/42", pr_number=None, repo=None)
-        assert _format_pr_label(row) == "<https://github.com/org/repo/pull/42|PR>"
 
-    def test_format_pr_label_no_info(self):
-        row = _make_row(pr_url=None, pr_number=None, repo=None)
-        assert _format_pr_label(row) == "PR"
+class TestFormatPrLabel:
+    def test_from_artifacts(self):
+        row = _make_task_row(
+            artifacts=[
+                {
+                    "name": "PR #42",
+                    "url": "https://github.com/org/repo/pull/42",
+                    "type": "pull_request",
+                }
+            ],
+        )
+        assert _format_pr_label(row) == "PR #42 (https://github.com/org/repo/pull/42)"
+
+    def test_from_artifacts_merge_request(self):
+        row = _make_task_row(
+            artifacts=[
+                {
+                    "name": "MR #10",
+                    "url": "https://gitlab.com/org/repo/-/merge_requests/10",
+                    "type": "merge_request",
+                }
+            ],
+        )
+        assert _format_pr_label(row) == "MR #10 (https://gitlab.com/org/repo/-/merge_requests/10)"
+
+    def test_from_metadata_prs(self):
+        row = _make_task_row(
+            artifacts=[],
+            repo="org/repo",
+            metadata={"prs": [{"url": "https://github.com/org/repo/pull/42", "number": 42}]},
+        )
+        assert _format_pr_label(row) == "org/repo#42 (https://github.com/org/repo/pull/42)"
+
+    def test_no_info(self):
+        row = _make_task_row(artifacts=[], metadata={})
+        assert _format_pr_label(row) == "PR (no link)"
+
+    def test_artifacts_as_json_string(self):
+        import json
+
+        row = _make_task_row(
+            artifacts=json.dumps(
+                [
+                    {
+                        "name": "PR #42",
+                        "url": "https://github.com/org/repo/pull/42",
+                        "type": "pull_request",
+                    }
+                ]
+            ),
+        )
+        assert _format_pr_label(row) == "PR #42 (https://github.com/org/repo/pull/42)"

--- a/presets/shared/skills/post-pr/scripts/post_pr_operations.py
+++ b/presets/shared/skills/post-pr/scripts/post_pr_operations.py
@@ -518,13 +518,6 @@ class PostPROperations:
             if self.dry_run:
                 logger.info(f"[DRY RUN] Would send Slack notification: {message}")
             else:
-                repo = None
-                try:
-                    info = self._parse_pr_url(pr_url)
-                    repo = f"{info['owner']}/{info['repo']}" if info.get("owner") else info.get("repo")
-                except Exception:
-                    pass
-
                 result = memory_call(
                     "slack_notify",
                     {
@@ -533,16 +526,12 @@ class PostPROperations:
                         "message": message,
                         "webhook_url": self.slack_webhook,
                         "notify_mode": os.environ.get("SLACK_NOTIFY_MODE", "immediate"),
-                        "pr_url": pr_url,
-                        "pr_number": pr_number,
-                        "repo": repo,
-                        "title": summary,
                     },
                 )
                 if result and result.get("sent"):
                     logger.info("Sent Slack notification via MCP")
-                elif result and result.get("queued"):
-                    logger.info("Slack notification queued for digest")
+                elif result and result.get("suppressed"):
+                    logger.info("Slack notification suppressed (daily digest mode)")
                 else:
                     reason = result.get("reason", "unknown") if result else "MCP call failed"
                     logger.warning(f"Slack notification not sent: {reason}")

--- a/presets/shared/skills/post-pr/tests/test_operations.py
+++ b/presets/shared/skills/post-pr/tests/test_operations.py
@@ -356,8 +356,8 @@ class TestSlackNotify:
         assert params["external_key"] == "TICKET-123"
         assert params["event_type"] == "pr_created"
         assert params["webhook_url"] == "https://hooks.slack.com/test"
-        assert params["pr_url"] == "https://github.com/test/repo/pull/1"
-        assert params["pr_number"] == 1
+        assert "pr_url" not in params
+        assert "pr_number" not in params
         assert "Test PR" in params["message"]
 
     def test_slack_notify_no_webhook(self, temp_dir, monkeypatch):
@@ -379,10 +379,14 @@ class TestSlackNotify:
         assert "Slack webhook not configured" in result.message
 
     @patch("scripts.post_pr_operations.memory_call")
-    def test_slack_notify_queued_for_digest(self, mock_memory_call, operations, monkeypatch):
-        """Test Slack notification queued in digest mode."""
+    def test_slack_notify_suppressed_in_digest_mode(self, mock_memory_call, operations, monkeypatch):
+        """Test Slack notification suppressed in digest mode."""
         monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/test")
-        mock_memory_call.return_value = {"sent": False, "queued": True, "reason": "Queued for daily digest"}
+        mock_memory_call.return_value = {
+            "sent": False,
+            "suppressed": True,
+            "reason": "Suppressed — daily digest mode active",
+        }
 
         result = operations.slack_notify(
             pr_url="https://github.com/test/repo/pull/3",


### PR DESCRIPTION
### Description

Redesign daily digest from event-based queue to task-based snapshot. The old design queued notifications into `slack_digest_queue`, marked them as sent, and never showed them again — on idle days the digest was empty even though open PRs existed. The new design queries the `tasks` table directly for `pr_open`/`pr_changes` status, always reflecting the current state.

Key changes:
- `slack_notify` in digest mode: suppresses instead of queuing (no DB operations)
- `slack_send_digest`: queries `tasks` table instead of `slack_digest_queue`
- `_format_digest`: single-line format with PR link, title, JIRA key, status, and age
- Removed dead parameters (`pr_url`, `pr_number`, `repo`, `title`) from `slack_notify` signature and caller
- Updated documentation to reflect the new behavior

`slack_digest_queue` table remains in schema (unused, harmless).

[RHCLOUD-48014](https://issues.redhat.com/browse/RHCLOUD-48014)

---

### Blast radius

- **memory-server** — `slack_notify` and `slack_send_digest` MCP tools changed. Requires image tag bump in app-interface.
- **bot runner** — `bot/slack_digest.py` and `bot/run.py` unchanged, interface (`instance_id`, `webhook_url`, `digest_key`) stays the same.
- **post-pr skill** — `post_pr_operations.py` no longer passes removed parameters. Must deploy bot (submodule bump in `hcc-framework-agent-dev`) before memory server to avoid FastMCP validation errors on the removed params.
- **wrap-up skills** (jira-kanban, jira-sprint) — do not pass the removed parameters, unaffected.
- Tested locally: formatted real task data from stage memory server and sent to Slack webhook — message accepted (HTTP 200), links auto-linked correctly.

---

### Rollback plan

`git revert` is sufficient. The `slack_digest_queue` table is still in the schema, so reverting restores queue-based behavior with no migration needed. Rollback deploy order: revert memory server image first, then bot submodule.

---

### Checklist
- [x] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images pinned to specific tags, not `latest`

### AI disclosure
Assisted by: Claude Code (Opus)

