### PR TITLE
REHOR-51: added stripping of sensitive headers

### DIFF
--- a/proxy/executor/cmd/client/main.go
+++ b/proxy/executor/cmd/client/main.go
@@ -117,4 +117,3 @@ func needsStdin(tool string, args []string) bool {
 	}
 	return false
 }
-

--- a/proxy/executor/cmd/server/main.go
+++ b/proxy/executor/cmd/server/main.go
@@ -34,7 +34,7 @@ var (
 
 	jiraListen   = flag.String("jira-listen", ":8445", "jira auth proxy listen address")
 	jiraURL      = flag.String("jira-url", "", "upstream Jira URL")
-	jiraUsername  = flag.String("jira-username", "", "Jira username")
+	jiraUsername = flag.String("jira-username", "", "Jira username")
 	jiraToken    = flag.String("jira-token", "", "Jira API token")
 
 	screenshotListen = flag.String("screenshot-listen", ":8446", "screenshot upload proxy listen address")

--- a/proxy/executor/common.go
+++ b/proxy/executor/common.go
@@ -1,6 +1,9 @@
 package executor
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 // statusRecorder wraps http.ResponseWriter to capture the status code.
 // Used by proxy handlers for logging the HTTP status code after ServeHTTP completes.
@@ -16,4 +19,17 @@ func (r *statusRecorder) WriteHeader(code int) {
 
 func (r *statusRecorder) Unwrap() http.ResponseWriter {
 	return r.ResponseWriter
+}
+
+func stripSensitiveResponseHeaders(resp *http.Response) error {
+	resp.Header.Del("Authorization")
+	resp.Header.Del("Set-Cookie")
+	resp.Header.Del("WWW-Authenticate")
+	for k := range resp.Header {
+		ck := http.CanonicalHeaderKey(k)
+		if strings.HasPrefix(ck, "X-") && strings.Contains(ck, "Token") {
+			resp.Header.Del(k)
+		}
+	}
+	return nil
 }

--- a/proxy/executor/common_test.go
+++ b/proxy/executor/common_test.go
@@ -1,0 +1,26 @@
+package executor
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestStripSensitiveResponseHeaders(t *testing.T) {
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("Authorization", "Bearer leaked-token")
+	resp.Header.Set("Set-Cookie", "session=secret")
+	resp.Header.Set("WWW-Authenticate", `Basic realm="git"`)
+	resp.Header.Set("X-Access-Token", "abc")
+	resp.Header.Set("Content-Type", "application/json")
+	if err := stripSensitiveResponseHeaders(resp); err != nil {
+		t.Fatalf("stripSensitiveResponseHeaders: %v", err)
+	}
+	for _, h := range []string{"Authorization", "Set-Cookie", "WWW-Authenticate", "X-Access-Token"} {
+		if got := resp.Header.Get(h); got != "" {
+			t.Errorf("%s = %q, want empty", h, got)
+		}
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}

--- a/proxy/executor/gitauth.go
+++ b/proxy/executor/gitauth.go
@@ -64,9 +64,9 @@ func NewGitAuthProxy() http.Handler {
 type contextKey string
 
 const (
-	hostConfigKey contextKey = "hostConfig"
+	hostConfigKey    contextKey = "hostConfig"
 	pathRemainderKey contextKey = "pathRemainder"
-	tokenKey contextKey = "token"
+	tokenKey         contextKey = "token"
 )
 
 func newGitAuthProxyWithRegistry(hostRegistry map[string]*GitHost) http.Handler {
@@ -108,7 +108,8 @@ func newGitAuthProxyWithRegistry(hostRegistry map[string]*GitHost) http.Handler 
 				r.Out.Header.Set("Authorization", basicAuth)
 			}
 		},
-		FlushInterval: DisableFlush,
+		FlushInterval:  DisableFlush,
+		ModifyResponse: stripSensitiveResponseHeaders,
 	}
 
 	// Helper to log requests with consistent format

--- a/proxy/executor/glitchtip.go
+++ b/proxy/executor/glitchtip.go
@@ -25,7 +25,8 @@ func NewGlitchTipProxy(glitchtipURL, token string) http.Handler {
 			r.Out.Host = upstream.Host
 			r.Out.Header.Set("Authorization", bearerAuth)
 		},
-		FlushInterval: -1,
+		FlushInterval:  -1,
+		ModifyResponse: stripSensitiveResponseHeaders,
 	}
 
 	mux := http.NewServeMux()

--- a/proxy/executor/glitchtip_test.go
+++ b/proxy/executor/glitchtip_test.go
@@ -88,3 +88,30 @@ func TestGlitchTipValidateConfig(t *testing.T) {
 		t.Error("empty token should fail")
 	}
 }
+
+func TestGlitchTipStripsSensitiveResponseHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Authorization", "Bearer leaked-token")
+		w.Header().Set("Set-Cookie", "session=secret")
+		w.Header().Set("WWW-Authenticate", `Basic realm="git"`)
+		w.Header().Set("X-Access-Token", "abc")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler := NewGlitchTipProxy(upstream.URL, "token")
+
+	req := httptest.NewRequest("GET", "/api/0/organizations/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	for _, h := range []string{"Authorization", "Set-Cookie", "WWW-Authenticate", "X-Access-Token"} {
+		if got := w.Header().Get(h); got != "" {
+			t.Errorf("client got %s = %q, want empty", h, got)
+		}
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}

--- a/proxy/executor/jira.go
+++ b/proxy/executor/jira.go
@@ -26,7 +26,8 @@ func NewJiraProxy(jiraURL, username, token string) http.Handler {
 			r.Out.Host = upstream.Host
 			r.Out.Header.Set("Authorization", basicAuth)
 		},
-		FlushInterval: -1,
+		FlushInterval:  -1,
+		ModifyResponse: stripSensitiveResponseHeaders,
 	}
 
 	mux := http.NewServeMux()

--- a/proxy/executor/jira_test.go
+++ b/proxy/executor/jira_test.go
@@ -92,3 +92,30 @@ func TestJiraValidateConfig(t *testing.T) {
 		t.Error("empty token should fail")
 	}
 }
+
+func TestJiraStripsSensitiveResponseHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Authorization", "Bearer leaked-token")
+		w.Header().Set("Set-Cookie", "session=secret")
+		w.Header().Set("WWW-Authenticate", `Basic realm="git"`)
+		w.Header().Set("X-Access-Token", "abc")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler := NewJiraProxy(upstream.URL, "bot@redhat.com", "secret-token")
+
+	req := httptest.NewRequest("GET", "/rest/api/2/issue/PROJ-123", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	for _, h := range []string{"Authorization", "Set-Cookie", "WWW-Authenticate", "X-Access-Token"} {
+		if got := w.Header().Get(h); got != "" {
+			t.Errorf("client got %s = %q, want empty", h, got)
+		}
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}

--- a/proxy/executor/vertex.go
+++ b/proxy/executor/vertex.go
@@ -51,7 +51,8 @@ func NewVertexProxy(projectID, region string, ts oauth2.TokenSource, policy *Ver
 			}
 			r.Out.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 		},
-		FlushInterval: -1,
+		FlushInterval:  -1,
+		ModifyResponse: stripSensitiveResponseHeaders,
 	}
 
 	mux := http.NewServeMux()

--- a/proxy/executor/vertex_test.go
+++ b/proxy/executor/vertex_test.go
@@ -17,10 +17,10 @@ func (s *staticTokenSource) Token() (*oauth2.Token, error) {
 
 func TestRewritePath(t *testing.T) {
 	tests := []struct {
-		path      string
-		project   string
-		region    string
-		want      string
+		path    string
+		project string
+		region  string
+		want    string
 	}{
 		{
 			"/v1/projects/dummy-id/locations/global/publishers/anthropic/models/claude-sonnet-4-20250514:rawPredict",


### PR DESCRIPTION
### Description
Strips security sensitive headers from gitauth, glitchtip, jira and vertex.

[RHCLOUD-51](https://redhat.atlassian.net/jira/software/c/projects/REHOR/boards/12796?selectedIssue=REHOR-51)

---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [ ] No breaking changes to existing consumers (or migration path documented)
- [ ] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
