### PR TITLE
fix(proxy): probe /metrics instead of TCP:3128 (REHOR-130)

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -315,14 +315,18 @@ objects:
               secretKeyRef:
                 name: devbot-secrets
                 key: glitchtip-token
+          # HTTP /metrics avoids Squid logging TCP kubelet probes as
+          # DENIED error:transaction-end-before-headers (TCP:3128).
           livenessProbe:
-            tcpSocket:
-              port: 3128
+            httpGet:
+              path: /metrics
+              port: metrics
             initialDelaySeconds: 5
             periodSeconds: 15
           readinessProbe:
-            tcpSocket:
-              port: 3128
+            httpGet:
+              path: /metrics
+              port: metrics
             initialDelaySeconds: 3
             periodSeconds: 10
           resources:


### PR DESCRIPTION
## Summary
- Switch `devbot-proxy` liveness/readiness probes from TCP `:3128` (Squid) to `httpGet /metrics` on port `metrics`.
- Stops kubelet TCP health checks from filling Squid logs with `DENIED error:transaction-end-before-headers`.

## Test plan
- [ ] Confirm `/metrics` on `:9091` returns 200 in stage (`oc exec deployment/devbot-proxy -- curl -sf http://127.0.0.1:9091/metrics`)
- [ ] After deploy, verify probes use HTTP metrics and pod stays Ready
- [ ] Confirm Squid logs no longer show the ~10s `transaction-end-before-headers` cadence from probes

Fixes https://issues.redhat.com/browse/REHOR-130
