### PR TITLE
chore: remove obsolete hour sleep interval

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
   },
   "polling": {
     "intervalSeconds": 300,
-    "idleIntervalSeconds": 3600,
+    "idleIntervalSeconds": 300,
     "idleReminderCooldownSeconds": 172800
   }
 }


### PR DESCRIPTION
Preflights are preventing idle cycles already