### PR TITLE
fix(deploy): raise devbot-proxy memory limit to 512Mi

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -346,7 +346,7 @@ objects:
               memory: 128Mi
             limits:
               cpu: 300m
-              memory: 256Mi
+              memory: 512Mi
 
 # --- Proxy Service ---
 - apiVersion: v1


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->

Raise the devbot-proxy memory limit from 256Mi to 512Mi in `deploy/template.yaml`

The proxy in `platform-frontend-ai-dev-stage` (cluster: `hcmais01ue1`) was OOMKilled (exit 137) while buffering large Vertex `claude-opus-4-6` streaming responses (250k–278k bytes, multiple concurrent sessions). At idle it already sat at ~183Mi — 71% of the 256Mi limit.

[RHCLOUD-REHOR-43](https://redhat.atlassian.net/browse/REHOR-43)

---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [ ] No breaking changes to existing consumers (or migration path documented)
- [ ] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
