### PR TITLE
fix(analytics): qualify instance_id in JOIN to avoid ambiguous column

### DIFF
--- a/memory-server/bot_memory_server/api.py
+++ b/memory-server/bot_memory_server/api.py
@@ -848,6 +848,8 @@ async def api_analytics(request: Request) -> JSONResponse:
     )
 
     # Ticket lifecycle — cycles per ticket, impl vs review, cost, time to resolve
+    # Qualify column refs for the JOIN (both cycles and tasks have instance_id/timestamp)
+    c_date_filter = date_filter.replace("instance_id", "c.instance_id").replace("timestamp", "c.timestamp")
     ticket_rows = await pool.fetch(
         f"""
         SELECT
@@ -862,7 +864,7 @@ async def api_analytics(request: Request) -> JSONResponse:
             ROUND(EXTRACT(EPOCH FROM (MAX(c.timestamp) - MIN(c.timestamp)))/3600.0, 1) AS hours_span
         FROM cycles c
         LEFT JOIN tasks t ON t.external_key = c.external_key
-        WHERE {date_filter} AND c.external_key IS NOT NULL AND NOT c.no_work
+        WHERE {c_date_filter} AND c.external_key IS NOT NULL AND NOT c.no_work
         GROUP BY c.external_key, t.title, t.status, t.repo
         ORDER BY total_cycles DESC
         LIMIT 30


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->

[RHCLOUD-XXXXX](https://issues.redhat.com/browse/RHCLOUD-XXXXX)
- Fix ambiguous column reference in analytics JOIN query
---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [ ] No breaking changes to existing consumers (or migration path documented)
- [ ] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
