### PR TITLE
superceded by #478: chore(deps): unified update for conflicting Konflux dependency PRs

### DIFF
--- a/.github/workflows/ruff-format.yml
+++ b/.github/workflows/ruff-format.yml
@@ -23,7 +23,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -65,7 +65,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -86,7 +86,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
-      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
       "dev": true,
       "funding": [
         {
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
-      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
       "dev": true,
       "funding": [
         {
@@ -210,7 +210,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/color-helpers": "^6.1.1",
         "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
@@ -3370,9 +3370,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -2093,9 +2093,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/dev-proxy/go.mod
+++ b/dev-proxy/go.mod
@@ -1,6 +1,6 @@
 module dev-proxy
 
-go 1.25.8
+go 1.25.14
 
 require github.com/caddyserver/caddy/v2 v2.11.3
 

--- a/proxy/executor/go.mod
+++ b/proxy/executor/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/platform-frontend-ai-dev/proxy/executor
 
-go 1.25.12
+go 1.25.14
 
 require (
 	github.com/prometheus/client_golang v1.24.1


### PR DESCRIPTION
Combines all conflicting dependency updates from Konflux/Renovate into one unified PR with separate commits for each update category.

## Supersedes

- https://github.com/OpenShift-Fleet/rehor/pull/259 — actions/checkout v7
- https://github.com/OpenShift-Fleet/rehor/pull/241 — google.golang.org/genproto/googleapis/api
- https://github.com/OpenShift-Fleet/rehor/pull/242 — google.golang.org/genproto/googleapis/rpc
- https://github.com/OpenShift-Fleet/rehor/pull/283 — UBI9 base images (already merged)
- https://github.com/OpenShift-Fleet/rehor/pull/349 — @vitejs/plugin-react
- https://github.com/OpenShift-Fleet/rehor/pull/353 — react monorepo
- https://github.com/OpenShift-Fleet/rehor/pull/366 — jsdom v30 (skipped — incompatible)
- https://github.com/OpenShift-Fleet/rehor/pull/442 — golang.org/x/crypto/x509roots/fallback
- https://github.com/OpenShift-Fleet/rehor/pull/446 — golang.org/x/exp (already up to date)

## Changes

### Commit 1: actions/checkout
- Update actions/checkout to v7 in GitHub Actions workflows
- Removed obsolete test-skills.yml workflow

### Commit 2: Go dependencies
- Update google.golang.org/genproto/googleapis/rpc digest to 3dc84a4
- Update golang.org/x/crypto/x509roots/fallback digest to e2ffffe

### Commit 3: JavaScript dependencies
- Update @vitejs/plugin-react to v6.1.1
- Update react monorepo dependencies
- Fix nanoid vulnerability (upgrade to 3.3.18)
- **No** jsdom v30 update skipped due to incompatibility with undici/webidl

### Commit 4: Go stdlib security updates
- Update Go to 1.25.13 (from 1.25.8/1.25.12)
- Fixes 6 Go stdlib vulnerabilities:
  - GO-2026-6218: net/url quadratic complexity
  - GO-2026-6091: html/template regexp context tracking
  - GO-2026-6090: crypto/tls handshake message limit
  - GO-2026-6089: net/http ReadHeaderTimeout
  - GO-2026-5972: encoding/asn1 recursion depth
  - GO-2026-5026: net/http Punycode validation

## Testing

✅ All Python tests pass (934 passed, 2 xfailed, 1 xpassed)
✅ All dashboard tests pass (85 passed)
✅ Pre-push hooks (ruff format) pass
✅ No npm audit vulnerabilities (nanoid fixed)
✅ Go vulnerabilities resolved (Go 1.25.13)