### PR TITLE
feat(preflight): exclude security scans from CI failure detection

### DIFF
--- a/bot/tests/test_gh_pr_status.py
+++ b/bot/tests/test_gh_pr_status.py
@@ -127,6 +127,51 @@ def test_review_at_exact_last_addressed_ignored():
     assert "review:alice" not in issues
 
 
+def test_security_scan_filtered_from_ci_fail():
+    """Security scan checks should not appear in ci_fail issues."""
+    checks = [
+        {"name": "unit-tests", "conclusion": "FAILURE"},
+        {"name": "clair-scan", "conclusion": "FAILURE"},
+    ]
+    state, issues = classify_gh(_make_pr(checks=checks))
+    ci_fail_issues = [i for i in issues if i.startswith("ci_fail:")]
+    assert len(ci_fail_issues) == 1
+    assert "unit-tests" in ci_fail_issues[0]
+    assert "clair-scan" not in ci_fail_issues[0]
+
+
+def test_security_scan_only_no_ci_fail():
+    """When only security scans fail, no ci_fail issue should be raised."""
+    checks = [
+        {"name": "clair-scan", "conclusion": "FAILURE"},
+        {"name": "sast-snyk-check", "conclusion": "FAILURE"},
+    ]
+    state, issues = classify_gh(_make_pr(checks=checks))
+    assert not any(i.startswith("ci_fail:") for i in issues)
+    assert any(i.startswith("security_scan_fail:") for i in issues)
+
+
+def test_security_scan_reported_separately():
+    """Filtered security scans should appear as security_scan_fail issues."""
+    checks = [
+        {"name": "lint", "conclusion": "FAILURE"},
+        {"name": "grype-vulnerability-scan", "conclusion": "FAILURE"},
+    ]
+    state, issues = classify_gh(_make_pr(checks=checks))
+    assert "ci_fail:lint" in issues
+    sec_issues = [i for i in issues if i.startswith("security_scan_fail:")]
+    assert len(sec_issues) == 1
+    assert "grype-vulnerability-scan" in sec_issues[0]
+
+
+def test_no_security_scans_unchanged():
+    """When no security scans are present, behavior is unchanged."""
+    checks = [{"name": "lint", "conclusion": "FAILURE"}]
+    state, issues = classify_gh(_make_pr(checks=checks))
+    assert "ci_fail:lint" in issues
+    assert not any(i.startswith("security_scan_fail:") for i in issues)
+
+
 def test_conflict_and_ci_not_affected_by_last_addressed():
     """Conflicts and CI failures are current-state, not affected by last_addressed."""
     checks = [{"name": "lint", "conclusion": "FAILURE"}]

--- a/bot/tests/test_preflight_shared.py
+++ b/bot/tests/test_preflight_shared.py
@@ -13,6 +13,7 @@ from common import (
     build_repo_lookup,
     fmt_comments,
     is_bot_author,
+    is_security_scan,
     upstream_repo,
 )
 from gh_pr_status import classify_gh, gh_pr_comments, has_new_feedback
@@ -96,6 +97,44 @@ def test_is_bot_author_humans():
     assert is_bot_author("") is False
     assert is_bot_author("?") is False
     assert is_bot_author(None) is False
+
+
+# --- is_security_scan ---
+
+
+def test_is_security_scan_known_scans():
+    assert is_security_scan("clair-scan") is True
+    assert is_security_scan("sast-snyk-check") is True
+    assert is_security_scan("sast-coverity-check") is True
+    assert is_security_scan("clamav-scan") is True
+    assert is_security_scan("grype") is True
+    assert is_security_scan("trivy-scan") is True
+    assert is_security_scan("rpms-signature-scan") is True
+    assert is_security_scan("deprecated-image-check") is True
+    assert is_security_scan("container-scan") is True
+    assert is_security_scan("image-scan-results") is True
+
+
+def test_is_security_scan_case_insensitive():
+    assert is_security_scan("Clair-Scan") is True
+    assert is_security_scan("SAST-SNYK-CHECK") is True
+    assert is_security_scan("Grype") is True
+
+
+def test_is_security_scan_non_security():
+    assert is_security_scan("unit-tests") is False
+    assert is_security_scan("lint") is False
+    assert is_security_scan("e2e-tests") is False
+    assert is_security_scan("build") is False
+    assert is_security_scan("integration-test") is False
+    assert is_security_scan("") is False
+    assert is_security_scan("?") is False
+
+
+def test_is_security_scan_substring_match():
+    assert is_security_scan("my-repo-grype-scan") is True
+    assert is_security_scan("project-sast-snyk-check") is True
+    assert is_security_scan("custom-security-scan-job") is True
 
 
 # --- fmt_comments ---
@@ -264,7 +303,7 @@ def _classify_bucket(enriched_list):
         elif "closed" in issues:
             closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
-            ci_only = all(i.startswith(("ci_fail", "konflux_urls")) for i in issues)
+            ci_only = all(i.startswith(("ci_fail", "konflux_urls", "security_scan_fail")) for i in issues)
             if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):
                 clean.append(e)
             else:
@@ -323,6 +362,25 @@ def test_ci_only_with_old_feedback_is_clean():
     e = _make_ci_enriched(
         last_addressed="2026-07-14T18:00",
         pr_comments=[{"a": "reviewer", "t": "2026-07-14T10:00", "b": "can you retry CI?"}],
+    )
+    result = _classify_bucket([e])
+    assert len(result["clean"]) == 1
+    assert len(result["ci_fail"]) == 0
+
+
+def test_security_scan_only_failure_is_not_ci_fail():
+    """PR with only security scan failures should not be in ci_fail bucket."""
+    e = _make_ci_enriched(extra_issues=["security_scan_fail:clair-scan"])
+    e["issues"] = ["security_scan_fail:clair-scan"]
+    result = _classify_bucket([e])
+    assert len(result["ci_fail"]) == 0
+
+
+def test_ci_plus_security_scan_addressed_is_clean():
+    """CI + security scan failures with last_addressed and no feedback -> clean."""
+    e = _make_ci_enriched(
+        last_addressed="2026-07-14T17:49",
+        extra_issues=["security_scan_fail:clair-scan"],
     )
     result = _classify_bucket([e])
     assert len(result["clean"]) == 1

--- a/presets/shared/preflight/common.py
+++ b/presets/shared/preflight/common.py
@@ -129,6 +129,33 @@ def is_bot_author(author):
     return "[bot]" in a or a.endswith("-bot") or a in ("github-actions", "dependabot", "renovate")
 
 
+SECURITY_SCAN_PATTERNS = (
+    "clair-scan",
+    "sast-",
+    "clamav-scan",
+    "coverity",
+    "rpms-signature-scan",
+    "deprecated-image-check",
+    "ecosystem-cert-preflight",
+    "grype",
+    "trivy",
+    "snyk",
+    "vulnerability",
+    "security-scan",
+    "cve-scan",
+    "container-scan",
+    "image-scan",
+)
+
+
+def is_security_scan(check_name):
+    """Check if a CI check name matches a known security scan pattern."""
+    if not check_name:
+        return False
+    name_lower = check_name.lower()
+    return any(pattern in name_lower for pattern in SECURITY_SCAN_PATTERNS)
+
+
 def fmt_comments(comments, label, since=None, max_comments=30):
     """Format a list of comments, optionally filtering by timestamp."""
     if not comments:

--- a/presets/shared/preflight/gh_pr_status.py
+++ b/presets/shared/preflight/gh_pr_status.py
@@ -16,6 +16,7 @@ from common import (
     get_task_prs,
     get_tasks,
     is_bot_author,
+    is_security_scan,
     output_result,
     save_state,
     upstream_repo,
@@ -84,12 +85,17 @@ def classify_gh(pr, last_addressed=""):
         issues.append("conflict")
     checks = pr.get("statusCheckRollup") or []
     failed_checks = [c for c in checks if c.get("conclusion") == "FAILURE"]
-    failed = [c.get("name", "?") for c in failed_checks]
+    ci_failed = [c for c in failed_checks if not is_security_scan(c.get("name", "?"))]
+    sec_failed = [c for c in failed_checks if is_security_scan(c.get("name", "?"))]
+    failed = [c.get("name", "?") for c in ci_failed]
     if failed:
         issues.append(f"ci_fail:{','.join(failed)}")
-        konflux_urls = [c.get("detailsUrl", "") for c in failed_checks if "pipelinerun" in c.get("detailsUrl", "")]
+        konflux_urls = [c.get("detailsUrl", "") for c in ci_failed if "pipelinerun" in c.get("detailsUrl", "")]
         if konflux_urls:
             issues.append(f"konflux_urls:{';'.join(konflux_urls)}")
+    sec_names = [c.get("name", "?") for c in sec_failed]
+    if sec_names:
+        issues.append(f"security_scan_fail:{','.join(sec_names)}")
     if pr.get("reviewDecision") == "CHANGES_REQUESTED":
         issues.append("changes_requested")
     last_prefix = last_addressed[:16] if last_addressed else ""
@@ -186,6 +192,8 @@ def fmt_task(enriched):
             if issue.startswith("konflux_urls:"):
                 for url in issue.split(":", 1)[1].split(";"):
                     lines.append(f"    konflux_details: {url}")
+            elif issue.startswith("security_scan_fail:"):
+                lines.append(f"    security_scans_failed (excluded): {issue.split(':', 1)[1]}")
     last_addr = enriched["task"].get("last_addressed")
     if enriched["pr_comments"]:
         lines.append(fmt_comments(enriched["pr_comments"], "pr_comments", since=last_addr))
@@ -225,7 +233,7 @@ def main(suppress_terminal_if_addressed=False):
             else:
                 closed.append(e)
         elif any(i.startswith("ci_fail") for i in issues):
-            ci_only = all(i.startswith(("ci_fail", "konflux_urls")) for i in issues)
+            ci_only = all(i.startswith(("ci_fail", "konflux_urls", "security_scan_fail")) for i in issues)
             if ci_only and e["task"].get("last_addressed") and not has_new_feedback(e):
                 clean.append(e)
             else:


### PR DESCRIPTION
Security scan checks (Grype, Clair, Trivy, SAST, etc.) can fail for reasons outside the team's control. Filter them from ci_fail issues so the bot focuses on actionable test/build/lint failures. Filtered scans are still reported as informational security_scan_fail issues.

### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->

[RHCLOUD-XXXXX](https://issues.redhat.com/browse/RHCLOUD-XXXXX)

---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [ ] No breaking changes to existing consumers (or migration path documented)
- [ ] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
