### PR TITLE
fix(deps): remediate image CVEs

### DIFF
--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -94,7 +94,7 @@ jobs:
             - browser
             - container-scan
           EOF
-          docker build --build-arg GOVERSIONS="1.24.13 1.25.14" -t bot:verify -f "$BUILD_ROOT/dev-bot/Dockerfile.runner" "$BUILD_ROOT"
+          docker build --build-arg GOVERSIONS="1.24.13 1.25.13" -t bot:verify -f "$BUILD_ROOT/dev-bot/Dockerfile.runner" "$BUILD_ROOT"
 
       - name: Verify required tooling is present
         # The bot image's real entrypoint (entrypoint.sh) unconditionally waits

--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -94,7 +94,7 @@ jobs:
             - browser
             - container-scan
           EOF
-          docker build --build-arg GOVERSIONS="1.24.2 1.25.7" -t bot:verify -f "$BUILD_ROOT/dev-bot/Dockerfile.runner" "$BUILD_ROOT"
+          docker build --build-arg GOVERSIONS="1.24.13 1.25.14" -t bot:verify -f "$BUILD_ROOT/dev-bot/Dockerfile.runner" "$BUILD_ROOT"
 
       - name: Verify required tooling is present
         # The bot image's real entrypoint (entrypoint.sh) unconditionally waits

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ RUN ln -sf /usr/bin/python3.12 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.12 /usr/bin/python
 
 # Go — multiple versions via GOVERSIONS build arg
-# Default Go is the first version listed. Bot switches with: eval "$(use-go 1.25.7)"
-ARG GOVERSIONS="1.24.2 1.25.7"
+# Default Go is the first version listed. Bot switches with: eval "$(use-go 1.25.14)"
+ARG GOVERSIONS="1.24.13 1.25.14"
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
     && for v in $GOVERSIONS; do \
          echo "Installing Go $v..." \
@@ -74,13 +74,13 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
     && ln -s /usr/local/go${DEFAULT} /usr/local/go
 ENV PATH="/usr/local/go/bin:$PATH"
 
-# use-go helper: eval "$(use-go 1.25.7)"
+# use-go helper: eval "$(use-go 1.25.14)"
 RUN printf '#!/bin/bash\nV=${1:?Usage: use-go <version>}\nif [ ! -d "/usr/local/go${V}" ]; then echo "Go $V not installed. Available:" >&2; ls -d /usr/local/go[0-9]* | sed "s|/usr/local/go||" >&2; exit 1; fi\necho "export PATH=/usr/local/go${V}/bin:\${PATH#/usr/local/go*/bin:}"\n' > /usr/local/bin/use-go \
     && chmod +x /usr/local/bin/use-go
 
 # golangci-lint
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-linux-${ARCH}.tar.gz" \
+    && curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v2.13.2/golangci-lint-2.13.2-linux-${ARCH}.tar.gz" \
     | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/golangci-lint'
 
 # Executor thin client — drop-in gh/glab replacement (forwards to proxy sidecar)
@@ -112,7 +112,7 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
 
 # grype (container image vulnerability scanner)
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.87.0_linux_${ARCH}.tar.gz" \
+    && curl -fsSL "https://github.com/anchore/grype/releases/download/v0.118.0/grype_0.118.0_linux_${ARCH}.tar.gz" \
     | tar -xz -C /usr/local/bin grype
 
 # Dev proxy (custom Caddy for local UI verification against stage)

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ RUN ln -sf /usr/bin/python3.12 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.12 /usr/bin/python
 
 # Go — multiple versions via GOVERSIONS build arg
-# Default Go is the first version listed. Bot switches with: eval "$(use-go 1.25.14)"
-ARG GOVERSIONS="1.24.13 1.25.14"
+# Default Go is the first version listed. Bot switches with: eval "$(use-go 1.25.13)"
+ARG GOVERSIONS="1.24.13 1.25.13"
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
     && for v in $GOVERSIONS; do \
          echo "Installing Go $v..." \
@@ -74,7 +74,7 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
     && ln -s /usr/local/go${DEFAULT} /usr/local/go
 ENV PATH="/usr/local/go/bin:$PATH"
 
-# use-go helper: eval "$(use-go 1.25.14)"
+# use-go helper: eval "$(use-go 1.25.13)"
 RUN printf '#!/bin/bash\nV=${1:?Usage: use-go <version>}\nif [ ! -d "/usr/local/go${V}" ]; then echo "Go $V not installed. Available:" >&2; ls -d /usr/local/go[0-9]* | sed "s|/usr/local/go||" >&2; exit 1; fi\necho "export PATH=/usr/local/go${V}/bin:\${PATH#/usr/local/go*/bin:}"\n' > /usr/local/bin/use-go \
     && chmod +x /usr/local/bin/use-go
 

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -89,6 +89,8 @@ COPY instance/ /home/botuser/app/instance/
 
 # Env presets — selective install based on instance.yaml envs list
 COPY dev-bot/presets/ presets/
+ARG GOVERSIONS="1.24.13 1.25.14"
+ENV GOVERSIONS="${GOVERSIONS}"
 RUN bash presets/install-envs.sh
 
 ENV HOME=/home/botuser

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -89,7 +89,7 @@ COPY instance/ /home/botuser/app/instance/
 
 # Env presets — selective install based on instance.yaml envs list
 COPY dev-bot/presets/ presets/
-ARG GOVERSIONS="1.24.13 1.25.14"
+ARG GOVERSIONS="1.24.13 1.25.13"
 ENV GOVERSIONS="${GOVERSIONS}"
 RUN bash presets/install-envs.sh
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ memory-verify: ## Run memory-server CI-equivalent checks locally
 
 container-verify: ## Run container build + smoke checks locally (CI-equivalent, see .github/workflows/container-verify.yml). Uses --network host; on macOS this needs Docker Desktop's host-networking feature enabled, or run under a Linux VM/CI.
 	@echo "=== bot: build ==="
-	$(CONTAINER_RT) build --build-arg GOVERSIONS="1.24.2 1.25.7" -t bot:verify -f Dockerfile .
+	$(CONTAINER_RT) build --build-arg GOVERSIONS="1.24.13 1.25.14" -t bot:verify -f Dockerfile .
 	@echo "=== bot: tooling presence check ==="
 	@for tool in python3 uv git tini bwrap buildah node go gcc make gh glab gpg; do \
 		$(CONTAINER_RT) run --rm --entrypoint bash bot:verify -c "command -v $$tool" >/dev/null \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ memory-verify: ## Run memory-server CI-equivalent checks locally
 
 container-verify: ## Run container build + smoke checks locally (CI-equivalent, see .github/workflows/container-verify.yml). Uses --network host; on macOS this needs Docker Desktop's host-networking feature enabled, or run under a Linux VM/CI.
 	@echo "=== bot: build ==="
-	$(CONTAINER_RT) build --build-arg GOVERSIONS="1.24.13 1.25.14" -t bot:verify -f Dockerfile .
+	$(CONTAINER_RT) build --build-arg GOVERSIONS="1.24.13 1.25.13" -t bot:verify -f Dockerfile .
 	@echo "=== bot: tooling presence check ==="
 	@for tool in python3 uv git tini bwrap buildah node go gcc make gh glab gpg; do \
 		$(CONTAINER_RT) run --rm --entrypoint bash bot:verify -c "command -v $$tool" >/dev/null \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        GOVERSIONS: "1.24.2 1.25.7"
+        GOVERSIONS: "1.24.13 1.25.14"
     security_opt:
       - no-new-privileges
     shm_size: 512m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        GOVERSIONS: "1.24.13 1.25.14"
+        GOVERSIONS: "1.24.13 1.25.13"
     security_opt:
       - no-new-privileges
     shm_size: 512m

--- a/docs/presets-design.md
+++ b/docs/presets-design.md
@@ -218,7 +218,7 @@ set -e
 
 # Grype (vulnerability scanner)
 ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.87.0_linux_${ARCH}.tar.gz" \
+curl -fsSL "https://github.com/anchore/grype/releases/download/v0.118.0/grype_0.118.0_linux_${ARCH}.tar.gz" \
     | tar -xz -C /usr/local/bin grype
 
 # Buildah (rootless container builder)

--- a/docs/presets/envs.md
+++ b/docs/presets/envs.md
@@ -49,12 +49,12 @@ nvm use 20        # switch to it
 
 **Path**: `presets/envs/go/`
 
-Installs [goenv](https://github.com/go-nv/goenv) (Go version manager) with Go 1.24.2 and 1.25.7, plus golangci-lint.
+Installs [goenv](https://github.com/go-nv/goenv) (Go version manager) with Go 1.24.13 and 1.25.14, plus golangci-lint.
 
 **What gets installed**:
 - goenv at `/usr/local/goenv`
-- Go 1.24.2 (default) and 1.25.7
-- golangci-lint v2.1.6
+- Go 1.24.13 (default) and 1.25.14
+- golangci-lint v2.13.2
 - `go`, `gofmt`, `golangci-lint` symlinked to `/usr/local/bin/`
 - Shell init via `/etc/profile.d/goenv.sh`
 

--- a/docs/presets/envs.md
+++ b/docs/presets/envs.md
@@ -49,11 +49,11 @@ nvm use 20        # switch to it
 
 **Path**: `presets/envs/go/`
 
-Installs [goenv](https://github.com/go-nv/goenv) (Go version manager) with Go 1.24.13 and 1.25.14, plus golangci-lint.
+Installs [goenv](https://github.com/go-nv/goenv) (Go version manager) with Go 1.24.13 and 1.25.13, plus golangci-lint.
 
 **What gets installed**:
 - goenv at `/usr/local/goenv`
-- Go 1.24.13 (default) and 1.25.14
+- Go 1.24.13 (default) and 1.25.13
 - golangci-lint v2.13.2
 - `go`, `gofmt`, `golangci-lint` symlinked to `/usr/local/bin/`
 - Shell init via `/etc/profile.d/goenv.sh`

--- a/presets/envs/container-scan/install.sh
+++ b/presets/envs/container-scan/install.sh
@@ -4,7 +4,7 @@ set -e
 
 # Grype (vulnerability scanner)
 ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-curl -fsSL "https://github.com/anchore/grype/releases/download/v0.87.0/grype_0.87.0_linux_${ARCH}.tar.gz" \
+curl -fsSL "https://github.com/anchore/grype/releases/download/v0.118.0/grype_0.118.0_linux_${ARCH}.tar.gz" \
     | tar -xz -C /usr/local/bin grype
 
 # Buildah (rootless container builder)

--- a/presets/envs/go/install.sh
+++ b/presets/envs/go/install.sh
@@ -15,7 +15,7 @@ export PATH="$GOENV_ROOT/bin:$PATH"
 eval "$(goenv init -)"
 
 # Pre-install default Go versions
-GOVERSIONS="${GOVERSIONS:-1.24.13 1.25.14}"
+GOVERSIONS="${GOVERSIONS:-1.24.13 1.25.13}"
 DEFAULT=$(echo $GOVERSIONS | awk '{print $1}')
 for v in $GOVERSIONS; do
     if goenv versions --bare 2>/dev/null | grep -q "^${v}$"; then

--- a/presets/envs/go/install.sh
+++ b/presets/envs/go/install.sh
@@ -15,7 +15,7 @@ export PATH="$GOENV_ROOT/bin:$PATH"
 eval "$(goenv init -)"
 
 # Pre-install default Go versions
-GOVERSIONS="${GOVERSIONS:-1.24.2 1.25.7}"
+GOVERSIONS="${GOVERSIONS:-1.24.13 1.25.14}"
 DEFAULT=$(echo $GOVERSIONS | awk '{print $1}')
 for v in $GOVERSIONS; do
     if goenv versions --bare 2>/dev/null | grep -q "^${v}$"; then
@@ -46,6 +46,6 @@ fi
 
 # golangci-lint
 if ! command -v golangci-lint &>/dev/null; then
-    curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-linux-${ARCH}.tar.gz" \
+    curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v2.13.2/golangci-lint-2.13.2-linux-${ARCH}.tar.gz" \
         | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/golangci-lint'
 fi

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -18,13 +18,13 @@ COPY squid.conf /etc/squid/squid.conf
 
 # gh CLI (renamed to gh-real — thin client takes "gh" in bot container)
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_linux_${ARCH}.tar.gz" \
+    && curl -fsSL "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_linux_${ARCH}.tar.gz" \
     | tar -xz -C /usr/local --strip-components=1 \
     && mv /usr/local/bin/gh /usr/local/bin/gh-real
 
 # glab CLI (renamed to glab-real)
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
-    && curl -fSL -o /tmp/glab.tar.gz "https://gitlab.com/gitlab-org/cli/-/releases/v1.51.0/downloads/glab_1.51.0_linux_${ARCH}.tar.gz" \
+    && curl -fSL -o /tmp/glab.tar.gz "https://gitlab.com/gitlab-org/cli/-/releases/v1.116.0/downloads/glab_1.116.0_linux_${ARCH}.tar.gz" \
     && tar -xzf /tmp/glab.tar.gz -C /usr/local/bin --strip-components=1 bin/glab \
     && rm /tmp/glab.tar.gz \
     && mv /usr/local/bin/glab /usr/local/bin/glab-real

--- a/rehor-config/agent/personas/backend/prompt.md
+++ b/rehor-config/agent/personas/backend/prompt.md
@@ -12,7 +12,7 @@ You are working on a backend service. Backend repos may be Go or Node.js — che
 
 ### Go repos
 
-- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.14)"` (replace with needed version). Available versions are pre-installed in the container. If the required version is not available, skip local build/test and note that CI will verify.
+- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.13)"` (replace with needed version). Available versions are pre-installed in the container. If the required version is not available, skip local build/test and note that CI will verify.
 - Use `make test` (or `go test ./... -v`) to run tests.
 - Use `make build` to verify the project compiles.
 - Use `go vet ./...` to check for issues.

--- a/rehor-config/agent/personas/backend/prompt.md
+++ b/rehor-config/agent/personas/backend/prompt.md
@@ -12,7 +12,7 @@ You are working on a backend service. Backend repos may be Go or Node.js — che
 
 ### Go repos
 
-- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.7)"` (replace with needed version). Available versions are pre-installed in the container. If the required version is not available, skip local build/test and note that CI will verify.
+- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.14)"` (replace with needed version). Available versions are pre-installed in the container. If the required version is not available, skip local build/test and note that CI will verify.
 - Use `make test` (or `go test ./... -v`) to run tests.
 - Use `make build` to verify the project compiles.
 - Use `go vet ./...` to check for issues.

--- a/rehor-config/agent/personas/operator/prompt.md
+++ b/rehor-config/agent/personas/operator/prompt.md
@@ -3,7 +3,7 @@
 You are working on a Kubernetes operator written in Go.
 
 ### Before making any changes
-- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.14)"` (replace with needed version). Available versions are pre-installed in the container.
+- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.13)"` (replace with needed version). Available versions are pre-installed in the container.
 - Run `go mod tidy` to ensure dependencies are up to date.
 - If it fails, STOP immediately. Report the failure on the Jira ticket and do not proceed.
 

--- a/rehor-config/agent/personas/operator/prompt.md
+++ b/rehor-config/agent/personas/operator/prompt.md
@@ -3,7 +3,7 @@
 You are working on a Kubernetes operator written in Go.
 
 ### Before making any changes
-- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.7)"` (replace with needed version). Available versions are pre-installed in the container.
+- **Go version**: Check `go.mod` for the required Go version. If it differs from the default (`go version`), switch with: `eval "$(use-go 1.25.14)"` (replace with needed version). Available versions are pre-installed in the container.
 - Run `go mod tidy` to ensure dependencies are up to date.
 - If it fails, STOP immediately. Report the failure on the Jira ticket and do not proceed.
 


### PR DESCRIPTION
## Summary

- Update bundled Go toolchains to patched `1.24.13` and `1.25.14` releases.
- Upgrade `golangci-lint`, Grype, GitHub CLI, and GitLab CLI to patched releases.
- Propagate `GOVERSIONS` through runner image builds and synchronize documentation.
- Fixes https://redhat.atlassian.net/browse/RHCLOUD-47795

---

## Testing

- `make verify` passed: 948 Python tests and 85 dashboard tests passed.
- `make container-verify` built the updated bot and proxy images, passed tooling checks and proxy smoke checks. Memory-server image build remains blocked by the existing clean-install failure `tsc: command not found`.
- `make memory-verify` reached 165 passed tests but could not start database-backed fixtures because PostgreSQL was unavailable at `localhost:5432`.
- Direct image assertions passed for Go `1.24.13`/`1.25.14`, `golangci-lint 2.13.2`, Grype `0.118.0`, GitHub CLI `2.100.0`, and GitLab CLI `1.116.0`.