### PR TITLE
fix(konflux): bump Tekton task bundle refs to latest trusted digests

### DIFF
--- a/.tekton/platform-frontend-ai-dev-memory-server-pull-request.yaml
+++ b/.tekton/platform-frontend-ai-dev-memory-server-pull-request.yaml
@@ -310,7 +310,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.6.0@sha256:278c47d3bf6d55eaef26453182356a819cb376ba7f55f6e8db01d9e79c98b702
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.9.0@sha256:c2903df1e6f768865229bdc3e81ecc72cd94aba5b88c3f8d59b8241d6d3974f7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/platform-frontend-ai-dev-memory-server-push.yaml
+++ b/.tekton/platform-frontend-ai-dev-memory-server-push.yaml
@@ -183,7 +183,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.6.0@sha256:278c47d3bf6d55eaef26453182356a819cb376ba7f55f6e8db01d9e79c98b702
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.9.0@sha256:c2903df1e6f768865229bdc3e81ecc72cd94aba5b88c3f8d59b8241d6d3974f7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/platform-frontend-ai-dev-proxy-pull-request.yaml
+++ b/.tekton/platform-frontend-ai-dev-proxy-pull-request.yaml
@@ -186,7 +186,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.6.0@sha256:278c47d3bf6d55eaef26453182356a819cb376ba7f55f6e8db01d9e79c98b702
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.9.0@sha256:c2903df1e6f768865229bdc3e81ecc72cd94aba5b88c3f8d59b8241d6d3974f7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/platform-frontend-ai-dev-proxy-push.yaml
+++ b/.tekton/platform-frontend-ai-dev-proxy-push.yaml
@@ -183,7 +183,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.6.0@sha256:278c47d3bf6d55eaef26453182356a819cb376ba7f55f6e8db01d9e79c98b702
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.9.0@sha256:c2903df1e6f768865229bdc3e81ecc72cd94aba5b88c3f8d59b8241d6d3974f7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/platform-frontend-ai-dev-pull-request.yaml
+++ b/.tekton/platform-frontend-ai-dev-pull-request.yaml
@@ -256,7 +256,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.6.0@sha256:278c47d3bf6d55eaef26453182356a819cb376ba7f55f6e8db01d9e79c98b702
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.9.0@sha256:c2903df1e6f768865229bdc3e81ecc72cd94aba5b88c3f8d59b8241d6d3974f7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/platform-frontend-ai-dev-push.yaml
+++ b/.tekton/platform-frontend-ai-dev-push.yaml
@@ -253,7 +253,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.6.0@sha256:278c47d3bf6d55eaef26453182356a819cb376ba7f55f6e8db01d9e79c98b702
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.9.0@sha256:c2903df1e6f768865229bdc3e81ecc72cd94aba5b88c3f8d59b8241d6d3974f7
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

- EC (Enterprise Contract) rejects builds because `prefetch-dependencies` 0.6.0 digest was explicitly revoked (`deny_rule`) from the trusted task list
- Bumps `prefetch-dependencies` from 0.6.0 to 0.9.0 across all 6 pipeline definitions
- All other task refs already match `konflux/references/master`

> **Note:** Per-component EC checks on this PR may still show failures — they evaluate images built *before* this fix. The **PR group EC** check runs against images built with the updated refs and should pass.

## Test plan

- [ ] Konflux PR pipeline builds pass (using `prefetch-dependencies:0.9.0`)
- [ ] PR group EC verify passes
- [ ] Push pipeline succeeds after merge