### PR TITLE
fix(e2e): set BOT_INSTANCE_ID for container-e2e bot container

### DIFF
--- a/tests/container-e2e/test-container.sh
+++ b/tests/container-e2e/test-container.sh
@@ -180,6 +180,7 @@ log "Starting bot container with real entrypoint"
   -e BOT_MEMORY_HEALTH_URL=http://"$MEMORY_CONTAINER":8080/health \
   -e BOT_MEMORY_HEALTH_TIMEOUT=90 \
   -e BOT_LABEL=rehor62-e2e \
+  -e BOT_INSTANCE_ID=rehor62-e2e \
   -e GH_USER_NAME="Dev Bot" \
   -e GH_USER_EMAIL="dev-bot@example.com" \
   -e GL_USER_NAME="Dev Bot" \


### PR DESCRIPTION
## What

`tests/container-e2e/test-container.sh` starts the bot container without `BOT_INSTANCE_ID`. `bot/run.py` has required `--instance-id` (or the `BOT_INSTANCE_ID` env var) since May (`b7fbaaa4`, RHCLOUD-47797), so the entrypoint's final line:

```
exec uv run dev-bot --label "$BOT_LABEL"
```

fails argparse validation (`dev-bot: error: --instance-id is required (or set BOT_INSTANCE_ID env var)`) immediately after printing `Credentials configured. Starting bot with label: ...`, and the container exits right there.

## Why this shows up as a flaky "entrypoint did not reach final startup stage"

`40-entrypoint.sh` does a one-shot `docker logs $BOT_CONTAINER | grep -qE "Credentials configured..."` against a container that's dying at that exact moment. Depending on timing, `docker logs` either returns the line before the container fully exits, or races it and the check fails. That matches what we're seeing in CI: `e2e-minimal` intermittently fails across unrelated PRs (e.g. #428), while other runs on the same branches pass.

Confirmed the crash is unconditional (100% reproducible) by tracing the code path; the check's pass/fail is the flaky part, not the underlying crash.

## Fix

Add `-e BOT_INSTANCE_ID=rehor62-e2e` alongside the existing `BOT_LABEL` when starting the bot container. This matches every other invocation path in the repo — `docker-compose.yml`, the OpenShift deploy template, and the Tekton pipelines all already set `BOT_INSTANCE_ID`; the e2e harness (merged today as part of REHOR-62) was the one place that didn't.

## Checklist

- [x] Root-caused via commit history (`bot/run.py` required this since May, e2e harness merged today) and cross-referenced against 5 recent CI runs (mix of pass/fail on the same branches, consistent with a timing race against a container that's always crashing)
- [x] Fix matches the existing convention used by `docker-compose.yml` / deploy template / Tekton pipelines
- [x] `shellcheck` clean (only pre-existing informational `SC1091` notices, unrelated to this change)
- [ ] CI (`e2e-minimal`) green on this PR — will confirm once the workflow runs

## Note

Once the bot process actually stays alive (instead of crash-exiting), none of the current checks (`50-skills.sh` runs against a separate static `sleep infinity` container, not the real bot process) verify long-term liveness of the bot process itself. Not fixing that here since it's out of scope, but worth a follow-up if we want the harness to catch future startup regressions past the initial handoff line.