### PR TITLE
feat: establish shared TypeScript lint tooling

### DIFF
--- a/.github/branch-protection/README.md
+++ b/.github/branch-protection/README.md
@@ -15,9 +15,9 @@ Check names are extracted from real PR runs using `gh pr checks <number> --repo 
 
 ### Path-scoping caveat
 
-GitHub Actions workflows in this repo use path filters. A PR touching only Python code won't trigger Go or Dashboard checks. If branch protection requires a check that doesn't run, the PR will be blocked.
+Most GitHub Actions workflows in this repo use path filters. The TypeScript Lint workflow is intentionally unfiltered on pull requests because its `TypeScript Lint / Biome` check is required by branch protection. The main bot and memory-server Konflux pipelines also run on every PR (no path filter in CEL expression). The proxy Konflux pipeline is path-filtered to proxy/** changes. If branch protection requires a check that doesn't run, the PR will be blocked.
 
-**Current approach:** require only the two Konflux container build checks that always run on every PR (main bot + memory-server). Path-filtered checks (all GitHub Actions workflows + proxy Konflux) are trusted to pass when they fire but not listed as hard requirements in branch protection.
+**Current approach:** require the TypeScript Lint check plus the two Konflux container build checks that always run on every PR (main bot + memory-server). Other path-filtered checks are trusted to pass when they fire but are not listed as hard requirements in branch protection.
 
 ### Updating required checks
 

--- a/.github/branch-protection/master-protection.json
+++ b/.github/branch-protection/master-protection.json
@@ -4,7 +4,8 @@
     "strict": true,
     "contexts": [
       "Red Hat Konflux / platform-frontend-ai-dev-on-pull-request",
-      "Red Hat Konflux / platform-frontend-ai-dev-memory-server-on-pull-request"
+      "Red Hat Konflux / platform-frontend-ai-dev-memory-server-on-pull-request",
+      "TypeScript Lint / Biome"
     ]
   },
   "enforce_admins": true,

--- a/.github/branch-protection/required-checks.json
+++ b/.github/branch-protection/required-checks.json
@@ -6,6 +6,13 @@
   "checks": {
     "github_actions": [
       {
+        "name": "TypeScript Lint / Biome",
+        "workflow": "typescript-lint.yml",
+        "scope": "repository-wide TypeScript formatting and linting (Biome)",
+        "required": true,
+        "note": "unfiltered on pull requests so this required check runs for every PR."
+      },
+      {
         "name": "format",
         "workflow": "ruff-format.yml",
         "scope": "python code formatting (ruff)",
@@ -127,8 +134,8 @@
     ]
   },
   "path_scoping_notes": {
-    "description": "All GitHub Actions workflows use path filters. Only the main bot and memory-server Konflux pipelines run on every PR (no path filter in CEL expression). The proxy Konflux pipeline is path-filtered to proxy/** changes.",
-    "required_in_branch_protection": "Only checks that fire on EVERY PR can be hard-required in branch protection. Currently that is the two non-path-filtered Konflux build checks. Path-filtered checks (all GitHub Actions + proxy Konflux) are trusted to pass when they fire, but not enforced as branch protection gates.",
-    "future": "If a lightweight always-running gate workflow is added (e.g. a status-aggregator that reports success/neutral for path-filtered checks that didn't fire), more checks can be promoted to required."
+    "description": "Most GitHub Actions workflows use path filters. The TypeScript Lint workflow intentionally runs on every pull request because its check is required by branch protection. The main bot and memory-server Konflux pipelines also run on every PR (no path filter in CEL expression). The proxy Konflux pipeline is path-filtered to proxy/** changes.",
+    "required_in_branch_protection": "Only checks that fire on EVERY PR can be hard-required in branch protection. That is the TypeScript Lint check plus the two non-path-filtered Konflux build checks. Other path-filtered checks are trusted to pass when they fire, but not enforced as branch protection gates.",
+    "future": "If additional lightweight always-running gate workflows are added (e.g. status aggregators that report success/neutral for path-filtered checks that did not fire), more checks can be promoted to required."
   }
 }

--- a/.github/workflows/dashboard-tests.yml
+++ b/.github/workflows/dashboard-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci
 
       - name: Type check
-        run: npm run lint
+        run: npm run typecheck
 
       - name: Build
         run: npm run build

--- a/.github/workflows/typescript-lint.yml
+++ b/.github/workflows/typescript-lint.yml
@@ -1,0 +1,35 @@
+name: TypeScript Lint
+
+# This workflow has no pull_request path filter because its check is required by
+# master branch protection. It runs the same repository-wide Biome check for
+# every pull request, so the required check is never left pending on unrelated
+# changes.
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    paths:
+      - "dashboard/**"
+      - "biome.json"
+      - "Makefile"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/typescript-lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  biome:
+    name: Biome
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Check TypeScript formatting and lint
+        run: bunx @biomejs/biome@2.5.12 check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
+  - repo: https://github.com/biomejs/pre-commit
+    rev: 922fba1f8fd9f9f096d04586e54369a31e6c1c31 # v2.5.12
+    hooks:
+      - id: biome-ci
+
   - repo: local
     hooks:
       - id: mypy

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-.PHONY: install run init dashboard costs costs-today costs-week seed-costs stop logs help memory-server memory-server-stop memory-dump memory-import memory-reset verify memory-verify precommit-install precommit-run prepush-install prepush-check verify-required-checks check-branch-protection container-verify container-e2e container-e2e-browser
+.PHONY: install run init dashboard costs costs-today costs-week seed-costs stop logs help memory-server memory-server-stop memory-dump memory-import memory-reset verify ts-verify ts-format memory-verify precommit-install precommit-run prepush-install prepush-check verify-required-checks check-branch-protection container-verify container-e2e container-e2e-browser
 
 LABEL ?= hcc-ai-framework
+BIOME_VERSION ?= 2.5.12
 CONTAINER_RT ?= $(shell command -v docker >/dev/null 2>&1 && echo docker || echo podman)
+
+ts-verify: ## Check TypeScript formatting and lint with Biome
+	bunx @biomejs/biome@$(BIOME_VERSION) check .
+
+ts-format: ## Format TypeScript files with Biome (local fix)
+	bunx @biomejs/biome@$(BIOME_VERSION) check --write .
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -20,8 +27,10 @@ verify: ## Run all checks (same as CI)
 	cd proxy/executor && go vet ./...
 	@echo "=== Go: tests ==="
 	cd proxy/executor && go test -race ./...
+	@echo "=== TypeScript: Biome ==="
+	$(MAKE) ts-verify
 	@echo "=== Dashboard: type check ==="
-	cd dashboard && npm run lint
+	cd dashboard && npm run typecheck
 	@echo "=== Dashboard: build ==="
 	cd dashboard && npm run build
 	@echo "=== Dashboard: tests ==="

--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
   "files": {
-    "includes": [
-      "dashboard/**",
-      "coordinator/**",
-      "!**/node_modules",
-      "!**/dist",
-      "!dashboard/public/**"
-    ]
+    "includes": ["dashboard/**", "!**/node_modules", "!**/dist", "!dashboard/public"]
   },
   "formatter": {
     "enabled": true,
@@ -28,7 +22,22 @@
     }
   },
   "linter": {
-    "enabled": false
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "a11y": {
+        "noStaticElementInteractions": "warn",
+        "useHtmlLang": "warn",
+        "useKeyWithClickEvents": "warn"
+      },
+      "correctness": {
+        "useExhaustiveDependencies": "warn"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "warn",
+        "useIterableCallbackReturn": "warn"
+      }
+    }
   },
   "assist": {
     "actions": {
@@ -40,12 +49,6 @@
   "overrides": [
     {
       "includes": ["dashboard/**"],
-      "javascript": {
-        "globals": []
-      }
-    },
-    {
-      "includes": ["coordinator/**"],
       "javascript": {
         "globals": []
       }

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "files": {
+    "includes": [
+      "dashboard/**",
+      "coordinator/**",
+      "!**/node_modules",
+      "!**/dist",
+      "!dashboard/public/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "bracketSpacing": true,
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "linter": {
+    "enabled": false
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["dashboard/**"],
+      "javascript": {
+        "globals": []
+      }
+    },
+    {
+      "includes": ["coordinator/**"],
+      "javascript": {
+        "globals": []
+      }
+    }
+  ]
+}

--- a/dashboard/e2e/fixtures.ts
+++ b/dashboard/e2e/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base, type Locator } from '@playwright/test';
+import { test as base, type Locator } from "@playwright/test";
 
 type MountResult = Locator & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -8,10 +8,10 @@ type MountResult = Locator & {
 
 export const test = base.extend<{ mount: (scenarioId: string) => Promise<MountResult> }>({
   mount: async ({ page }, use) => {
-    await page.goto('/e2e/gallery.html');
+    await page.goto("/e2e/gallery.html");
     await use(async (scenarioId: string): Promise<MountResult> => {
       await page.evaluate((id) => (window as any).mount(id), scenarioId);
-      return Object.assign(page.locator('#root'), {
+      return Object.assign(page.locator("#root"), {
         update: async () => {},
         unmount: async () => {},
       });
@@ -19,4 +19,4 @@ export const test = base.extend<{ mount: (scenarioId: string) => Promise<MountRe
   },
 });
 
-export { expect } from '@playwright/test';
+export { expect } from "@playwright/test";

--- a/dashboard/e2e/gallery.tsx
+++ b/dashboard/e2e/gallery.tsx
@@ -1,31 +1,23 @@
-import { createRoot } from 'react-dom/client';
-import { MemoryRouter } from 'react-router-dom';
-import '@patternfly/patternfly/patternfly.css';
-import '@patternfly/patternfly/patternfly-addons.css';
-import '../src/App.css';
+import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import "@patternfly/patternfly/patternfly.css";
+import "@patternfly/patternfly/patternfly-addons.css";
+import "../src/App.css";
 
-import type { WSEvent } from '../src/types';
-
-import TaskCard from '../src/components/TaskCard';
-import BotBanner from '../src/components/BotBanner';
-import ConfirmDialog from '../src/components/ConfirmDialog';
-import CycleRunCard from '../src/components/CycleRunCard';
-import DetailPanel from '../src/components/DetailPanel';
-import Toasts from '../src/components/Toasts';
-
-import Tasks from '../src/pages/Tasks';
-import ArchivedTasks from '../src/pages/ArchivedTasks';
-import Costs from '../src/pages/Costs';
-import CycleRuns from '../src/pages/CycleRuns';
-import Instances from '../src/pages/Instances';
-
-import { WSProvider } from './mockWebSocket';
-
-import {
-  makeTask,
-  makeBotStatus,
-  makeCycleRun,
-} from '../src/test/helpers';
+import BotBanner from "../src/components/BotBanner";
+import ConfirmDialog from "../src/components/ConfirmDialog";
+import CycleRunCard from "../src/components/CycleRunCard";
+import DetailPanel from "../src/components/DetailPanel";
+import TaskCard from "../src/components/TaskCard";
+import Toasts from "../src/components/Toasts";
+import ArchivedTasks from "../src/pages/ArchivedTasks";
+import Costs from "../src/pages/Costs";
+import CycleRuns from "../src/pages/CycleRuns";
+import Instances from "../src/pages/Instances";
+import Tasks from "../src/pages/Tasks";
+import { makeBotStatus, makeCycleRun, makeTask } from "../src/test/helpers";
+import type { WSEvent } from "../src/types";
+import { WSProvider } from "./mockWebSocket";
 
 // --- Hidden input helper for recording callbacks ---
 
@@ -42,74 +34,91 @@ function record(id: string, value: string) {
 
 const scenarios: Record<string, () => JSX.Element> = {
   // ── TaskCard ──
-  'TaskCard/JiraLink': () => (
-    <TaskCard task={makeTask({ source_type: 'jira', external_key: 'RHCLOUD-100', source_url: null })} />
+  "TaskCard/JiraLink": () => (
+    <TaskCard
+      task={makeTask({ source_type: "jira", external_key: "RHCLOUD-100", source_url: null })}
+    />
   ),
-  'TaskCard/GitHubNoUrl': () => (
-    <TaskCard task={makeTask({ source_type: 'github', external_key: 'org/repo#42', source_url: null })} />
+  "TaskCard/GitHubNoUrl": () => (
+    <TaskCard
+      task={makeTask({ source_type: "github", external_key: "org/repo#42", source_url: null })}
+    />
   ),
-  'TaskCard/InProgress': () => (
-    <TaskCard task={makeTask({ status: 'in_progress' })} />
+  "TaskCard/InProgress": () => <TaskCard task={makeTask({ status: "in_progress" })} />,
+  "TaskCard/Paused": () => (
+    <TaskCard task={makeTask({ status: "paused", paused_reason: "Waiting for review" })} />
   ),
-  'TaskCard/Paused': () => (
-    <TaskCard task={makeTask({ status: 'paused', paused_reason: 'Waiting for review' })} />
+  "TaskCard/PrOpen": () => <TaskCard task={makeTask({ status: "pr_open" })} />,
+  "TaskCard/NoPausedReason": () => <TaskCard task={makeTask({ paused_reason: null })} />,
+  "TaskCard/WithInstanceId": () => <TaskCard task={makeTask({ instance_id: "bot-42" })} />,
+  "TaskCard/GitHubWithUrl": () => (
+    <TaskCard
+      task={makeTask({
+        source_type: "github",
+        external_key: "org/repo#42",
+        source_url: "https://github.com/org/repo/issues/42",
+      })}
+    />
   ),
-  'TaskCard/PrOpen': () => (
-    <TaskCard task={makeTask({ status: 'pr_open' })} />
-  ),
-  'TaskCard/NoPausedReason': () => (
-    <TaskCard task={makeTask({ paused_reason: null })} />
-  ),
-  'TaskCard/WithInstanceId': () => (
-    <TaskCard task={makeTask({ instance_id: 'bot-42' })} />
-  ),
-  'TaskCard/GitHubWithUrl': () => (
-    <TaskCard task={makeTask({ source_type: 'github', external_key: 'org/repo#42', source_url: 'https://github.com/org/repo/issues/42' })} />
-  ),
-  'TaskCard/ClickHandling': () => (
+  "TaskCard/ClickHandling": () => (
     <>
       <RecordInput id="clicked" />
       <TaskCard
-        task={makeTask({ external_key: 'RHCLOUD-100', source_type: 'jira' })}
-        onClick={() => record('clicked', 'true')}
+        task={makeTask({ external_key: "RHCLOUD-100", source_type: "jira" })}
+        onClick={() => record("clicked", "true")}
       />
     </>
   ),
 
   // ── BotBanner ──
-  'BotBanner/Idle': () => (
-    <BotBanner status={makeBotStatus({ state: 'idle', message: 'Waiting for tasks', updated_at: new Date().toISOString() })} />
+  "BotBanner/Idle": () => (
+    <BotBanner
+      status={makeBotStatus({
+        state: "idle",
+        message: "Waiting for tasks",
+        updated_at: new Date().toISOString(),
+      })}
+    />
   ),
-  'BotBanner/Working': () => (
-    <BotBanner status={makeBotStatus({
-      state: 'working',
-      message: 'Working on RHCLOUD-100',
-      external_key: 'RHCLOUD-100',
-      source_type: 'jira',
-      repo: 'org/repo',
-      cycle_start: new Date(Date.now() - 125_000).toISOString(),
-    })} />
+  "BotBanner/Working": () => (
+    <BotBanner
+      status={makeBotStatus({
+        state: "working",
+        message: "Working on RHCLOUD-100",
+        external_key: "RHCLOUD-100",
+        source_type: "jira",
+        repo: "org/repo",
+        cycle_start: new Date(Date.now() - 125_000).toISOString(),
+      })}
+    />
   ),
-  'BotBanner/Error': () => (
-    <BotBanner status={makeBotStatus({ state: 'error', message: 'Cycle failed' })} />
+  "BotBanner/Error": () => (
+    <BotBanner status={makeBotStatus({ state: "error", message: "Cycle failed" })} />
   ),
-  'BotBanner/Sleep': () => (
-    <BotBanner status={makeBotStatus({ state: 'idle', message: '', instance_id: 'dev-bot', updated_at: '2020-01-01T00:00:00Z' })} />
+  "BotBanner/Sleep": () => (
+    <BotBanner
+      status={makeBotStatus({
+        state: "idle",
+        message: "",
+        instance_id: "dev-bot",
+        updated_at: "2020-01-01T00:00:00Z",
+      })}
+    />
   ),
   // ── ConfirmDialog ──
-  'ConfirmDialog/Default': () => (
+  "ConfirmDialog/Default": () => (
     <>
       <RecordInput id="confirmed" />
       <ConfirmDialog
         open={true}
         title="Confirm Action"
         message="Are you sure?"
-        onConfirm={(val) => record('confirmed', val ?? '__undefined__')}
-        onCancel={() => record('confirmed', '__cancelled__')}
+        onConfirm={(val) => record("confirmed", val ?? "__undefined__")}
+        onCancel={() => record("confirmed", "__cancelled__")}
       />
     </>
   ),
-  'ConfirmDialog/WithInput': () => (
+  "ConfirmDialog/WithInput": () => (
     <>
       <RecordInput id="confirmed" />
       <ConfirmDialog
@@ -118,12 +127,12 @@ const scenarios: Record<string, () => JSX.Element> = {
         message="Are you sure?"
         inputLabel="Reason"
         inputPlaceholder="Enter reason"
-        onConfirm={(val) => record('confirmed', val ?? '__undefined__')}
-        onCancel={() => record('confirmed', '__cancelled__')}
+        onConfirm={(val) => record("confirmed", val ?? "__undefined__")}
+        onCancel={() => record("confirmed", "__cancelled__")}
       />
     </>
   ),
-  'ConfirmDialog/Danger': () => (
+  "ConfirmDialog/Danger": () => (
     <ConfirmDialog
       open={true}
       title="Delete"
@@ -134,7 +143,7 @@ const scenarios: Record<string, () => JSX.Element> = {
       onCancel={() => {}}
     />
   ),
-  'ConfirmDialog/Primary': () => (
+  "ConfirmDialog/Primary": () => (
     <ConfirmDialog
       open={true}
       title="Confirm"
@@ -147,177 +156,193 @@ const scenarios: Record<string, () => JSX.Element> = {
   ),
 
   // ── CycleRunCard ──
-  'CycleRunCard/Default': () => (
-    <CycleRunCard run={makeCycleRun({ id: 7, cycle_type: 'task_work' })} />
+  "CycleRunCard/Default": () => (
+    <CycleRunCard run={makeCycleRun({ id: 7, cycle_type: "task_work" })} />
   ),
-  'CycleRunCard/WithDuration': () => (
-    <CycleRunCard run={makeCycleRun({
-      started_at: '2025-07-01T10:00:00Z',
-      finished_at: '2025-07-01T10:05:00Z',
-      tool_calls: 8,
-      tokens_used: 2500,
-    })} />
+  "CycleRunCard/WithDuration": () => (
+    <CycleRunCard
+      run={makeCycleRun({
+        started_at: "2025-07-01T10:00:00Z",
+        finished_at: "2025-07-01T10:05:00Z",
+        tool_calls: 8,
+        tokens_used: 2500,
+      })}
+    />
   ),
-  'CycleRunCard/NoFinished': () => (
+  "CycleRunCard/NoFinished": () => (
     <CycleRunCard run={makeCycleRun({ finished_at: null, tool_calls: 3, tokens_used: 100 })} />
   ),
-  'CycleRunCard/NullStats': () => (
+  "CycleRunCard/NullStats": () => (
     <CycleRunCard run={makeCycleRun({ tool_calls: null, tokens_used: null })} />
   ),
-  'CycleRunCard/WithProgress': () => (
-    <CycleRunCard run={makeCycleRun({
-      progress: { external_key: 'RHCLOUD-100', source_type: 'jira' },
-    })} />
+  "CycleRunCard/WithProgress": () => (
+    <CycleRunCard
+      run={makeCycleRun({
+        progress: { external_key: "RHCLOUD-100", source_type: "jira" },
+      })}
+    />
   ),
-  'CycleRunCard/WithSummary': () => (
-    <CycleRunCard run={makeCycleRun({
-      progress: { summary: 'Implemented fix for login', last_step: 'run tests' },
-    })} />
+  "CycleRunCard/WithSummary": () => (
+    <CycleRunCard
+      run={makeCycleRun({
+        progress: { summary: "Implemented fix for login", last_step: "run tests" },
+      })}
+    />
   ),
-  'CycleRunCard/WithInstanceId': () => (
-    <CycleRunCard run={makeCycleRun({ instance_id: 'prod-bot' })} />
+  "CycleRunCard/WithInstanceId": () => (
+    <CycleRunCard run={makeCycleRun({ instance_id: "prod-bot" })} />
   ),
-  'CycleRunCard/Selected': () => (
-    <CycleRunCard run={makeCycleRun()} selected />
-  ),
-  'CycleRunCard/ClickHandling': () => (
+  "CycleRunCard/Selected": () => <CycleRunCard run={makeCycleRun()} selected />,
+  "CycleRunCard/ClickHandling": () => (
     <>
       <RecordInput id="clicked" />
-      <CycleRunCard
-        run={makeCycleRun()}
-        onClick={() => record('clicked', 'true')}
-      />
+      <CycleRunCard run={makeCycleRun()} onClick={() => record("clicked", "true")} />
     </>
   ),
-  'CycleRunCard/WithTranscript': () => (
-    <CycleRunCard run={makeCycleRun({ id: 5, has_transcript: true, cycle_type: 'task_work', started_at: '2025-07-01T10:00:00Z' })} />
+  "CycleRunCard/WithTranscript": () => (
+    <CycleRunCard
+      run={makeCycleRun({
+        id: 5,
+        has_transcript: true,
+        cycle_type: "task_work",
+        started_at: "2025-07-01T10:00:00Z",
+      })}
+    />
   ),
 
   // ── DetailPanel ──
-  'DetailPanel/PauseVisible': () => (
+  "DetailPanel/PauseVisible": () => (
     <>
       <RecordInput id="action" />
       <DetailPanel
         type="task"
-        task={makeTask({ status: 'in_progress', external_key: 'RHCLOUD-555' })}
+        task={makeTask({ status: "in_progress", external_key: "RHCLOUD-555" })}
         onClose={() => {}}
-        onPause={(key) => record('action', `pause:${key}`)}
+        onPause={(key) => record("action", `pause:${key}`)}
       />
     </>
   ),
-  'DetailPanel/PausePrOpen': () => (
+  "DetailPanel/PausePrOpen": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ status: 'pr_open' })}
+      task={makeTask({ status: "pr_open" })}
       onClose={() => {}}
       onPause={() => {}}
     />
   ),
-  'DetailPanel/PausePrChanges': () => (
+  "DetailPanel/PausePrChanges": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ status: 'pr_changes' })}
+      task={makeTask({ status: "pr_changes" })}
       onClose={() => {}}
       onPause={() => {}}
     />
   ),
-  'DetailPanel/PausedNoPause': () => (
+  "DetailPanel/PausedNoPause": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ status: 'paused' })}
+      task={makeTask({ status: "paused" })}
       onClose={() => {}}
       onPause={() => {}}
     />
   ),
-  'DetailPanel/DoneNoPause': () => (
+  "DetailPanel/DoneNoPause": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ status: 'done' })}
+      task={makeTask({ status: "done" })}
       onClose={() => {}}
       onPause={() => {}}
     />
   ),
-  'DetailPanel/NoPauseCallback': () => (
-    <DetailPanel
-      type="task"
-      task={makeTask({ status: 'in_progress' })}
-      onClose={() => {}}
-    />
+  "DetailPanel/NoPauseCallback": () => (
+    <DetailPanel type="task" task={makeTask({ status: "in_progress" })} onClose={() => {}} />
   ),
-  'DetailPanel/UnpauseVisible': () => (
+  "DetailPanel/UnpauseVisible": () => (
     <>
       <RecordInput id="action" />
       <DetailPanel
         type="task"
-        task={makeTask({ status: 'paused', external_key: 'RHCLOUD-777' })}
+        task={makeTask({ status: "paused", external_key: "RHCLOUD-777" })}
         onClose={() => {}}
-        onUnpause={(key) => record('action', `unpause:${key}`)}
+        onUnpause={(key) => record("action", `unpause:${key}`)}
       />
     </>
   ),
-  'DetailPanel/InProgressNoUnpause': () => (
+  "DetailPanel/InProgressNoUnpause": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ status: 'in_progress' })}
+      task={makeTask({ status: "in_progress" })}
       onClose={() => {}}
       onUnpause={() => {}}
     />
   ),
-  'DetailPanel/ArchiveVisible': () => (
+  "DetailPanel/ArchiveVisible": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ status: 'in_progress' })}
+      task={makeTask({ status: "in_progress" })}
       onClose={() => {}}
       onDelete={() => {}}
     />
   ),
-  'DetailPanel/ArchivedNoArchive': () => (
+  "DetailPanel/ArchivedNoArchive": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ status: 'archived' })}
+      task={makeTask({ status: "archived" })}
       onClose={() => {}}
       onDelete={() => {}}
     />
   ),
-  'DetailPanel/WithPausedReason': () => (
+  "DetailPanel/WithPausedReason": () => (
     <DetailPanel
       type="task"
-      task={makeTask({ paused_reason: 'Blocked by dependency' })}
+      task={makeTask({ paused_reason: "Blocked by dependency" })}
       onClose={() => {}}
     />
   ),
 
   // ── Toasts (useWS aliased to mockWebSocket via Vite config) ──
-  'Toasts/Default': () => (
+  "Toasts/Default": () => (
     <WSProvider>
       <Toasts />
     </WSProvider>
   ),
 
   // ── Pages (API mocked via page.route() in tests) ──
-  'Tasks/Default': () => (
-    <MemoryRouter><Tasks /></MemoryRouter>
+  "Tasks/Default": () => (
+    <MemoryRouter>
+      <Tasks />
+    </MemoryRouter>
   ),
-  'ArchivedTasks/Default': () => (
-    <MemoryRouter><ArchivedTasks /></MemoryRouter>
+  "ArchivedTasks/Default": () => (
+    <MemoryRouter>
+      <ArchivedTasks />
+    </MemoryRouter>
   ),
-  'Costs/Default': () => (
-    <div style={{ width: '1200px', height: '800px' }}><Costs /></div>
+  "Costs/Default": () => (
+    <div style={{ width: "1200px", height: "800px" }}>
+      <Costs />
+    </div>
   ),
-  'CycleRuns/Default': () => (
-    <MemoryRouter><CycleRuns /></MemoryRouter>
+  "CycleRuns/Default": () => (
+    <MemoryRouter>
+      <CycleRuns />
+    </MemoryRouter>
   ),
-  'CycleRuns/WithInstanceId': () => (
-    <MemoryRouter><CycleRuns instanceId="prod-bot" /></MemoryRouter>
+  "CycleRuns/WithInstanceId": () => (
+    <MemoryRouter>
+      <CycleRuns instanceId="prod-bot" />
+    </MemoryRouter>
   ),
-  'Instances/Default': () => (
-    <MemoryRouter><Instances /></MemoryRouter>
+  "Instances/Default": () => (
+    <MemoryRouter>
+      <Instances />
+    </MemoryRouter>
   ),
 };
 
 // --- Mount/unmount API ---
 
-const root = createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById("root")!);
 
 (window as any).mount = (scenarioId: string) => {
   const scenario = scenarios[scenarioId];

--- a/dashboard/e2e/mockWebSocket.tsx
+++ b/dashboard/e2e/mockWebSocket.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useRef, useCallback, type ReactNode } from 'react';
-import type { WSEvent } from '../src/types';
+import { createContext, type ReactNode, useCallback, useContext, useRef } from "react";
+import type { WSEvent } from "../src/types";
 
 interface WSContextValue {
   connected: boolean;

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "test:ct": "npx playwright test",
     "test:ct:ui": "npx playwright test --ui",
     "generate-fixtures": "python3 tests/fixtures/generate_json.py"

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -1,14 +1,14 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './src',
-  testMatch: '**/*.spec.ts',
+  testDir: "./src",
+  testMatch: "**/*.spec.ts",
   use: {
-    baseURL: 'http://localhost:5174',
-    serviceWorkers: 'block',
+    baseURL: "http://localhost:5174",
+    serviceWorkers: "block",
   },
   webServer: {
-    command: 'npx vite --config vite.gallery.config.ts --port 5174',
+    command: "npx vite --config vite.gallery.config.ts --port 5174",
     port: 5174,
     reuseExistingServer: !process.env.CI,
   },

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -26,14 +26,14 @@
   --row-border: rgba(0, 0, 0, 0.1);
 }
 
-
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   min-height: 100vh;
   margin: 0;
 }
@@ -48,7 +48,7 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   color: var(--pf-t--global--text--color--regular, var(--text));
   line-height: 1.5;
 }
@@ -190,13 +190,24 @@ header {
 }
 
 @keyframes pulse-dot {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 @keyframes ping-ring {
-  0% { transform: scale(0.8); opacity: 0.8; }
-  100% { transform: scale(2); opacity: 0; }
+  0% {
+    transform: scale(0.8);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
 }
 
 .state-badge {
@@ -248,8 +259,14 @@ header {
 }
 
 @keyframes fade-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .banner-meta {
@@ -377,7 +394,9 @@ header {
   border-radius: 8px;
   padding: 16px;
   cursor: pointer;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   border-left: 3px solid var(--border);
 }
 .instance-card:hover {
@@ -465,7 +484,9 @@ header {
   padding: 2px 8px;
   font-size: 11px;
   cursor: pointer;
-  transition: background 0.15s, opacity 0.15s;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
   line-height: 1;
 }
 .wake-btn:hover {
@@ -500,7 +521,9 @@ header {
   color: var(--text-dim);
   text-decoration: none;
   border-bottom: 2px solid transparent;
-  transition: color 0.2s, border-color 0.2s;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
 }
 .tab-nav a:hover {
   color: var(--text);
@@ -1072,8 +1095,14 @@ select:focus,
 }
 
 @keyframes toast-in {
-  from { opacity: 0; transform: translateX(40px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .toast-header {
@@ -1306,7 +1335,9 @@ select:focus,
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 .metric-tab:hover {
   color: var(--text);
@@ -1350,7 +1381,9 @@ select:focus,
   font-size: 13px;
   align-items: center;
 }
-.cycle-row:last-child { border-bottom: none; }
+.cycle-row:last-child {
+  border-bottom: none;
+}
 .cycle-row-header {
   font-weight: 600;
   color: var(--text-dim);
@@ -1364,16 +1397,48 @@ select:focus,
   padding-bottom: 8px;
   border-bottom: 1px solid var(--border);
 }
-.cycle-work { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-.cycle-work a { font-weight: 600; font-size: 13px; }
-.cycle-repo { font-size: 11px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cycle-cost { font-weight: 600; font-variant-numeric: tabular-nums; }
-.cycle-time { color: var(--text-dim); }
-.cycle-turns { color: var(--text-dim); }
-.cycle-duration { font-variant-numeric: tabular-nums; }
-.cycle-tokens { display: flex; gap: 8px; font-size: 12px; }
-.cycle-tokens-dim { color: var(--text-dim); }
-.cycle-status { font-weight: 500; font-size: 12px; }
+.cycle-work {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.cycle-work a {
+  font-weight: 600;
+  font-size: 13px;
+}
+.cycle-repo {
+  font-size: 11px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cycle-cost {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.cycle-time {
+  color: var(--text-dim);
+}
+.cycle-turns {
+  color: var(--text-dim);
+}
+.cycle-duration {
+  font-variant-numeric: tabular-nums;
+}
+.cycle-tokens {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+}
+.cycle-tokens-dim {
+  color: var(--text-dim);
+}
+.cycle-status {
+  font-weight: 500;
+  font-size: 12px;
+}
 
 .costs-daily-header {
   display: flex;
@@ -1400,8 +1465,13 @@ select:focus,
   gap: 16px;
 }
 @media (max-width: 900px) {
-  .costs-charts { grid-template-columns: 1fr; }
-  .cycle-row { grid-template-columns: 90px 1fr 55px 55px 65px 100px 65px; font-size: 12px; }
+  .costs-charts {
+    grid-template-columns: 1fr;
+  }
+  .cycle-row {
+    grid-template-columns: 90px 1fr 55px 55px 65px 100px 65px;
+    font-size: 12px;
+  }
 }
 
 /* Analytics */
@@ -1411,7 +1481,9 @@ select:focus,
   gap: 16px;
 }
 @media (max-width: 900px) {
-  .analytics-charts { grid-template-columns: 1fr; }
+  .analytics-charts {
+    grid-template-columns: 1fr;
+  }
 }
 
 .work-type-legend {
@@ -1473,12 +1545,25 @@ select:focus,
   transition: border-color 0.15s;
   border-left: 3px solid var(--text-dim);
 }
-.cycle-run-card:hover { border-color: var(--accent); }
-.cycle-run-card.selected { border-color: var(--accent); background: var(--card-hover); }
-.cycle-run-card.cycle-type-task_work { border-left-color: var(--accent); }
-.cycle-run-card.cycle-type-idle { border-left-color: #6e7681; }
-.cycle-run-card.cycle-type-error { border-left-color: #f85149; }
-.cycle-run-card.cycle-type-triage_only { border-left-color: #d29922; }
+.cycle-run-card:hover {
+  border-color: var(--accent);
+}
+.cycle-run-card.selected {
+  border-color: var(--accent);
+  background: var(--card-hover);
+}
+.cycle-run-card.cycle-type-task_work {
+  border-left-color: var(--accent);
+}
+.cycle-run-card.cycle-type-idle {
+  border-left-color: #6e7681;
+}
+.cycle-run-card.cycle-type-error {
+  border-left-color: #f85149;
+}
+.cycle-run-card.cycle-type-triage_only {
+  border-left-color: #d29922;
+}
 
 .cycle-run-header {
   display: flex;
@@ -1486,8 +1571,15 @@ select:focus,
   gap: 8px;
   margin-bottom: 6px;
 }
-.cycle-run-id { color: var(--text-dim); font-size: 12px; }
-.cycle-run-time { color: var(--text-dim); font-size: 12px; margin-left: auto; }
+.cycle-run-id {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+.cycle-run-time {
+  color: var(--text-dim);
+  font-size: 12px;
+  margin-left: auto;
+}
 
 .cycle-type-badge {
   font-size: 11px;
@@ -1496,10 +1588,22 @@ select:focus,
   border-radius: 4px;
   text-transform: uppercase;
 }
-.cycle-type-badge.task_work { background: rgba(88,166,255,0.15); color: var(--accent); }
-.cycle-type-badge.idle { background: rgba(110,118,129,0.15); color: var(--text-dim); }
-.cycle-type-badge.error { background: rgba(248,81,73,0.15); color: var(--red); }
-.cycle-type-badge.triage_only { background: rgba(210,153,34,0.15); color: var(--yellow); }
+.cycle-type-badge.task_work {
+  background: rgba(88, 166, 255, 0.15);
+  color: var(--accent);
+}
+.cycle-type-badge.idle {
+  background: rgba(110, 118, 129, 0.15);
+  color: var(--text-dim);
+}
+.cycle-type-badge.error {
+  background: rgba(248, 81, 73, 0.15);
+  color: var(--red);
+}
+.cycle-type-badge.triage_only {
+  background: rgba(210, 153, 34, 0.15);
+  color: var(--yellow);
+}
 
 .cycle-run-meta {
   display: flex;
@@ -1515,7 +1619,9 @@ select:focus,
   display: block;
   margin-bottom: 4px;
 }
-.cycle-run-jira:hover { text-decoration: underline; }
+.cycle-run-jira:hover {
+  text-decoration: underline;
+}
 .cycle-run-summary {
   font-size: 12px;
   color: var(--text-secondary);
@@ -1538,7 +1644,9 @@ select:focus,
 }
 
 /* Transcript viewer */
-.transcript-load { padding: 12px 0; }
+.transcript-load {
+  padding: 12px 0;
+}
 .btn-load-transcript {
   background: var(--accent);
   color: #fff;
@@ -1548,22 +1656,34 @@ select:focus,
   cursor: pointer;
   font-size: 13px;
 }
-.btn-load-transcript:hover { opacity: 0.9; }
-.transcript-loading, .transcript-error {
+.btn-load-transcript:hover {
+  opacity: 0.9;
+}
+.transcript-loading,
+.transcript-error {
   padding: 12px;
   font-size: 13px;
   color: var(--text-dim);
 }
-.transcript-error { color: #f85149; }
+.transcript-error {
+  color: #f85149;
+}
 
-.transcript-viewer { margin-top: 8px; border-radius: 6px; overflow: hidden; }
+.transcript-viewer {
+  margin-top: 8px;
+  border-radius: 6px;
+  overflow: hidden;
+}
 .transcript-controls {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
 }
-.transcript-count { font-size: 12px; color: var(--text-dim); }
+.transcript-count {
+  font-size: 12px;
+  color: var(--text-dim);
+}
 .btn-toggle-raw {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
@@ -1573,7 +1693,11 @@ select:focus,
   cursor: pointer;
   font-size: 12px;
 }
-.btn-toggle-raw.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn-toggle-raw.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
 
 .input-prompt-content {
   background: #0d1520;
@@ -1605,17 +1729,28 @@ select:focus,
   margin-top: 0;
 }
 
-.transcript-messages { max-height: 600px; overflow-y: auto; }
+.transcript-messages {
+  max-height: 600px;
+  overflow-y: auto;
+}
 .transcript-line {
   border-left: 3px solid var(--border);
   padding: 6px 10px;
   margin-bottom: 4px;
   font-size: 12px;
 }
-.transcript-line.role-assistant { border-left-color: var(--accent); }
-.transcript-line.role-user { border-left-color: #3fb950; }
-.transcript-line.role-tool { border-left-color: #6e7681; }
-.transcript-line.role-system { border-left-color: #d29922; }
+.transcript-line.role-assistant {
+  border-left-color: var(--accent);
+}
+.transcript-line.role-user {
+  border-left-color: #3fb950;
+}
+.transcript-line.role-tool {
+  border-left-color: #6e7681;
+}
+.transcript-line.role-system {
+  border-left-color: #d29922;
+}
 
 .transcript-line-header {
   display: flex;
@@ -1656,9 +1791,11 @@ select:focus,
   color: var(--text);
   padding: 4px 0;
 }
-.transcript-line-md p { margin: 4px 0; }
+.transcript-line-md p {
+  margin: 4px 0;
+}
 .transcript-line-md code {
-  background: rgba(110,118,129,0.2);
+  background: rgba(110, 118, 129, 0.2);
   padding: 1px 4px;
   border-radius: 3px;
   font-size: 12px;
@@ -1675,15 +1812,20 @@ select:focus,
   background: none;
   padding: 0;
 }
-.transcript-line-md ul, .transcript-line-md ol {
+.transcript-line-md ul,
+.transcript-line-md ol {
   padding-left: 20px;
   margin: 4px 0;
 }
-.transcript-line-md h1, .transcript-line-md h2, .transcript-line-md h3 {
+.transcript-line-md h1,
+.transcript-line-md h2,
+.transcript-line-md h3 {
   font-size: 14px;
   margin: 8px 0 4px;
 }
-.transcript-line-md a { color: var(--accent); }
+.transcript-line-md a {
+  color: var(--accent);
+}
 .transcript-buttons {
   display: flex;
   gap: 4px;
@@ -1703,10 +1845,19 @@ select:focus,
   overflow-y: auto;
   padding: 20px 40px;
 }
-.detail-fullscreen .detail-body { max-width: 1200px; margin: 0 auto; }
-.detail-fullscreen .transcript-messages { max-height: none; }
-.detail-fullscreen .transcript-raw { max-height: none; }
-.detail-fullscreen .transcript-line-content { max-height: 600px; }
+.detail-fullscreen .detail-body {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+.detail-fullscreen .transcript-messages {
+  max-height: none;
+}
+.detail-fullscreen .transcript-raw {
+  max-height: none;
+}
+.detail-fullscreen .transcript-line-content {
+  max-height: 600px;
+}
 
 .detail-header-actions {
   display: flex;
@@ -1723,11 +1874,20 @@ select:focus,
   border-radius: 4px;
   line-height: 1;
 }
-.detail-expand:hover { color: var(--text); border-color: var(--text-dim); }
+.detail-expand:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
 
 /* Task group cards (cycle runs grouped by task) */
-.task-group-list { display: flex; flex-direction: column; gap: 4px; }
-.task-group-list > * { animation: fadeSlideIn 0.5s ease-out; }
+.task-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.task-group-list > * {
+  animation: fadeSlideIn 0.5s ease-out;
+}
 .task-group-card {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -1736,8 +1896,13 @@ select:focus,
   cursor: pointer;
   transition: border-color 0.15s;
 }
-.task-group-card:hover { border-color: var(--accent); }
-.task-group-card.expanded { border-color: var(--accent); background: var(--card-hover, rgba(88,166,255,0.05)); }
+.task-group-card:hover {
+  border-color: var(--accent);
+}
+.task-group-card.expanded {
+  border-color: var(--accent);
+  background: var(--card-hover, rgba(88, 166, 255, 0.05));
+}
 
 .task-group-header {
   display: flex;
@@ -1790,8 +1955,14 @@ select:focus,
   font-size: 12px;
   font-weight: 600;
 }
-.btn-download-zip:hover { color: var(--accent); border-color: var(--accent); }
-.btn-download-zip:disabled { opacity: 0.5; cursor: wait; }
+.btn-download-zip:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.btn-download-zip:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
 
 .btn-download-cycle {
   background: none;
@@ -1803,7 +1974,9 @@ select:focus,
   margin-left: auto;
   line-height: 1;
 }
-.btn-download-cycle:hover { color: var(--accent); }
+.btn-download-cycle:hover {
+  color: var(--accent);
+}
 
 .transcript-search {
   background: var(--bg);
@@ -1815,7 +1988,10 @@ select:focus,
   outline: none;
   width: 160px;
 }
-.transcript-search:focus { border-color: var(--accent); width: 220px; }
+.transcript-search:focus {
+  border-color: var(--accent);
+  width: 220px;
+}
 .search-highlight {
   background: rgba(210, 153, 34, 0.4);
   color: var(--text);

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,41 +1,56 @@
-import { lazy, Suspense, useEffect, useState, useCallback } from 'react';
-
-import { HashRouter, Routes, Route, NavLink, Navigate, useParams, useNavigate, useLocation, Link } from 'react-router-dom';
-import { WSProvider, useWS } from './hooks/useWebSocket';
-import type { BotInstance } from './types';
-import { fetchStats, fetchInstances } from './api';
-import { effectiveState } from './utils';
 import {
-  Nav,
-  NavList,
-  NavItem,
+  Label,
   Masthead,
   MastheadMain,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
-  ToolbarGroup,
-  Label,
   MenuToggle,
   MenuToggleElement,
+  Nav,
+  NavItem,
+  NavList,
   Select,
   SelectList,
-  SelectOption
-} from '@patternfly/react-core';
-import BotBanner from './components/BotBanner';
-import ThemeSelector from './components/ThemeSelector';
-import Toasts from './components/Toasts';
+  SelectOption,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from "@patternfly/react-core";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import {
+  HashRouter,
+  Link,
+  Navigate,
+  NavLink,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import { fetchInstances, fetchStats } from "./api";
+import BotBanner from "./components/BotBanner";
+import ThemeSelector from "./components/ThemeSelector";
+import Toasts from "./components/Toasts";
+import { useWS, WSProvider } from "./hooks/useWebSocket";
+import type { BotInstance } from "./types";
+import { effectiveState } from "./utils";
 
-const Instances = lazy(() => import('./pages/Instances'));
-const Tasks = lazy(() => import('./pages/Tasks'));
-const Memories = lazy(() => import('./pages/Memories'));
-const Search = lazy(() => import('./pages/Search'));
-const Costs = lazy(() => import('./pages/Costs'));
-const EmbeddingMap = lazy(() => import('./pages/EmbeddingMap'));
-const ArchivedTasks = lazy(() => import('./pages/ArchivedTasks'));
-const CycleRuns = lazy(() => import('./pages/CycleRuns'));
+const Instances = lazy(() => import("./pages/Instances"));
+const Tasks = lazy(() => import("./pages/Tasks"));
+const Memories = lazy(() => import("./pages/Memories"));
+const Search = lazy(() => import("./pages/Search"));
+const Costs = lazy(() => import("./pages/Costs"));
+const EmbeddingMap = lazy(() => import("./pages/EmbeddingMap"));
+const ArchivedTasks = lazy(() => import("./pages/ArchivedTasks"));
+const CycleRuns = lazy(() => import("./pages/CycleRuns"));
 
-function InstanceSelector({ instances, currentId }: { instances: BotInstance[]; currentId?: string }) {
+function InstanceSelector({
+  instances,
+  currentId,
+}: {
+  instances: BotInstance[];
+  currentId?: string;
+}) {
   const navigate = useNavigate();
   const location = useLocation();
   const [isOpen, setIsOpen] = useState(false);
@@ -43,24 +58,24 @@ function InstanceSelector({ instances, currentId }: { instances: BotInstance[]; 
   const handleSelect = (_e: any, val: string | number | undefined) => {
     const value = String(val);
     setIsOpen(false);
-    if (value === '__global__') {
-      navigate('/tasks');
-    } else if (value === '__instances__') {
-      navigate('/instances');
+    if (value === "__global__") {
+      navigate("/tasks");
+    } else if (value === "__instances__") {
+      navigate("/instances");
     } else {
-      const subPath = location.pathname.match(/\/instances\/[^/]+\/(.*)/)?.[1] || 'tasks';
+      const subPath = location.pathname.match(/\/instances\/[^/]+\/(.*)/)?.[1] || "tasks";
       navigate(`/instances/${encodeURIComponent(value)}/${subPath}`);
     }
   };
 
   const currentLabel = currentId
-    ? instances.find(i => i.instance_id === currentId)?.instance_id || currentId
-    : 'All instances';
+    ? instances.find((i) => i.instance_id === currentId)?.instance_id || currentId
+    : "All instances";
 
   return (
     <Select
       isOpen={isOpen}
-      selected={currentId || '__global__'}
+      selected={currentId || "__global__"}
       onSelect={handleSelect}
       onOpenChange={setIsOpen}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
@@ -75,9 +90,9 @@ function InstanceSelector({ instances, currentId }: { instances: BotInstance[]; 
         {instances.map((inst) => {
           const state = effectiveState(inst);
           return (
-          <SelectOption key={inst.instance_id} value={inst.instance_id}>
-            {inst.instance_id} — {state.toUpperCase()}
-          </SelectOption>
+            <SelectOption key={inst.instance_id} value={inst.instance_id}>
+              {inst.instance_id} — {state.toUpperCase()}
+            </SelectOption>
           );
         })}
       </SelectList>
@@ -87,20 +102,34 @@ function InstanceSelector({ instances, currentId }: { instances: BotInstance[]; 
 
 function InstanceScoped() {
   const { id } = useParams<{ id: string }>();
-  const instanceId = decodeURIComponent(id || '');
+  const instanceId = decodeURIComponent(id || "");
   const base = `/instances/${encodeURIComponent(instanceId)}`;
 
   return (
     <>
       <Nav variant="horizontal" aria-label="Instance navigation">
         <NavList>
-          <NavItem><NavLink to={`${base}/tasks`}>Tasks</NavLink></NavItem>
-          <NavItem><NavLink to={`${base}/archived`}>Archive</NavLink></NavItem>
-          <NavItem><NavLink to={`${base}/memories`}>Memories</NavLink></NavItem>
-          <NavItem><NavLink to={`${base}/search`}>Search</NavLink></NavItem>
-          <NavItem><NavLink to={`${base}/cycles`}>Cycles</NavLink></NavItem>
-          <NavItem><NavLink to={`${base}/costs`}>Costs</NavLink></NavItem>
-          <NavItem><NavLink to={`${base}/viz`}>Viz</NavLink></NavItem>
+          <NavItem>
+            <NavLink to={`${base}/tasks`}>Tasks</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink to={`${base}/archived`}>Archive</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink to={`${base}/memories`}>Memories</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink to={`${base}/search`}>Search</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink to={`${base}/cycles`}>Cycles</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink to={`${base}/costs`}>Costs</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink to={`${base}/viz`}>Viz</NavLink>
+          </NavItem>
         </NavList>
       </Nav>
       <Suspense fallback={null}>
@@ -120,7 +149,10 @@ function InstanceScoped() {
 }
 
 function AppInner() {
-  const [stats, setStats] = useState<{ tasks: number; memories: number }>({ tasks: 0, memories: 0 });
+  const [stats, setStats] = useState<{ tasks: number; memories: number }>({
+    tasks: 0,
+    memories: 0,
+  });
   const [instances, setInstances] = useState<BotInstance[]>([]);
   const { connected, onEvent } = useWS();
   const location = useLocation();
@@ -132,7 +164,12 @@ function AppInner() {
   const loadStats = useCallback(async () => {
     try {
       const s = await fetchStats();
-      const taskTotal = s.tasks ? Object.values(s.tasks as Record<string, number>).reduce((a: number, b: number) => a + b, 0) : 0;
+      const taskTotal = s.tasks
+        ? Object.values(s.tasks as Record<string, number>).reduce(
+            (a: number, b: number) => a + b,
+            0,
+          )
+        : 0;
       setStats({ tasks: taskTotal, memories: s.memories?.total ?? 0 });
     } catch {
       // ignore
@@ -154,15 +191,15 @@ function AppInner() {
 
   useEffect(() => {
     const unsub = onEvent((event) => {
-      if (event.type === 'bot_status') {
+      if (event.type === "bot_status") {
         loadInstances();
       }
       if (
-        event.type === 'task_added' ||
-        event.type === 'task_removed' ||
-        event.type === 'task_archived' ||
-        event.type === 'memory_stored' ||
-        event.type === 'memory_deleted'
+        event.type === "task_added" ||
+        event.type === "task_removed" ||
+        event.type === "task_archived" ||
+        event.type === "memory_stored" ||
+        event.type === "memory_deleted"
       ) {
         loadStats();
         loadInstances();
@@ -175,18 +212,27 @@ function AppInner() {
     <>
       <Masthead>
         <MastheadMain style={{ flex: 1 }}>
-          <Toolbar style={{ width: '100%' }}>
+          <Toolbar style={{ width: "100%" }}>
             <ToolbarContent>
               <ToolbarItem>
-                <Link to="/instances" style={{ display: 'flex', alignItems: 'center', gap: '8px', textDecoration: 'none', color: 'inherit' }}>
+                <Link
+                  to="/instances"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    textDecoration: "none",
+                    color: "inherit",
+                  }}
+                >
                   <img src="/static/icon.png" alt="" className="header-icon" />
-                  <span style={{ fontSize: '1.25rem', fontWeight: 700 }}>Řehoř</span>
+                  <span style={{ fontSize: "1.25rem", fontWeight: 700 }}>Řehoř</span>
                 </Link>
               </ToolbarItem>
               <ToolbarItem>
                 <InstanceSelector instances={instances} currentId={currentInstanceId} />
               </ToolbarItem>
-              <ToolbarGroup align={{ default: 'alignEnd' }}>
+              <ToolbarGroup align={{ default: "alignEnd" }}>
                 <ToolbarItem>
                   <ThemeSelector />
                 </ToolbarItem>
@@ -197,7 +243,10 @@ function AppInner() {
                   <Label variant="outline">{stats.memories} memories</Label>
                 </ToolbarItem>
                 <ToolbarItem>
-                  <span className={`ws-dot ${connected ? 'connected' : ''}`} title={connected ? 'Connected' : 'Disconnected'} />
+                  <span
+                    className={`ws-dot ${connected ? "connected" : ""}`}
+                    title={connected ? "Connected" : "Disconnected"}
+                  />
                 </ToolbarItem>
               </ToolbarGroup>
             </ToolbarContent>
@@ -205,52 +254,67 @@ function AppInner() {
         </MastheadMain>
       </Masthead>
       <div className="app">
-
-      {currentInstance && (
-        <BotBanner status={{
-          state: currentInstance.state,
-          message: currentInstance.message,
-          external_key: currentInstance.external_key,
-          source_type: currentInstance.source_type,
-          source_url: currentInstance.source_url,
-          repo: currentInstance.repo,
-          instance_id: currentInstance.instance_id,
-          cycle_start: currentInstance.cycle_start,
-          updated_at: currentInstance.updated_at,
-        }} />
-      )}
-
-      <Toasts />
-
-      <main>
-        {!currentInstanceId && (
-          <Nav variant="horizontal" aria-label="Global navigation">
-            <NavList>
-              <NavItem><NavLink to="/tasks">Tasks</NavLink></NavItem>
-              <NavItem><NavLink to="/archived">Archive</NavLink></NavItem>
-              <NavItem><NavLink to="/cycles">Cycles</NavLink></NavItem>
-              <NavItem><NavLink to="/memories">Memories</NavLink></NavItem>
-              <NavItem><NavLink to="/search">Search</NavLink></NavItem>
-              <NavItem><NavLink to="/costs">Costs</NavLink></NavItem>
-              <NavItem><NavLink to="/viz">Viz</NavLink></NavItem>
-            </NavList>
-          </Nav>
+        {currentInstance && (
+          <BotBanner
+            status={{
+              state: currentInstance.state,
+              message: currentInstance.message,
+              external_key: currentInstance.external_key,
+              source_type: currentInstance.source_type,
+              source_url: currentInstance.source_url,
+              repo: currentInstance.repo,
+              instance_id: currentInstance.instance_id,
+              cycle_start: currentInstance.cycle_start,
+              updated_at: currentInstance.updated_at,
+            }}
+          />
         )}
-        <Suspense fallback={null}>
-          <Routes>
-            <Route path="/instances/:id/*" element={<InstanceScoped />} />
-            <Route path="/instances" element={<Instances />} />
-            <Route path="/tasks" element={<Tasks />} />
-            <Route path="/archived" element={<ArchivedTasks />} />
-            <Route path="/cycles" element={<CycleRuns />} />
-            <Route path="/memories" element={<Memories />} />
-            <Route path="/search" element={<Search />} />
-            <Route path="/costs" element={<Costs />} />
-            <Route path="/viz" element={<EmbeddingMap />} />
-            <Route path="/" element={<Navigate to="/instances" replace />} />
-          </Routes>
-        </Suspense>
-      </main>
+
+        <Toasts />
+
+        <main>
+          {!currentInstanceId && (
+            <Nav variant="horizontal" aria-label="Global navigation">
+              <NavList>
+                <NavItem>
+                  <NavLink to="/tasks">Tasks</NavLink>
+                </NavItem>
+                <NavItem>
+                  <NavLink to="/archived">Archive</NavLink>
+                </NavItem>
+                <NavItem>
+                  <NavLink to="/cycles">Cycles</NavLink>
+                </NavItem>
+                <NavItem>
+                  <NavLink to="/memories">Memories</NavLink>
+                </NavItem>
+                <NavItem>
+                  <NavLink to="/search">Search</NavLink>
+                </NavItem>
+                <NavItem>
+                  <NavLink to="/costs">Costs</NavLink>
+                </NavItem>
+                <NavItem>
+                  <NavLink to="/viz">Viz</NavLink>
+                </NavItem>
+              </NavList>
+            </Nav>
+          )}
+          <Suspense fallback={null}>
+            <Routes>
+              <Route path="/instances/:id/*" element={<InstanceScoped />} />
+              <Route path="/instances" element={<Instances />} />
+              <Route path="/tasks" element={<Tasks />} />
+              <Route path="/archived" element={<ArchivedTasks />} />
+              <Route path="/cycles" element={<CycleRuns />} />
+              <Route path="/memories" element={<Memories />} />
+              <Route path="/search" element={<Search />} />
+              <Route path="/costs" element={<Costs />} />
+              <Route path="/viz" element={<EmbeddingMap />} />
+              <Route path="/" element={<Navigate to="/instances" replace />} />
+            </Routes>
+          </Suspense>
+        </main>
       </div>
     </>
   );

--- a/dashboard/src/api.test.ts
+++ b/dashboard/src/api.test.ts
@@ -1,31 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  fetchStats,
-  fetchBotStatus,
-  fetchInstances,
-  fetchTasks,
-  deleteTask,
-  unarchiveTask,
-  pauseTask,
-  unpauseTask,
-  fetchMemories,
-  fetchMemory,
   deleteMemory,
-  searchMemories,
-  fetchTags,
-  fetchEmbeddings,
+  deleteTask,
+  fetchAnalytics,
+  fetchBotStatus,
   fetchCosts,
   fetchCycleRuns,
   fetchCycleRunsByTask,
   fetchCycleRunTranscript,
-  fetchAnalytics,
-} from './api';
+  fetchEmbeddings,
+  fetchInstances,
+  fetchMemories,
+  fetchMemory,
+  fetchStats,
+  fetchTags,
+  fetchTasks,
+  pauseTask,
+  searchMemories,
+  unarchiveTask,
+  unpauseTask,
+} from "./api";
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
 
 function jsonResponse(data: unknown) {
-  return { json: () => Promise.resolve(data), ok: true, text: () => Promise.resolve('') };
+  return { json: () => Promise.resolve(data), ok: true, text: () => Promise.resolve("") };
 }
 
 beforeEach(() => {
@@ -33,239 +33,256 @@ beforeEach(() => {
   mockFetch.mockResolvedValue(jsonResponse({}));
 });
 
-describe('fetchStats', () => {
-  it('calls /api/stats', async () => {
+describe("fetchStats", () => {
+  it("calls /api/stats", async () => {
     const data = { tasks: 5 };
     mockFetch.mockResolvedValue(jsonResponse(data));
     const result = await fetchStats();
-    expect(mockFetch).toHaveBeenCalledWith('/api/stats');
+    expect(mockFetch).toHaveBeenCalledWith("/api/stats");
     expect(result).toEqual(data);
   });
 });
 
-describe('fetchBotStatus', () => {
-  it('calls /api/bot-status', async () => {
-    const data = { state: 'idle' };
+describe("fetchBotStatus", () => {
+  it("calls /api/bot-status", async () => {
+    const data = { state: "idle" };
     mockFetch.mockResolvedValue(jsonResponse(data));
     const result = await fetchBotStatus();
-    expect(mockFetch).toHaveBeenCalledWith('/api/bot-status');
+    expect(mockFetch).toHaveBeenCalledWith("/api/bot-status");
     expect(result).toEqual(data);
   });
 });
 
-describe('fetchInstances', () => {
-  it('calls /api/instances', async () => {
-    const data = [{ instance_id: 'bot-1' }];
+describe("fetchInstances", () => {
+  it("calls /api/instances", async () => {
+    const data = [{ instance_id: "bot-1" }];
     mockFetch.mockResolvedValue(jsonResponse(data));
     const result = await fetchInstances();
-    expect(mockFetch).toHaveBeenCalledWith('/api/instances');
+    expect(mockFetch).toHaveBeenCalledWith("/api/instances");
     expect(result).toEqual(data);
   });
 });
 
-describe('fetchTasks', () => {
-  it('builds query with all params', async () => {
+describe("fetchTasks", () => {
+  it("builds query with all params", async () => {
     await fetchTasks({
-      status: 'in_progress',
-      exclude_status: 'archived',
-      instance_id: 'dev-bot',
+      status: "in_progress",
+      exclude_status: "archived",
+      instance_id: "dev-bot",
       limit: 50,
       offset: 10,
     });
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/tasks?status=in_progress&exclude_status=archived&instance_id=dev-bot&limit=50&offset=10',
+      "/api/tasks?status=in_progress&exclude_status=archived&instance_id=dev-bot&limit=50&offset=10",
     );
   });
 
-  it('uses default limit and offset', async () => {
+  it("uses default limit and offset", async () => {
     await fetchTasks({});
-    expect(mockFetch).toHaveBeenCalledWith('/api/tasks?limit=20&offset=0');
+    expect(mockFetch).toHaveBeenCalledWith("/api/tasks?limit=20&offset=0");
   });
 
-  it('includes only provided params', async () => {
-    await fetchTasks({ status: 'paused' });
-    expect(mockFetch).toHaveBeenCalledWith('/api/tasks?status=paused&limit=20&offset=0');
-  });
-});
-
-describe('deleteTask', () => {
-  it('sends DELETE with encoded key', async () => {
-    mockFetch.mockResolvedValue({ ok: true });
-    await deleteTask('RHCLOUD/001');
-    expect(mockFetch).toHaveBeenCalledWith('/api/tasks/RHCLOUD%2F001', { method: 'DELETE' });
+  it("includes only provided params", async () => {
+    await fetchTasks({ status: "paused" });
+    expect(mockFetch).toHaveBeenCalledWith("/api/tasks?status=paused&limit=20&offset=0");
   });
 });
 
-describe('unarchiveTask', () => {
-  it('sends POST to unarchive endpoint', async () => {
+describe("deleteTask", () => {
+  it("sends DELETE with encoded key", async () => {
     mockFetch.mockResolvedValue({ ok: true });
-    await unarchiveTask('RHCLOUD-100');
-    expect(mockFetch).toHaveBeenCalledWith('/api/tasks/RHCLOUD-100/unarchive', { method: 'POST' });
+    await deleteTask("RHCLOUD/001");
+    expect(mockFetch).toHaveBeenCalledWith("/api/tasks/RHCLOUD%2F001", { method: "DELETE" });
   });
 });
 
-describe('pauseTask', () => {
-  it('sends POST with paused_reason body', async () => {
+describe("unarchiveTask", () => {
+  it("sends POST to unarchive endpoint", async () => {
     mockFetch.mockResolvedValue({ ok: true });
-    await pauseTask('RHCLOUD-200', 'blocked');
-    expect(mockFetch).toHaveBeenCalledWith('/api/tasks/RHCLOUD-200/pause', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ paused_reason: 'blocked' }),
+    await unarchiveTask("RHCLOUD-100");
+    expect(mockFetch).toHaveBeenCalledWith("/api/tasks/RHCLOUD-100/unarchive", { method: "POST" });
+  });
+});
+
+describe("pauseTask", () => {
+  it("sends POST with paused_reason body", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    await pauseTask("RHCLOUD-200", "blocked");
+    expect(mockFetch).toHaveBeenCalledWith("/api/tasks/RHCLOUD-200/pause", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ paused_reason: "blocked" }),
     });
   });
 
-  it('omits paused_reason when not provided', async () => {
+  it("omits paused_reason when not provided", async () => {
     mockFetch.mockResolvedValue({ ok: true });
-    await pauseTask('RHCLOUD-200');
-    expect(mockFetch).toHaveBeenCalledWith('/api/tasks/RHCLOUD-200/pause', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    await pauseTask("RHCLOUD-200");
+    expect(mockFetch).toHaveBeenCalledWith("/api/tasks/RHCLOUD-200/pause", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ paused_reason: undefined }),
     });
   });
 });
 
-describe('unpauseTask', () => {
-  it('sends POST to unpause endpoint', async () => {
+describe("unpauseTask", () => {
+  it("sends POST to unpause endpoint", async () => {
     mockFetch.mockResolvedValue({ ok: true });
-    await unpauseTask('RHCLOUD-300');
-    expect(mockFetch).toHaveBeenCalledWith('/api/tasks/RHCLOUD-300/unpause', { method: 'POST' });
+    await unpauseTask("RHCLOUD-300");
+    expect(mockFetch).toHaveBeenCalledWith("/api/tasks/RHCLOUD-300/unpause", { method: "POST" });
   });
 });
 
-describe('fetchMemories', () => {
-  it('builds query with filters and defaults', async () => {
-    await fetchMemories({ category: 'pattern', repo: 'org/repo', tag: 'auth', limit: 10, offset: 5 });
+describe("fetchMemories", () => {
+  it("builds query with filters and defaults", async () => {
+    await fetchMemories({
+      category: "pattern",
+      repo: "org/repo",
+      tag: "auth",
+      limit: 10,
+      offset: 5,
+    });
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/memories?category=pattern&repo=org%2Frepo&tag=auth&limit=10&offset=5',
+      "/api/memories?category=pattern&repo=org%2Frepo&tag=auth&limit=10&offset=5",
     );
   });
 
-  it('uses default limit and offset', async () => {
+  it("uses default limit and offset", async () => {
     await fetchMemories({});
-    expect(mockFetch).toHaveBeenCalledWith('/api/memories?limit=20&offset=0');
+    expect(mockFetch).toHaveBeenCalledWith("/api/memories?limit=20&offset=0");
   });
 });
 
-describe('fetchMemory', () => {
-  it('calls memory by id', async () => {
+describe("fetchMemory", () => {
+  it("calls memory by id", async () => {
     await fetchMemory(42);
-    expect(mockFetch).toHaveBeenCalledWith('/api/memories/42');
+    expect(mockFetch).toHaveBeenCalledWith("/api/memories/42");
   });
 });
 
-describe('deleteMemory', () => {
-  it('sends DELETE', async () => {
+describe("deleteMemory", () => {
+  it("sends DELETE", async () => {
     mockFetch.mockResolvedValue({ ok: true });
     await deleteMemory(7);
-    expect(mockFetch).toHaveBeenCalledWith('/api/memories/7', { method: 'DELETE' });
+    expect(mockFetch).toHaveBeenCalledWith("/api/memories/7", { method: "DELETE" });
   });
 });
 
-describe('searchMemories', () => {
-  it('builds search query with required q param', async () => {
-    await searchMemories('login bug');
-    expect(mockFetch).toHaveBeenCalledWith('/api/memories/search?q=login+bug');
+describe("searchMemories", () => {
+  it("builds search query with required q param", async () => {
+    await searchMemories("login bug");
+    expect(mockFetch).toHaveBeenCalledWith("/api/memories/search?q=login+bug");
   });
 
-  it('includes optional params', async () => {
-    await searchMemories('auth', { category: 'pattern', repo: 'org/repo', tag: 'security', limit: 5 });
+  it("includes optional params", async () => {
+    await searchMemories("auth", {
+      category: "pattern",
+      repo: "org/repo",
+      tag: "security",
+      limit: 5,
+    });
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/memories/search?q=auth&category=pattern&repo=org%2Frepo&tag=security&limit=5',
+      "/api/memories/search?q=auth&category=pattern&repo=org%2Frepo&tag=security&limit=5",
     );
   });
 });
 
-describe('fetchTags', () => {
-  it('calls /api/tags', async () => {
+describe("fetchTags", () => {
+  it("calls /api/tags", async () => {
     await fetchTags();
-    expect(mockFetch).toHaveBeenCalledWith('/api/tags');
+    expect(mockFetch).toHaveBeenCalledWith("/api/tags");
   });
 });
 
-describe('fetchEmbeddings', () => {
-  it('calls /api/memories/embeddings', async () => {
+describe("fetchEmbeddings", () => {
+  it("calls /api/memories/embeddings", async () => {
     await fetchEmbeddings();
-    expect(mockFetch).toHaveBeenCalledWith('/api/memories/embeddings');
+    expect(mockFetch).toHaveBeenCalledWith("/api/memories/embeddings");
   });
 });
 
-describe('fetchCosts', () => {
-  it('uses days param when no date range', async () => {
+describe("fetchCosts", () => {
+  it("uses days param when no date range", async () => {
     await fetchCosts(14, 100);
-    expect(mockFetch).toHaveBeenCalledWith('/api/costs?limit=100&days=14');
+    expect(mockFetch).toHaveBeenCalledWith("/api/costs?limit=100&days=14");
   });
 
-  it('uses from/to when date range provided', async () => {
-    await fetchCosts(30, 200, '2025-01-01', '2025-01-31');
-    expect(mockFetch).toHaveBeenCalledWith('/api/costs?limit=200&from=2025-01-01&to=2025-01-31');
+  it("uses from/to when date range provided", async () => {
+    await fetchCosts(30, 200, "2025-01-01", "2025-01-31");
+    expect(mockFetch).toHaveBeenCalledWith("/api/costs?limit=200&from=2025-01-01&to=2025-01-31");
   });
 
-  it('uses default days and limit', async () => {
+  it("uses default days and limit", async () => {
     await fetchCosts();
-    expect(mockFetch).toHaveBeenCalledWith('/api/costs?limit=200&days=30');
+    expect(mockFetch).toHaveBeenCalledWith("/api/costs?limit=200&days=30");
   });
 });
 
-describe('fetchCycleRuns', () => {
-  it('builds query with all params', async () => {
-    await fetchCycleRuns({ task_id: 42, instance_id: 'dev-bot', cycle_type: 'task_work', limit: 10, offset: 5 });
+describe("fetchCycleRuns", () => {
+  it("builds query with all params", async () => {
+    await fetchCycleRuns({
+      task_id: 42,
+      instance_id: "dev-bot",
+      cycle_type: "task_work",
+      limit: 10,
+      offset: 5,
+    });
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/cycle-runs?task_id=42&instance_id=dev-bot&cycle_type=task_work&limit=10&offset=5',
+      "/api/cycle-runs?task_id=42&instance_id=dev-bot&cycle_type=task_work&limit=10&offset=5",
     );
   });
 
-  it('supports task_id none', async () => {
-    await fetchCycleRuns({ task_id: 'none' });
-    expect(mockFetch).toHaveBeenCalledWith('/api/cycle-runs?task_id=none&limit=50&offset=0');
+  it("supports task_id none", async () => {
+    await fetchCycleRuns({ task_id: "none" });
+    expect(mockFetch).toHaveBeenCalledWith("/api/cycle-runs?task_id=none&limit=50&offset=0");
   });
 
-  it('uses defaults', async () => {
+  it("uses defaults", async () => {
     await fetchCycleRuns({});
-    expect(mockFetch).toHaveBeenCalledWith('/api/cycle-runs?limit=50&offset=0');
+    expect(mockFetch).toHaveBeenCalledWith("/api/cycle-runs?limit=50&offset=0");
   });
 });
 
-describe('fetchCycleRunsByTask', () => {
-  it('includes instance_id when provided', async () => {
-    await fetchCycleRunsByTask({ instance_id: 'dev-bot' });
-    expect(mockFetch).toHaveBeenCalledWith('/api/cycle-runs/by-task?instance_id=dev-bot');
+describe("fetchCycleRunsByTask", () => {
+  it("includes instance_id when provided", async () => {
+    await fetchCycleRunsByTask({ instance_id: "dev-bot" });
+    expect(mockFetch).toHaveBeenCalledWith("/api/cycle-runs/by-task?instance_id=dev-bot");
   });
 
-  it('calls without params', async () => {
+  it("calls without params", async () => {
     await fetchCycleRunsByTask({});
-    expect(mockFetch).toHaveBeenCalledWith('/api/cycle-runs/by-task?');
+    expect(mockFetch).toHaveBeenCalledWith("/api/cycle-runs/by-task?");
   });
 });
 
-describe('fetchCycleRunTranscript', () => {
-  it('returns text on success', async () => {
-    mockFetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('line1\nline2') });
+describe("fetchCycleRunTranscript", () => {
+  it("returns text on success", async () => {
+    mockFetch.mockResolvedValue({ ok: true, text: () => Promise.resolve("line1\nline2") });
     const result = await fetchCycleRunTranscript(99);
-    expect(mockFetch).toHaveBeenCalledWith('/api/cycle-runs/99/transcript?decompress=true');
-    expect(result).toBe('line1\nline2');
+    expect(mockFetch).toHaveBeenCalledWith("/api/cycle-runs/99/transcript?decompress=true");
+    expect(result).toBe("line1\nline2");
   });
 
-  it('throws on failure', async () => {
+  it("throws on failure", async () => {
     mockFetch.mockResolvedValue({ ok: false, status: 404 });
-    await expect(fetchCycleRunTranscript(99)).rejects.toThrow('Failed to fetch transcript: 404');
+    await expect(fetchCycleRunTranscript(99)).rejects.toThrow("Failed to fetch transcript: 404");
   });
 });
 
-describe('fetchAnalytics', () => {
-  it('uses days param when no date range', async () => {
+describe("fetchAnalytics", () => {
+  it("uses days param when no date range", async () => {
     await fetchAnalytics(7);
-    expect(mockFetch).toHaveBeenCalledWith('/api/analytics?days=7');
+    expect(mockFetch).toHaveBeenCalledWith("/api/analytics?days=7");
   });
 
-  it('uses from/to when date range provided', async () => {
-    await fetchAnalytics(30, '2025-06-01', '2025-06-30');
-    expect(mockFetch).toHaveBeenCalledWith('/api/analytics?from=2025-06-01&to=2025-06-30');
+  it("uses from/to when date range provided", async () => {
+    await fetchAnalytics(30, "2025-06-01", "2025-06-30");
+    expect(mockFetch).toHaveBeenCalledWith("/api/analytics?from=2025-06-01&to=2025-06-30");
   });
 
-  it('uses default days', async () => {
+  it("uses default days", async () => {
     await fetchAnalytics();
-    expect(mockFetch).toHaveBeenCalledWith('/api/analytics?days=30');
+    expect(mockFetch).toHaveBeenCalledWith("/api/analytics?days=30");
   });
 });

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -1,105 +1,132 @@
-import type { BotInstance } from './types';
+import type { BotInstance } from "./types";
 
 export async function fetchStats() {
-  return (await fetch('/api/stats')).json();
+  return (await fetch("/api/stats")).json();
 }
 
 export async function fetchBotStatus() {
-  return (await fetch('/api/bot-status')).json();
+  return (await fetch("/api/bot-status")).json();
 }
 
 export async function fetchInstances(): Promise<BotInstance[]> {
-  return (await fetch('/api/instances')).json();
+  return (await fetch("/api/instances")).json();
 }
 
-export async function fetchTasks(params: { status?: string; exclude_status?: string; limit?: number; offset?: number; instance_id?: string }) {
+export async function fetchTasks(params: {
+  status?: string;
+  exclude_status?: string;
+  limit?: number;
+  offset?: number;
+  instance_id?: string;
+}) {
   const qs = new URLSearchParams();
-  if (params.status) qs.set('status', params.status);
-  if (params.exclude_status) qs.set('exclude_status', params.exclude_status);
-  if (params.instance_id) qs.set('instance_id', params.instance_id);
-  qs.set('limit', String(params.limit ?? 20));
-  qs.set('offset', String(params.offset ?? 0));
-  return (await fetch('/api/tasks?' + qs)).json();
+  if (params.status) qs.set("status", params.status);
+  if (params.exclude_status) qs.set("exclude_status", params.exclude_status);
+  if (params.instance_id) qs.set("instance_id", params.instance_id);
+  qs.set("limit", String(params.limit ?? 20));
+  qs.set("offset", String(params.offset ?? 0));
+  return (await fetch("/api/tasks?" + qs)).json();
 }
 
 export async function deleteTask(key: string) {
-  return fetch('/api/tasks/' + encodeURIComponent(key), { method: 'DELETE' });
+  return fetch("/api/tasks/" + encodeURIComponent(key), { method: "DELETE" });
 }
 
 export async function unarchiveTask(key: string) {
-  return fetch('/api/tasks/' + encodeURIComponent(key) + '/unarchive', { method: 'POST' });
+  return fetch("/api/tasks/" + encodeURIComponent(key) + "/unarchive", { method: "POST" });
 }
 
 export async function pauseTask(key: string, pausedReason?: string) {
-  return fetch('/api/tasks/' + encodeURIComponent(key) + '/pause', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  return fetch("/api/tasks/" + encodeURIComponent(key) + "/pause", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ paused_reason: pausedReason || undefined }),
   });
 }
 
 export async function unpauseTask(key: string) {
-  return fetch('/api/tasks/' + encodeURIComponent(key) + '/unpause', { method: 'POST' });
+  return fetch("/api/tasks/" + encodeURIComponent(key) + "/unpause", { method: "POST" });
 }
 
-export async function fetchMemories(params: { category?: string; repo?: string; tag?: string; limit?: number; offset?: number }) {
+export async function fetchMemories(params: {
+  category?: string;
+  repo?: string;
+  tag?: string;
+  limit?: number;
+  offset?: number;
+}) {
   const qs = new URLSearchParams();
-  if (params.category) qs.set('category', params.category);
-  if (params.repo) qs.set('repo', params.repo);
-  if (params.tag) qs.set('tag', params.tag);
-  qs.set('limit', String(params.limit ?? 20));
-  qs.set('offset', String(params.offset ?? 0));
-  return (await fetch('/api/memories?' + qs)).json();
+  if (params.category) qs.set("category", params.category);
+  if (params.repo) qs.set("repo", params.repo);
+  if (params.tag) qs.set("tag", params.tag);
+  qs.set("limit", String(params.limit ?? 20));
+  qs.set("offset", String(params.offset ?? 0));
+  return (await fetch("/api/memories?" + qs)).json();
 }
 
 export async function fetchMemory(id: number) {
-  return (await fetch('/api/memories/' + id)).json();
+  return (await fetch("/api/memories/" + id)).json();
 }
 
 export async function deleteMemory(id: number) {
-  return fetch('/api/memories/' + id, { method: 'DELETE' });
+  return fetch("/api/memories/" + id, { method: "DELETE" });
 }
 
-export async function searchMemories(query: string, params?: { category?: string; repo?: string; tag?: string; limit?: number }) {
+export async function searchMemories(
+  query: string,
+  params?: { category?: string; repo?: string; tag?: string; limit?: number },
+) {
   const qs = new URLSearchParams({ q: query });
-  if (params?.category) qs.set('category', params.category);
-  if (params?.repo) qs.set('repo', params.repo);
-  if (params?.tag) qs.set('tag', params.tag);
-  if (params?.limit) qs.set('limit', String(params.limit));
-  return (await fetch('/api/memories/search?' + qs)).json();
+  if (params?.category) qs.set("category", params.category);
+  if (params?.repo) qs.set("repo", params.repo);
+  if (params?.tag) qs.set("tag", params.tag);
+  if (params?.limit) qs.set("limit", String(params.limit));
+  return (await fetch("/api/memories/search?" + qs)).json();
 }
 
 export async function fetchTags() {
-  return (await fetch('/api/tags')).json();
+  return (await fetch("/api/tags")).json();
 }
 
 export async function fetchEmbeddings() {
-  return (await fetch('/api/memories/embeddings')).json();
+  return (await fetch("/api/memories/embeddings")).json();
 }
 
-export async function fetchCosts(days = 30, limit = 200, dateFrom?: string, dateTo?: string, instanceId?: string) {
+export async function fetchCosts(
+  days = 30,
+  limit = 200,
+  dateFrom?: string,
+  dateTo?: string,
+  instanceId?: string,
+) {
   const qs = new URLSearchParams({ limit: String(limit) });
-  if (dateFrom) qs.set('from', dateFrom);
-  if (dateTo) qs.set('to', dateTo);
-  if (!dateFrom && !dateTo) qs.set('days', String(days));
-  if (instanceId) qs.set('instance_id', instanceId);
+  if (dateFrom) qs.set("from", dateFrom);
+  if (dateTo) qs.set("to", dateTo);
+  if (!dateFrom && !dateTo) qs.set("days", String(days));
+  if (instanceId) qs.set("instance_id", instanceId);
   return (await fetch(`/api/costs?${qs}`)).json();
 }
 
-export async function fetchCycleRuns(params: { task_id?: number | 'none'; instance_id?: string; cycle_type?: string; limit?: number; offset?: number }) {
+export async function fetchCycleRuns(params: {
+  task_id?: number | "none";
+  instance_id?: string;
+  cycle_type?: string;
+  limit?: number;
+  offset?: number;
+}) {
   const qs = new URLSearchParams();
-  if (params.task_id != null) qs.set('task_id', String(params.task_id));
-  if (params.instance_id) qs.set('instance_id', params.instance_id);
-  if (params.cycle_type) qs.set('cycle_type', params.cycle_type);
-  qs.set('limit', String(params.limit ?? 50));
-  qs.set('offset', String(params.offset ?? 0));
-  return (await fetch('/api/cycle-runs?' + qs)).json();
+  if (params.task_id != null) qs.set("task_id", String(params.task_id));
+  if (params.instance_id) qs.set("instance_id", params.instance_id);
+  if (params.cycle_type) qs.set("cycle_type", params.cycle_type);
+  qs.set("limit", String(params.limit ?? 50));
+  qs.set("offset", String(params.offset ?? 0));
+  return (await fetch("/api/cycle-runs?" + qs)).json();
 }
 
 export async function fetchCycleRunsByTask(params: { instance_id?: string }) {
   const qs = new URLSearchParams();
-  if (params.instance_id) qs.set('instance_id', params.instance_id);
-  return (await fetch('/api/cycle-runs/by-task?' + qs)).json();
+  if (params.instance_id) qs.set("instance_id", params.instance_id);
+  return (await fetch("/api/cycle-runs/by-task?" + qs)).json();
 }
 
 export async function fetchCycleRunTranscript(id: number): Promise<string> {
@@ -108,11 +135,16 @@ export async function fetchCycleRunTranscript(id: number): Promise<string> {
   return res.text();
 }
 
-export async function fetchAnalytics(days = 30, dateFrom?: string, dateTo?: string, instanceId?: string) {
+export async function fetchAnalytics(
+  days = 30,
+  dateFrom?: string,
+  dateTo?: string,
+  instanceId?: string,
+) {
   const qs = new URLSearchParams();
-  if (dateFrom) qs.set('from', dateFrom);
-  if (dateTo) qs.set('to', dateTo);
-  if (!dateFrom && !dateTo) qs.set('days', String(days));
-  if (instanceId) qs.set('instance_id', instanceId);
+  if (dateFrom) qs.set("from", dateFrom);
+  if (dateTo) qs.set("to", dateTo);
+  if (!dateFrom && !dateTo) qs.set("days", String(days));
+  if (instanceId) qs.set("instance_id", instanceId);
   return (await fetch(`/api/analytics?${qs}`)).json();
 }

--- a/dashboard/src/components/BotBanner.spec.ts
+++ b/dashboard/src/components/BotBanner.spec.ts
@@ -1,29 +1,29 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
-test.describe('BotBanner', () => {
-  test('renders idle state badge and message', async ({ mount }) => {
-    const root = await mount('BotBanner/Idle');
-    await expect(root.getByText('IDLE')).toBeVisible();
-    await expect(root.getByText('Waiting for tasks')).toBeVisible();
+test.describe("BotBanner", () => {
+  test("renders idle state badge and message", async ({ mount }) => {
+    const root = await mount("BotBanner/Idle");
+    await expect(root.getByText("IDLE")).toBeVisible();
+    await expect(root.getByText("Waiting for tasks")).toBeVisible();
   });
 
-  test('renders working state with task info', async ({ mount }) => {
-    const root = await mount('BotBanner/Working');
-    await expect(root.getByText('WORKING', { exact: true })).toBeVisible();
-    await expect(root.getByText('Working on RHCLOUD-100')).toBeVisible();
-    await expect(root.getByRole('link', { name: 'RHCLOUD-100' })).toBeVisible();
-    await expect(root.getByText('org/repo')).toBeVisible();
+  test("renders working state with task info", async ({ mount }) => {
+    const root = await mount("BotBanner/Working");
+    await expect(root.getByText("WORKING", { exact: true })).toBeVisible();
+    await expect(root.getByText("Working on RHCLOUD-100")).toBeVisible();
+    await expect(root.getByRole("link", { name: "RHCLOUD-100" })).toBeVisible();
+    await expect(root.getByText("org/repo")).toBeVisible();
   });
 
-  test('renders error state', async ({ mount }) => {
-    const root = await mount('BotBanner/Error');
-    await expect(root.getByText('ERROR')).toBeVisible();
-    await expect(root.getByText('Cycle failed')).toBeVisible();
+  test("renders error state", async ({ mount }) => {
+    const root = await mount("BotBanner/Error");
+    await expect(root.getByText("ERROR")).toBeVisible();
+    await expect(root.getByText("Cycle failed")).toBeVisible();
   });
 
-  test('renders sleep state when idle with stale updated_at', async ({ mount }) => {
-    const root = await mount('BotBanner/Sleep');
-    await expect(root.getByText('SLEEP', { exact: true })).toBeVisible();
+  test("renders sleep state when idle with stale updated_at", async ({ mount }) => {
+    const root = await mount("BotBanner/Sleep");
+    await expect(root.getByText("SLEEP", { exact: true })).toBeVisible();
     await expect(root.getByText("Bot hasn't checked in recently")).toBeVisible();
   });
 });

--- a/dashboard/src/components/BotBanner.tsx
+++ b/dashboard/src/components/BotBanner.tsx
@@ -1,27 +1,28 @@
-import { useEffect, useState } from 'react';
-import type { BotStatus } from '../types';
-import { timeAgo, sourceUrl, displayKey, effectiveState, stateLabelColor, stateIconStatus, stateBorderColor } from '../utils';
+import { Card, CardBody, Flex, FlexItem, Icon, Label } from "@patternfly/react-core";
+import { CircleIcon } from "@patternfly/react-icons";
+import { useEffect, useState } from "react";
+import type { BotStatus } from "../types";
 import {
-  Card,
-  CardBody,
-  Flex,
-  FlexItem,
-  Label,
-  Icon
-} from '@patternfly/react-core';
-import { CircleIcon } from '@patternfly/react-icons';
+  displayKey,
+  effectiveState,
+  sourceUrl,
+  stateBorderColor,
+  stateIconStatus,
+  stateLabelColor,
+  timeAgo,
+} from "../utils";
 
 interface Props {
   status: BotStatus;
 }
 
 export default function BotBanner({ status }: Props) {
-  const [elapsed, setElapsed] = useState('');
+  const [elapsed, setElapsed] = useState("");
   const state = effectiveState(status);
 
   useEffect(() => {
-    if (status.state !== 'working' || !status.cycle_start) {
-      setElapsed('');
+    if (status.state !== "working" || !status.cycle_start) {
+      setElapsed("");
       return;
     }
 
@@ -44,57 +45,106 @@ export default function BotBanner({ status }: Props) {
     return () => clearInterval(id);
   }, [status.state, status.cycle_start]);
 
-  const message = state === 'sleep' ? "Bot hasn't checked in recently" : status.message;
+  const message = state === "sleep" ? "Bot hasn't checked in recently" : status.message;
 
   return (
-    <Card isCompact isGlass style={{ borderLeft: `3px solid ${stateBorderColor(state)}`, marginBottom: '12px' }}>
+    <Card
+      isCompact
+      isGlass
+      style={{ borderLeft: `3px solid ${stateBorderColor(state)}`, marginBottom: "12px" }}
+    >
       <CardBody>
-      <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }} flexWrap={{ default: 'nowrap' }}>
-        <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ flex: 1, minWidth: 0 }}>
-          <FlexItem>
-            <Icon status={stateIconStatus(state)}>
-              <CircleIcon />
-            </Icon>
-          </FlexItem>
-          <FlexItem>
-            <Label color={stateLabelColor(state)}>
-              {state.toUpperCase()}
-            </Label>
-          </FlexItem>
-          <FlexItem style={{ minWidth: 0, flex: 1 }}>
-            <span style={{ color: 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', display: 'block' }}>{message}</span>
-          </FlexItem>
+        <Flex
+          alignItems={{ default: "alignItemsCenter" }}
+          justifyContent={{ default: "justifyContentSpaceBetween" }}
+          flexWrap={{ default: "nowrap" }}
+        >
+          <Flex
+            alignItems={{ default: "alignItemsCenter" }}
+            gap={{ default: "gapSm" }}
+            flexWrap={{ default: "nowrap" }}
+            style={{ flex: 1, minWidth: 0 }}
+          >
+            <FlexItem>
+              <Icon status={stateIconStatus(state)}>
+                <CircleIcon />
+              </Icon>
+            </FlexItem>
+            <FlexItem>
+              <Label color={stateLabelColor(state)}>{state.toUpperCase()}</Label>
+            </FlexItem>
+            <FlexItem style={{ minWidth: 0, flex: 1 }}>
+              <span
+                style={{
+                  color: "var(--text)",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  display: "block",
+                }}
+              >
+                {message}
+              </span>
+            </FlexItem>
+          </Flex>
+          <Flex
+            alignItems={{ default: "alignItemsCenter" }}
+            gap={{ default: "gapSm" }}
+            flexWrap={{ default: "nowrap" }}
+            style={{ flexShrink: 0 }}
+          >
+            {displayKey(status) && (
+              <FlexItem>
+                <Label color="blue" href={sourceUrl(status) || "#"}>
+                  {displayKey(status)}
+                </Label>
+              </FlexItem>
+            )}
+            {status.repo && (
+              <FlexItem>
+                <Label
+                  variant="outline"
+                  style={{
+                    maxWidth: "180px",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {status.repo}
+                </Label>
+              </FlexItem>
+            )}
+            {status.instance_id && (
+              <FlexItem>
+                <Label
+                  variant="outline"
+                  style={{
+                    maxWidth: "120px",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {status.instance_id}
+                </Label>
+              </FlexItem>
+            )}
+            {elapsed && (
+              <FlexItem>
+                <Label variant="outline">{elapsed}</Label>
+              </FlexItem>
+            )}
+            <FlexItem>
+              <span
+                style={{ color: "var(--text-dim)", fontSize: "12px" }}
+                title={status.updated_at}
+              >
+                {timeAgo(status.updated_at)}
+              </span>
+            </FlexItem>
+          </Flex>
         </Flex>
-        <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ flexShrink: 0 }}>
-          {displayKey(status) && (
-            <FlexItem>
-              <Label color="blue" href={sourceUrl(status) || '#'}>
-                {displayKey(status)}
-              </Label>
-            </FlexItem>
-          )}
-          {status.repo && (
-            <FlexItem>
-              <Label variant="outline" style={{ maxWidth: '180px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{status.repo}</Label>
-            </FlexItem>
-          )}
-          {status.instance_id && (
-            <FlexItem>
-              <Label variant="outline" style={{ maxWidth: '120px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{status.instance_id}</Label>
-            </FlexItem>
-          )}
-          {elapsed && (
-            <FlexItem>
-              <Label variant="outline">{elapsed}</Label>
-            </FlexItem>
-          )}
-          <FlexItem>
-            <span style={{ color: 'var(--text-dim)', fontSize: '12px' }} title={status.updated_at}>
-              {timeAgo(status.updated_at)}
-            </span>
-          </FlexItem>
-        </Flex>
-      </Flex>
       </CardBody>
     </Card>
   );

--- a/dashboard/src/components/ConfirmDialog.spec.ts
+++ b/dashboard/src/components/ConfirmDialog.spec.ts
@@ -1,44 +1,44 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
-test.describe('ConfirmDialog', () => {
-  test('renders title and message', async ({ mount, page }) => {
-    await mount('ConfirmDialog/Default');
-    await expect(page.getByText('Confirm Action')).toBeVisible();
-    await expect(page.getByText('Are you sure?')).toBeVisible();
+test.describe("ConfirmDialog", () => {
+  test("renders title and message", async ({ mount, page }) => {
+    await mount("ConfirmDialog/Default");
+    await expect(page.getByText("Confirm Action")).toBeVisible();
+    await expect(page.getByText("Are you sure?")).toBeVisible();
   });
 
-  test('calls onConfirm with undefined when no inputLabel', async ({ mount, page }) => {
-    await mount('ConfirmDialog/Default');
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    const val = await page.inputValue('#confirmed');
-    expect(val).toBe('__undefined__');
+  test("calls onConfirm with undefined when no inputLabel", async ({ mount, page }) => {
+    await mount("ConfirmDialog/Default");
+    await page.getByRole("button", { name: "Confirm" }).click();
+    const val = await page.inputValue("#confirmed");
+    expect(val).toBe("__undefined__");
   });
 
-  test('calls onConfirm with typed value when inputLabel provided', async ({ mount, page }) => {
-    await mount('ConfirmDialog/WithInput');
-    await page.getByPlaceholder('Enter reason').fill('needs more work');
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    const val = await page.inputValue('#confirmed');
-    expect(val).toBe('needs more work');
+  test("calls onConfirm with typed value when inputLabel provided", async ({ mount, page }) => {
+    await mount("ConfirmDialog/WithInput");
+    await page.getByPlaceholder("Enter reason").fill("needs more work");
+    await page.getByRole("button", { name: "Confirm" }).click();
+    const val = await page.inputValue("#confirmed");
+    expect(val).toBe("needs more work");
   });
 
-  test('calls onCancel when cancel clicked', async ({ mount, page }) => {
-    await mount('ConfirmDialog/Default');
-    await page.getByRole('button', { name: 'Cancel' }).click();
-    const val = await page.inputValue('#confirmed');
-    expect(val).toBe('__cancelled__');
+  test("calls onCancel when cancel clicked", async ({ mount, page }) => {
+    await mount("ConfirmDialog/Default");
+    await page.getByRole("button", { name: "Cancel" }).click();
+    const val = await page.inputValue("#confirmed");
+    expect(val).toBe("__cancelled__");
   });
 
-  test('confirm button uses danger variant when variant is danger', async ({ mount, page }) => {
-    await mount('ConfirmDialog/Danger');
-    const btn = page.getByRole('button', { name: 'Delete' });
+  test("confirm button uses danger variant when variant is danger", async ({ mount, page }) => {
+    await mount("ConfirmDialog/Danger");
+    const btn = page.getByRole("button", { name: "Delete" });
     await expect(btn).toBeVisible();
     await expect(btn).toHaveClass(/pf-m-danger/);
   });
 
-  test('confirm button uses primary variant when variant is default', async ({ mount, page }) => {
-    await mount('ConfirmDialog/Primary');
-    const btn = page.getByRole('button', { name: 'OK' });
+  test("confirm button uses primary variant when variant is default", async ({ mount, page }) => {
+    await mount("ConfirmDialog/Primary");
+    const btn = page.getByRole("button", { name: "OK" });
     await expect(btn).toBeVisible();
     await expect(btn).toHaveClass(/pf-m-primary/);
   });

--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react';
 import {
-  Modal,
-  ModalVariant,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
   Button,
   Content,
-  TextInput
-} from '@patternfly/react-core';
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  TextInput,
+} from "@patternfly/react-core";
+import { useState } from "react";
 
 interface Props {
   open: boolean;
@@ -16,7 +16,7 @@ interface Props {
   message: string;
   confirmLabel?: string;
   cancelLabel?: string;
-  variant?: 'default' | 'danger';
+  variant?: "default" | "danger";
   inputLabel?: string;
   inputPlaceholder?: string;
   onConfirm: (inputValue?: string) => void;
@@ -27,38 +27,33 @@ export default function ConfirmDialog({
   open,
   title,
   message,
-  confirmLabel = 'Confirm',
-  cancelLabel = 'Cancel',
-  variant = 'default',
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
   inputLabel,
   inputPlaceholder,
   onConfirm,
   onCancel,
 }: Props) {
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState("");
 
   const handleConfirm = () => {
     onConfirm(inputLabel ? inputValue : undefined);
-    setInputValue('');
+    setInputValue("");
   };
 
   const handleCancel = () => {
-    setInputValue('');
+    setInputValue("");
     onCancel();
   };
 
   return (
-    <Modal
-      variant={ModalVariant.small}
-      isOpen={open}
-      onClose={handleCancel}
-      aria-label={title}
-    >
+    <Modal variant={ModalVariant.small} isOpen={open} onClose={handleCancel} aria-label={title}>
       <ModalHeader title={title} />
       <ModalBody>
         <Content component="p">{message}</Content>
         {inputLabel && (
-          <div style={{ marginTop: '16px' }}>
+          <div style={{ marginTop: "16px" }}>
             <TextInput
               value={inputValue}
               onChange={(_e, val) => setInputValue(val)}
@@ -70,10 +65,7 @@ export default function ConfirmDialog({
         )}
       </ModalBody>
       <ModalFooter>
-        <Button
-          variant={variant === 'danger' ? 'danger' : 'primary'}
-          onClick={handleConfirm}
-        >
+        <Button variant={variant === "danger" ? "danger" : "primary"} onClick={handleConfirm}>
           {confirmLabel}
         </Button>
         <Button variant="secondary" onClick={handleCancel}>

--- a/dashboard/src/components/CycleRunCard.spec.ts
+++ b/dashboard/src/components/CycleRunCard.spec.ts
@@ -1,65 +1,65 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
-test.describe('CycleRunCard', () => {
-  test('renders cycle type label and id', async ({ mount }) => {
-    const root = await mount('CycleRunCard/Default');
-    await expect(root.getByText('Work')).toBeVisible();
-    await expect(root.getByText('#7')).toBeVisible();
+test.describe("CycleRunCard", () => {
+  test("renders cycle type label and id", async ({ mount }) => {
+    const root = await mount("CycleRunCard/Default");
+    await expect(root.getByText("Work")).toBeVisible();
+    await expect(root.getByText("#7")).toBeVisible();
   });
 
-  test('renders duration, tool calls, and tokens', async ({ mount }) => {
-    const root = await mount('CycleRunCard/WithDuration');
-    await expect(root.getByText('5m 0s')).toBeVisible();
-    await expect(root.getByText('8 tools')).toBeVisible();
-    await expect(root.getByText('2.5K tokens')).toBeVisible();
+  test("renders duration, tool calls, and tokens", async ({ mount }) => {
+    const root = await mount("CycleRunCard/WithDuration");
+    await expect(root.getByText("5m 0s")).toBeVisible();
+    await expect(root.getByText("8 tools")).toBeVisible();
+    await expect(root.getByText("2.5K tokens")).toBeVisible();
   });
 
-  test('omits duration when finished_at is null', async ({ mount }) => {
-    const root = await mount('CycleRunCard/NoFinished');
-    expect(await root.locator('.cycle-run-duration').count()).toBe(0);
-    await expect(root.getByText('3 tools')).toBeVisible();
+  test("omits duration when finished_at is null", async ({ mount }) => {
+    const root = await mount("CycleRunCard/NoFinished");
+    expect(await root.locator(".cycle-run-duration").count()).toBe(0);
+    await expect(root.getByText("3 tools")).toBeVisible();
   });
 
-  test('omits tool calls and tokens when null', async ({ mount }) => {
-    const root = await mount('CycleRunCard/NullStats');
-    expect(await root.locator('.cycle-run-tools').count()).toBe(0);
-    expect(await root.locator('.cycle-run-tokens').count()).toBe(0);
+  test("omits tool calls and tokens when null", async ({ mount }) => {
+    const root = await mount("CycleRunCard/NullStats");
+    expect(await root.locator(".cycle-run-tools").count()).toBe(0);
+    expect(await root.locator(".cycle-run-tokens").count()).toBe(0);
   });
 
-  test('renders external key from progress', async ({ mount }) => {
-    const root = await mount('CycleRunCard/WithProgress');
-    const link = root.getByRole('link', { name: 'RHCLOUD-100' });
-    await expect(link).toHaveAttribute('href', 'https://redhat.atlassian.net/browse/RHCLOUD-100');
+  test("renders external key from progress", async ({ mount }) => {
+    const root = await mount("CycleRunCard/WithProgress");
+    const link = root.getByRole("link", { name: "RHCLOUD-100" });
+    await expect(link).toHaveAttribute("href", "https://redhat.atlassian.net/browse/RHCLOUD-100");
   });
 
-  test('renders summary and last step from progress', async ({ mount }) => {
-    const root = await mount('CycleRunCard/WithSummary');
-    await expect(root.getByText('Implemented fix for login')).toBeVisible();
-    await expect(root.getByText('Step: run tests')).toBeVisible();
+  test("renders summary and last step from progress", async ({ mount }) => {
+    const root = await mount("CycleRunCard/WithSummary");
+    await expect(root.getByText("Implemented fix for login")).toBeVisible();
+    await expect(root.getByText("Step: run tests")).toBeVisible();
   });
 
-  test('renders instance_id when present', async ({ mount }) => {
-    const root = await mount('CycleRunCard/WithInstanceId');
-    await expect(root.getByText('prod-bot')).toBeVisible();
+  test("renders instance_id when present", async ({ mount }) => {
+    const root = await mount("CycleRunCard/WithInstanceId");
+    await expect(root.getByText("prod-bot")).toBeVisible();
   });
 
-  test('renders correctly when selected', async ({ mount }) => {
-    const root = await mount('CycleRunCard/Selected');
-    await expect(root.locator('.pf-v6-c-card')).toBeVisible();
+  test("renders correctly when selected", async ({ mount }) => {
+    const root = await mount("CycleRunCard/Selected");
+    await expect(root.locator(".pf-v6-c-card")).toBeVisible();
   });
 
-  test('calls onClick when card clicked', async ({ mount, page }) => {
-    const root = await mount('CycleRunCard/ClickHandling');
-    await root.locator('.pf-v6-c-card').click();
-    const clicked = await page.inputValue('#clicked');
-    expect(clicked).toBe('true');
+  test("calls onClick when card clicked", async ({ mount, page }) => {
+    const root = await mount("CycleRunCard/ClickHandling");
+    await root.locator(".pf-v6-c-card").click();
+    const clicked = await page.inputValue("#clicked");
+    expect(clicked).toBe("true");
   });
 
-  test('shows download button when has_transcript', async ({ mount, page }) => {
-    await page.route('**/api/cycle-runs/*/transcript', (route) => {
+  test("shows download button when has_transcript", async ({ mount, page }) => {
+    await page.route("**/api/cycle-runs/*/transcript", (route) => {
       route.fulfill({ body: '{"type":"text"}\n' });
     });
-    const root = await mount('CycleRunCard/WithTranscript');
-    await expect(root.getByTitle('Download transcript')).toBeVisible();
+    const root = await mount("CycleRunCard/WithTranscript");
+    await expect(root.getByTitle("Download transcript")).toBeVisible();
   });
 });

--- a/dashboard/src/components/CycleRunCard.tsx
+++ b/dashboard/src/components/CycleRunCard.tsx
@@ -1,19 +1,19 @@
-import type { CycleRun } from '../types';
-import { timeAgo, formatDuration, formatTokens, sourceUrl } from '../utils';
-import { fetchCycleRunTranscript } from '../api';
 import {
+  Button,
   Card,
+  CardBody,
   CardHeader,
   CardTitle,
-  CardBody,
+  Content,
   Flex,
   FlexItem,
   Label,
   LabelGroup,
-  Button,
-  Content
-} from '@patternfly/react-core';
-import { DownloadIcon } from '@patternfly/react-icons';
+} from "@patternfly/react-core";
+import { DownloadIcon } from "@patternfly/react-icons";
+import { fetchCycleRunTranscript } from "../api";
+import type { CycleRun } from "../types";
+import { formatDuration, formatTokens, sourceUrl, timeAgo } from "../utils";
 
 interface Props {
   run: CycleRun;
@@ -21,18 +21,18 @@ interface Props {
   onClick?: () => void;
 }
 
-const typeColors: Record<string, 'blue' | 'green' | 'orange' | 'grey' | 'red'> = {
-  task_work: 'blue',
-  triage_only: 'green',
-  idle: 'grey',
-  error: 'red',
+const typeColors: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
+  task_work: "blue",
+  triage_only: "green",
+  idle: "grey",
+  error: "red",
 };
 
 const typeLabels: Record<string, string> = {
-  task_work: 'Work',
-  triage_only: 'Triage',
-  idle: 'Idle',
-  error: 'Error',
+  task_work: "Work",
+  triage_only: "Triage",
+  idle: "Idle",
+  error: "Error",
 };
 
 export default function CycleRunCard({ run, selected, onClick }: Props) {
@@ -48,10 +48,10 @@ export default function CycleRunCard({ run, selected, onClick }: Props) {
     e.stopPropagation();
     try {
       const text = await fetchCycleRunTranscript(run.id);
-      const ts = run.started_at.replace(/[:.]/g, '-').slice(0, 19);
-      const blob = new Blob([text], { type: 'application/x-ndjson' });
+      const ts = run.started_at.replace(/[:.]/g, "-").slice(0, 19);
+      const blob = new Blob([text], { type: "application/x-ndjson" });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
       a.download = `cycle-${run.id}-${run.cycle_type}-${ts}.jsonl`;
       a.click();
@@ -62,29 +62,27 @@ export default function CycleRunCard({ run, selected, onClick }: Props) {
   };
 
   return (
-    <Card
-      isCompact
-      isGlass
-      isSelected={selected}
-      onClick={onClick}
-      style={{ cursor: 'pointer' }}
-    >
+    <Card isCompact isGlass isSelected={selected} onClick={onClick} style={{ cursor: "pointer" }}>
       <CardHeader
-        actions={{ actions: run.has_transcript ? (
-          <Button variant="plain" size="sm" onClick={handleDownload} title="Download transcript">
-            <DownloadIcon />
-          </Button>
-        ) : undefined }}
+        actions={{
+          actions: run.has_transcript ? (
+            <Button variant="plain" size="sm" onClick={handleDownload} title="Download transcript">
+              <DownloadIcon />
+            </Button>
+          ) : undefined,
+        }}
       >
         <CardTitle>
-          <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+          <Flex alignItems={{ default: "alignItemsCenter" }} gap={{ default: "gapSm" }}>
             <FlexItem>
-              <Label color={typeColors[run.cycle_type] || 'grey'}>
+              <Label color={typeColors[run.cycle_type] || "grey"}>
                 {typeLabels[run.cycle_type] || run.cycle_type}
               </Label>
             </FlexItem>
             <FlexItem>
-              <Content component="small" style={{ margin: 0 }}>#{run.id}</Content>
+              <Content component="small" style={{ margin: 0 }}>
+                #{run.id}
+              </Content>
             </FlexItem>
             <FlexItem>
               <Content component="small" style={{ margin: 0 }} title={run.started_at}>
@@ -95,18 +93,20 @@ export default function CycleRunCard({ run, selected, onClick }: Props) {
         </CardTitle>
       </CardHeader>
       <CardBody>
-        <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
           <FlexItem>
             <LabelGroup>
               {duration != null && <Label variant="outline">{formatDuration(duration)}</Label>}
               {run.tool_calls != null && <Label variant="outline">{run.tool_calls} tools</Label>}
-              {run.tokens_used != null && <Label variant="outline">{formatTokens(run.tokens_used)} tokens</Label>}
+              {run.tokens_used != null && (
+                <Label variant="outline">{formatTokens(run.tokens_used)} tokens</Label>
+              )}
             </LabelGroup>
           </FlexItem>
           {extKey && (
             <FlexItem>
               <span onClick={(e) => e.stopPropagation()}>
-                <Label color="blue" href={extUrl || '#'}>
+                <Label color="blue" href={extUrl || "#"}>
                   {extKey}
                 </Label>
               </span>
@@ -114,19 +114,26 @@ export default function CycleRunCard({ run, selected, onClick }: Props) {
           )}
           {progress.summary && (
             <FlexItem>
-              <Content component="p" style={{ margin: 0, color: 'var(--pf-t--global--text--color--subtle)' }}>
+              <Content
+                component="p"
+                style={{ margin: 0, color: "var(--pf-t--global--text--color--subtle)" }}
+              >
                 {String(progress.summary).slice(0, 120)}
               </Content>
             </FlexItem>
           )}
           {progress.last_step && (
             <FlexItem>
-              <Content component="small" style={{ margin: 0 }}>Step: {progress.last_step}</Content>
+              <Content component="small" style={{ margin: 0 }}>
+                Step: {progress.last_step}
+              </Content>
             </FlexItem>
           )}
           {run.instance_id && (
             <FlexItem>
-              <Label variant="outline" color="grey">{run.instance_id}</Label>
+              <Label variant="outline" color="grey">
+                {run.instance_id}
+              </Label>
             </FlexItem>
           )}
         </Flex>

--- a/dashboard/src/components/DetailPanel.spec.ts
+++ b/dashboard/src/components/DetailPanel.spec.ts
@@ -1,73 +1,73 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
-test.describe('DetailPanel — TaskDetail', () => {
-  test('shows Pause Task button when status is in_progress', async ({ mount }) => {
-    const root = await mount('DetailPanel/PauseVisible');
-    await expect(root.getByText('Pause Task')).toBeVisible();
+test.describe("DetailPanel — TaskDetail", () => {
+  test("shows Pause Task button when status is in_progress", async ({ mount }) => {
+    const root = await mount("DetailPanel/PauseVisible");
+    await expect(root.getByText("Pause Task")).toBeVisible();
   });
 
-  test('shows Pause Task button when status is pr_open', async ({ mount }) => {
-    const root = await mount('DetailPanel/PausePrOpen');
-    await expect(root.getByText('Pause Task')).toBeVisible();
+  test("shows Pause Task button when status is pr_open", async ({ mount }) => {
+    const root = await mount("DetailPanel/PausePrOpen");
+    await expect(root.getByText("Pause Task")).toBeVisible();
   });
 
-  test('shows Pause Task button when status is pr_changes', async ({ mount }) => {
-    const root = await mount('DetailPanel/PausePrChanges');
-    await expect(root.getByText('Pause Task')).toBeVisible();
+  test("shows Pause Task button when status is pr_changes", async ({ mount }) => {
+    const root = await mount("DetailPanel/PausePrChanges");
+    await expect(root.getByText("Pause Task")).toBeVisible();
   });
 
-  test('does NOT show Pause Task when status is paused', async ({ mount }) => {
-    const root = await mount('DetailPanel/PausedNoPause');
-    expect(await root.getByText('Pause Task').count()).toBe(0);
+  test("does NOT show Pause Task when status is paused", async ({ mount }) => {
+    const root = await mount("DetailPanel/PausedNoPause");
+    expect(await root.getByText("Pause Task").count()).toBe(0);
   });
 
-  test('does NOT show Pause Task when status is done', async ({ mount }) => {
-    const root = await mount('DetailPanel/DoneNoPause');
-    expect(await root.getByText('Pause Task').count()).toBe(0);
+  test("does NOT show Pause Task when status is done", async ({ mount }) => {
+    const root = await mount("DetailPanel/DoneNoPause");
+    expect(await root.getByText("Pause Task").count()).toBe(0);
   });
 
-  test('does NOT show Pause Task when onPause not provided', async ({ mount }) => {
-    const root = await mount('DetailPanel/NoPauseCallback');
-    expect(await root.getByText('Pause Task').count()).toBe(0);
+  test("does NOT show Pause Task when onPause not provided", async ({ mount }) => {
+    const root = await mount("DetailPanel/NoPauseCallback");
+    expect(await root.getByText("Pause Task").count()).toBe(0);
   });
 
-  test('shows Unpause Task button when status is paused', async ({ mount }) => {
-    const root = await mount('DetailPanel/UnpauseVisible');
-    await expect(root.getByText('Unpause Task')).toBeVisible();
+  test("shows Unpause Task button when status is paused", async ({ mount }) => {
+    const root = await mount("DetailPanel/UnpauseVisible");
+    await expect(root.getByText("Unpause Task")).toBeVisible();
   });
 
-  test('does NOT show Unpause Task when status is in_progress', async ({ mount }) => {
-    const root = await mount('DetailPanel/InProgressNoUnpause');
-    expect(await root.getByText('Unpause Task').count()).toBe(0);
+  test("does NOT show Unpause Task when status is in_progress", async ({ mount }) => {
+    const root = await mount("DetailPanel/InProgressNoUnpause");
+    expect(await root.getByText("Unpause Task").count()).toBe(0);
   });
 
-  test('shows Archive Task when status is not archived', async ({ mount }) => {
-    const root = await mount('DetailPanel/ArchiveVisible');
-    await expect(root.getByText('Archive Task')).toBeVisible();
+  test("shows Archive Task when status is not archived", async ({ mount }) => {
+    const root = await mount("DetailPanel/ArchiveVisible");
+    await expect(root.getByText("Archive Task")).toBeVisible();
   });
 
-  test('does NOT show Archive Task when status is archived', async ({ mount }) => {
-    const root = await mount('DetailPanel/ArchivedNoArchive');
-    expect(await root.getByText('Archive Task').count()).toBe(0);
+  test("does NOT show Archive Task when status is archived", async ({ mount }) => {
+    const root = await mount("DetailPanel/ArchivedNoArchive");
+    expect(await root.getByText("Archive Task").count()).toBe(0);
   });
 
-  test('shows paused_reason when set', async ({ mount }) => {
-    const root = await mount('DetailPanel/WithPausedReason');
-    await expect(root.getByText('Blocked by dependency')).toBeVisible();
-    await expect(root.getByText('Paused Reason')).toBeVisible();
+  test("shows paused_reason when set", async ({ mount }) => {
+    const root = await mount("DetailPanel/WithPausedReason");
+    await expect(root.getByText("Blocked by dependency")).toBeVisible();
+    await expect(root.getByText("Paused Reason")).toBeVisible();
   });
 
-  test('calls onPause with correct key', async ({ mount, page }) => {
-    const root = await mount('DetailPanel/PauseVisible');
-    await root.getByText('Pause Task').click();
-    const val = await page.inputValue('#action');
-    expect(val).toBe('pause:RHCLOUD-555');
+  test("calls onPause with correct key", async ({ mount, page }) => {
+    const root = await mount("DetailPanel/PauseVisible");
+    await root.getByText("Pause Task").click();
+    const val = await page.inputValue("#action");
+    expect(val).toBe("pause:RHCLOUD-555");
   });
 
-  test('calls onUnpause with correct key', async ({ mount, page }) => {
-    const root = await mount('DetailPanel/UnpauseVisible');
-    await root.getByText('Unpause Task').click();
-    const val = await page.inputValue('#action');
-    expect(val).toBe('unpause:RHCLOUD-777');
+  test("calls onUnpause with correct key", async ({ mount, page }) => {
+    const root = await mount("DetailPanel/UnpauseVisible");
+    await root.getByText("Unpause Task").click();
+    const val = await page.inputValue("#action");
+    expect(val).toBe("unpause:RHCLOUD-777");
   });
 });

--- a/dashboard/src/components/DetailPanel.tsx
+++ b/dashboard/src/components/DetailPanel.tsx
@@ -1,36 +1,36 @@
-import type { Task, Memory } from '../types';
-import { timeAgo, sourceUrl, displayKey } from '../utils';
 import {
+  Button,
   Card,
-  CardHeader,
-  CardTitle,
   CardBody,
   CardFooter,
-  Button,
-  Label,
-  LabelGroup,
-  Flex,
-  FlexItem,
+  CardHeader,
+  CardTitle,
+  CodeBlock,
+  CodeBlockCode,
   Content,
   DescriptionList,
+  DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  DescriptionListDescription,
   Divider,
-  CodeBlock,
-  CodeBlockCode
-} from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+} from "@patternfly/react-core";
+import { TimesIcon } from "@patternfly/react-icons";
+import type { Memory, Task } from "../types";
+import { displayKey, sourceUrl, timeAgo } from "../utils";
 
 interface MemoryDetailProps {
-  type: 'memory';
+  type: "memory";
   memory: Memory;
   onClose: () => void;
   onDelete: (id: number) => void;
 }
 
 interface TaskDetailProps {
-  type: 'task';
+  type: "task";
   task: Task;
   onClose: () => void;
   onDelete?: (key: string) => void;
@@ -41,45 +41,51 @@ interface TaskDetailProps {
 
 type Props = MemoryDetailProps | TaskDetailProps;
 
-const categoryColors: Record<string, 'green' | 'orange' | 'blue' | 'grey'> = {
-  learning: 'green',
-  review_feedback: 'orange',
-  codebase_pattern: 'blue',
+const categoryColors: Record<string, "green" | "orange" | "blue" | "grey"> = {
+  learning: "green",
+  review_feedback: "orange",
+  codebase_pattern: "blue",
 };
 
-const statusColors: Record<string, 'blue' | 'green' | 'orange' | 'red' | 'purple' | 'grey'> = {
-  in_progress: 'blue',
-  pr_open: 'green',
-  pr_changes: 'orange',
-  done: 'grey',
-  paused: 'purple',
-  archived: 'grey',
+const statusColors: Record<string, "blue" | "green" | "orange" | "red" | "purple" | "grey"> = {
+  in_progress: "blue",
+  pr_open: "green",
+  pr_changes: "orange",
+  done: "grey",
+  paused: "purple",
+  archived: "grey",
 };
 
 const statusLabels: Record<string, string> = {
-  in_progress: 'In Progress',
-  pr_open: 'PR Open',
-  pr_changes: 'Changes Requested',
-  done: 'Done',
-  paused: 'Paused',
-  archived: 'Archived',
+  in_progress: "In Progress",
+  pr_open: "PR Open",
+  pr_changes: "Changes Requested",
+  done: "Done",
+  paused: "Paused",
+  archived: "Archived",
 };
 
 export default function DetailPanel(props: Props) {
-  if (props.type === 'memory') {
+  if (props.type === "memory") {
     return <MemoryDetail {...props} />;
   }
   return <TaskDetail {...props} />;
 }
 
-function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, 'type'>) {
-  const badgeColor = categoryColors[memory.category] || 'green';
+function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, "type">) {
+  const badgeColor = categoryColors[memory.category] || "green";
   const prUrl = memory.metadata?.pr_url;
 
   return (
     <Card isGlass>
       <CardHeader
-        actions={{ actions: <Button variant="plain" onClick={onClose}><TimesIcon /></Button> }}
+        actions={{
+          actions: (
+            <Button variant="plain" onClick={onClose}>
+              <TimesIcon />
+            </Button>
+          ),
+        }}
       >
         <CardTitle>{memory.title}</CardTitle>
       </CardHeader>
@@ -88,13 +94,13 @@ function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, 'ty
           <CodeBlockCode>{memory.content}</CodeBlockCode>
         </CodeBlock>
 
-        <Divider style={{ margin: '16px 0' }} />
+        <Divider style={{ margin: "16px 0" }} />
 
         <DescriptionList isHorizontal isCompact>
           <DescriptionListGroup>
             <DescriptionListTerm>Category</DescriptionListTerm>
             <DescriptionListDescription>
-              <Label color={badgeColor}>{memory.category.replace(/_/g, ' ')}</Label>
+              <Label color={badgeColor}>{memory.category.replace(/_/g, " ")}</Label>
             </DescriptionListDescription>
           </DescriptionListGroup>
           {memory.repo && (
@@ -107,7 +113,7 @@ function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, 'ty
             <DescriptionListGroup>
               <DescriptionListTerm>Source</DescriptionListTerm>
               <DescriptionListDescription>
-                <a href={sourceUrl(memory) || '#'} target="_blank" rel="noopener noreferrer">
+                <a href={sourceUrl(memory) || "#"} target="_blank" rel="noopener noreferrer">
                   {displayKey(memory)}
                 </a>
               </DescriptionListDescription>
@@ -117,7 +123,9 @@ function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, 'ty
             <DescriptionListGroup>
               <DescriptionListTerm>PR</DescriptionListTerm>
               <DescriptionListDescription>
-                <a href={prUrl} target="_blank" rel="noopener noreferrer">{prUrl}</a>
+                <a href={prUrl} target="_blank" rel="noopener noreferrer">
+                  {prUrl}
+                </a>
               </DescriptionListDescription>
             </DescriptionListGroup>
           )}
@@ -143,10 +151,12 @@ function MemoryDetail({ memory, onClose, onDelete }: Omit<MemoryDetailProps, 'ty
 
         {memory.tags.length > 0 && (
           <>
-            <Divider style={{ margin: '16px 0' }} />
+            <Divider style={{ margin: "16px 0" }} />
             <LabelGroup categoryName="Tags">
               {memory.tags.map((t) => (
-                <Label key={t} variant="outline">{t}</Label>
+                <Label key={t} variant="outline">
+                  {t}
+                </Label>
               ))}
             </LabelGroup>
           </>
@@ -168,29 +178,34 @@ function TaskDetail({
   onUnarchive,
   onPause,
   onUnpause,
-}: Omit<TaskDetailProps, 'type'>) {
+}: Omit<TaskDetailProps, "type">) {
   const meta = task.metadata || {};
-  const prs: Array<{ repo: string; number: number; url: string; host: string }> =
-    meta.prs || [];
+  const prs: Array<{ repo: string; number: number; url: string; host: string }> = meta.prs || [];
   const repos: string[] = meta.repos || [task.repo];
   const key = displayKey(task);
   const url = sourceUrl(task);
   const artifacts = task.artifacts || [];
   const isActive =
-    task.status === 'in_progress' ||
-    task.status === 'pr_open' ||
-    task.status === 'pr_changes';
+    task.status === "in_progress" || task.status === "pr_open" || task.status === "pr_changes";
 
   return (
     <Card isGlass>
       <CardHeader
-        actions={{ actions: <Button variant="plain" onClick={onClose}><TimesIcon /></Button> }}
+        actions={{
+          actions: (
+            <Button variant="plain" onClick={onClose}>
+              <TimesIcon />
+            </Button>
+          ),
+        }}
       >
         <CardTitle>
-          <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+          <Flex alignItems={{ default: "alignItemsCenter" }} gap={{ default: "gapSm" }}>
             <FlexItem>
               {url ? (
-                <a href={url} target="_blank" rel="noopener noreferrer">{key}</a>
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                  {key}
+                </a>
               ) : (
                 <span>{key}</span>
               )}
@@ -208,18 +223,20 @@ function TaskDetail({
           <DescriptionListGroup>
             <DescriptionListTerm>Status</DescriptionListTerm>
             <DescriptionListDescription>
-              <Label color={statusColors[task.status] || 'grey'}>
+              <Label color={statusColors[task.status] || "grey"}>
                 {statusLabels[task.status] || task.status}
               </Label>
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Repo(s)</DescriptionListTerm>
-            <DescriptionListDescription>{repos.join(', ')}</DescriptionListDescription>
+            <DescriptionListDescription>{repos.join(", ")}</DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Branch</DescriptionListTerm>
-            <DescriptionListDescription><code>{task.branch}</code></DescriptionListDescription>
+            <DescriptionListDescription>
+              <code>{task.branch}</code>
+            </DescriptionListDescription>
           </DescriptionListGroup>
 
           {artifacts.length > 0 && (
@@ -228,7 +245,9 @@ function TaskDetail({
               <DescriptionListDescription>
                 {artifacts.map((a, i) => (
                   <div key={i}>
-                    <a href={a.url} target="_blank" rel="noopener noreferrer">{a.name}</a>
+                    <a href={a.url} target="_blank" rel="noopener noreferrer">
+                      {a.name}
+                    </a>
                     {a.type && <span> ({a.type})</span>}
                   </div>
                 ))}
@@ -269,7 +288,7 @@ function TaskDetail({
 
         {task.summary && (
           <>
-            <Divider style={{ margin: '16px 0' }} />
+            <Divider style={{ margin: "16px 0" }} />
             <Content component="h4">Summary</Content>
             <Content component="p">{task.summary}</Content>
           </>
@@ -277,7 +296,7 @@ function TaskDetail({
 
         {task.paused_reason && (
           <>
-            <Divider style={{ margin: '16px 0' }} />
+            <Divider style={{ margin: "16px 0" }} />
             <Content component="h4">Paused Reason</Content>
             <Content component="p">{task.paused_reason}</Content>
           </>
@@ -285,7 +304,7 @@ function TaskDetail({
 
         {meta.last_step && (
           <>
-            <Divider style={{ margin: '16px 0' }} />
+            <Divider style={{ margin: "16px 0" }} />
             <Content component="h4">Progress</Content>
             <DescriptionList isCompact>
               {meta.last_step && (
@@ -305,7 +324,9 @@ function TaskDetail({
                   <DescriptionListTerm>Files changed</DescriptionListTerm>
                   <DescriptionListDescription>
                     {meta.files_changed.map((f: string, i: number) => (
-                      <div key={i}><code>{f}</code></div>
+                      <div key={i}>
+                        <code>{f}</code>
+                      </div>
                     ))}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
@@ -328,7 +349,7 @@ function TaskDetail({
 
         {!meta.last_step && Object.keys(meta).length > 0 && (
           <>
-            <Divider style={{ margin: '16px 0' }} />
+            <Divider style={{ margin: "16px 0" }} />
             <Content component="h4">Metadata</Content>
             <CodeBlock>
               <CodeBlockCode>{JSON.stringify(meta, null, 2)}</CodeBlockCode>
@@ -337,8 +358,8 @@ function TaskDetail({
         )}
       </CardBody>
       <CardFooter>
-        <Flex gap={{ default: 'gapSm' }}>
-          {onUnpause && task.status === 'paused' && (
+        <Flex gap={{ default: "gapSm" }}>
+          {onUnpause && task.status === "paused" && (
             <FlexItem>
               <Button variant="primary" onClick={() => onUnpause(key)}>
                 Unpause Task
@@ -359,7 +380,7 @@ function TaskDetail({
               </Button>
             </FlexItem>
           )}
-          {onDelete && task.status !== 'archived' && (
+          {onDelete && task.status !== "archived" && (
             <FlexItem>
               <Button variant="danger" onClick={() => onDelete(key)}>
                 Archive Task

--- a/dashboard/src/components/MemoryCard.tsx
+++ b/dashboard/src/components/MemoryCard.tsx
@@ -1,15 +1,15 @@
-import type { Memory } from '../types';
-import { sourceUrl, displayKey } from '../utils';
 import {
   Card,
-  CardHeader,
-  CardTitle,
   CardBody,
   CardFooter,
+  CardHeader,
+  CardTitle,
+  Content,
   Label,
   LabelGroup,
-  Content
-} from '@patternfly/react-core';
+} from "@patternfly/react-core";
+import type { Memory } from "../types";
+import { displayKey, sourceUrl } from "../utils";
 
 interface Props {
   memory: Memory;
@@ -18,48 +18,46 @@ interface Props {
   onClick?: () => void;
 }
 
-const categoryColors: Record<string, 'green' | 'orange' | 'blue' | 'grey'> = {
-  learning: 'green',
-  review_feedback: 'orange',
-  codebase_pattern: 'blue',
+const categoryColors: Record<string, "green" | "orange" | "blue" | "grey"> = {
+  learning: "green",
+  review_feedback: "orange",
+  codebase_pattern: "blue",
 };
 
 export default function MemoryCard({ memory, selected, showSimilarity, onClick }: Props) {
-  const preview = memory.content.length > 150
-    ? memory.content.slice(0, 150) + '...'
-    : memory.content;
+  const preview =
+    memory.content.length > 150 ? memory.content.slice(0, 150) + "..." : memory.content;
 
-  const badgeColor = categoryColors[memory.category] || 'green';
+  const badgeColor = categoryColors[memory.category] || "green";
 
   return (
-    <Card
-      isCompact
-      isGlass
-      isSelected={selected}
-      onClick={onClick}
-      style={{ cursor: 'pointer' }}
-    >
+    <Card isCompact isGlass isSelected={selected} onClick={onClick} style={{ cursor: "pointer" }}>
       <CardHeader>
         <CardTitle>{memory.title}</CardTitle>
       </CardHeader>
       <CardBody>
-        <Content component="p" style={{ color: 'var(--pf-t--global--text--color--subtle)', margin: 0 }}>
+        <Content
+          component="p"
+          style={{ color: "var(--pf-t--global--text--color--subtle)", margin: 0 }}
+        >
           {preview}
         </Content>
       </CardBody>
       <CardFooter>
         <LabelGroup>
-          <Label color={badgeColor}>{memory.category.replace(/_/g, ' ')}</Label>
+          <Label color={badgeColor}>{memory.category.replace(/_/g, " ")}</Label>
           {memory.repo && <Label variant="outline">{memory.repo}</Label>}
           {displayKey(memory) && (
             <span onClick={(e) => e.stopPropagation()}>
-              <Label color="blue" href={sourceUrl(memory) || '#'}>
+              <Label color="blue" href={sourceUrl(memory) || "#"}>
                 {displayKey(memory)}
               </Label>
             </span>
           )}
           {memory.tags.map((t) => (
-            <Label key={t} variant="outline">{t}</Label>
+            <Label key={t} variant="outline">
+              {t}
+            </Label>
           ))}
           {showSimilarity && memory.similarity != null && (
             <Label color="blue">{(memory.similarity * 100).toFixed(0)}%</Label>

--- a/dashboard/src/components/Pagination.tsx
+++ b/dashboard/src/components/Pagination.tsx
@@ -1,4 +1,4 @@
-import { Pagination as PFPagination } from '@patternfly/react-core';
+import { Pagination as PFPagination } from "@patternfly/react-core";
 
 interface Props {
   total: number;
@@ -19,7 +19,7 @@ export default function Pagination({ total, limit, offset, onChange }: Props) {
       page={currentPage}
       onSetPage={(_e, page) => onChange((page - 1) * limit)}
       isCompact
-      style={{ marginTop: '16px' }}
+      style={{ marginTop: "16px" }}
     />
   );
 }

--- a/dashboard/src/components/TaskCard.spec.ts
+++ b/dashboard/src/components/TaskCard.spec.ts
@@ -1,63 +1,65 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
-test.describe('TaskCard', () => {
-  test('renders external key as link for jira source type', async ({ mount }) => {
-    const root = await mount('TaskCard/JiraLink');
-    const link = root.getByRole('link', { name: 'RHCLOUD-100' });
-    await expect(link).toHaveAttribute('href', /RHCLOUD-100/);
+test.describe("TaskCard", () => {
+  test("renders external key as link for jira source type", async ({ mount }) => {
+    const root = await mount("TaskCard/JiraLink");
+    const link = root.getByRole("link", { name: "RHCLOUD-100" });
+    await expect(link).toHaveAttribute("href", /RHCLOUD-100/);
   });
 
-  test('renders external key as span when github with no source_url', async ({ mount }) => {
-    const root = await mount('TaskCard/GitHubNoUrl');
-    const span = root.getByText('org/repo#42');
+  test("renders external key as span when github with no source_url", async ({ mount }) => {
+    const root = await mount("TaskCard/GitHubNoUrl");
+    const span = root.getByText("org/repo#42");
     await expect(span).toBeVisible();
   });
 
-  test('shows correct status label for in_progress', async ({ mount }) => {
-    const root = await mount('TaskCard/InProgress');
-    await expect(root.getByText('In Progress')).toBeVisible();
+  test("shows correct status label for in_progress", async ({ mount }) => {
+    const root = await mount("TaskCard/InProgress");
+    await expect(root.getByText("In Progress")).toBeVisible();
   });
 
-  test('shows correct status label for paused', async ({ mount }) => {
-    const root = await mount('TaskCard/Paused');
-    await expect(root.getByText('Paused')).toBeVisible();
+  test("shows correct status label for paused", async ({ mount }) => {
+    const root = await mount("TaskCard/Paused");
+    await expect(root.getByText("Paused")).toBeVisible();
   });
 
-  test('shows correct status label for pr_open', async ({ mount }) => {
-    const root = await mount('TaskCard/PrOpen');
-    await expect(root.getByText('PR Open')).toBeVisible();
+  test("shows correct status label for pr_open", async ({ mount }) => {
+    const root = await mount("TaskCard/PrOpen");
+    await expect(root.getByText("PR Open")).toBeVisible();
   });
 
-  test('shows paused_reason when present', async ({ mount }) => {
-    const root = await mount('TaskCard/Paused');
-    await expect(root.getByText('Waiting for review')).toBeVisible();
+  test("shows paused_reason when present", async ({ mount }) => {
+    const root = await mount("TaskCard/Paused");
+    await expect(root.getByText("Waiting for review")).toBeVisible();
   });
 
-  test('does not show paused_reason when null', async ({ mount }) => {
-    const root = await mount('TaskCard/NoPausedReason');
-    await expect(root.getByText('Waiting for review')).not.toBeVisible().catch(() => {});
-    expect(await root.getByText('Waiting for review').count()).toBe(0);
+  test("does not show paused_reason when null", async ({ mount }) => {
+    const root = await mount("TaskCard/NoPausedReason");
+    await expect(root.getByText("Waiting for review"))
+      .not.toBeVisible()
+      .catch(() => {});
+    expect(await root.getByText("Waiting for review").count()).toBe(0);
   });
 
-  test('renders card for github source type', async ({ mount }) => {
-    const root = await mount('TaskCard/GitHubWithUrl');
-    await expect(root.locator('.pf-v6-c-card')).toBeVisible();
+  test("renders card for github source type", async ({ mount }) => {
+    const root = await mount("TaskCard/GitHubWithUrl");
+    await expect(root.locator(".pf-v6-c-card")).toBeVisible();
   });
 
-  test('renders card for jira source type', async ({ mount }) => {
-    const root = await mount('TaskCard/JiraLink');
-    await expect(root.locator('.pf-v6-c-card')).toBeVisible();
+  test("renders card for jira source type", async ({ mount }) => {
+    const root = await mount("TaskCard/JiraLink");
+    await expect(root.locator(".pf-v6-c-card")).toBeVisible();
   });
 
-  test('calls onClick when card clicked', async ({ mount, page }) => {
-    const root = await mount('TaskCard/ClickHandling');
-    await root.locator('.pf-v6-c-card').click();
-    const clicked = await page.inputValue('#clicked');
-    expect(clicked).toBe('true');
+  test("calls onClick when card clicked", async ({ mount, page }) => {
+    const root = await mount("TaskCard/ClickHandling");
+    await root.locator(".pf-v6-c-card").click();
+    const clicked = await page.inputValue("#clicked");
+    expect(clicked).toBe("true");
   });
 
-  test('shows instance_id', async ({ mount }) => {
-    const root = await mount('TaskCard/WithInstanceId');
-    await expect(root.getByText('bot-42')).toBeVisible();
+  test("shows instance_id", async ({ mount }) => {
+    const root = await mount("TaskCard/WithInstanceId");
+    await expect(root.getByText("bot-42")).toBeVisible();
   });
 });

--- a/dashboard/src/components/TaskCard.tsx
+++ b/dashboard/src/components/TaskCard.tsx
@@ -1,18 +1,18 @@
-import type { Task } from '../types';
-import { timeAgo, sourceUrl, displayKey } from '../utils';
 import {
   Card,
   CardBody,
   CardHeader,
   CardTitle,
+  Content,
   Flex,
   FlexItem,
+  Icon,
   Label,
   LabelGroup,
-  Content,
-  Icon
-} from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+} from "@patternfly/react-core";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import type { Task } from "../types";
+import { displayKey, sourceUrl, timeAgo } from "../utils";
 
 interface Props {
   task: Task;
@@ -21,21 +21,21 @@ interface Props {
 }
 
 const statusLabels: Record<string, string> = {
-  in_progress: 'In Progress',
-  pr_open: 'PR Open',
-  pr_changes: 'Changes Requested',
-  done: 'Done',
-  paused: 'Paused',
-  archived: 'Archived',
+  in_progress: "In Progress",
+  pr_open: "PR Open",
+  pr_changes: "Changes Requested",
+  done: "Done",
+  paused: "Paused",
+  archived: "Archived",
 };
 
-const statusColors: Record<string, 'blue' | 'green' | 'orange' | 'red' | 'purple' | 'grey'> = {
-  in_progress: 'blue',
-  pr_open: 'green',
-  pr_changes: 'orange',
-  done: 'grey',
-  paused: 'purple',
-  archived: 'grey',
+const statusColors: Record<string, "blue" | "green" | "orange" | "red" | "purple" | "grey"> = {
+  in_progress: "blue",
+  pr_open: "green",
+  pr_changes: "orange",
+  done: "grey",
+  paused: "purple",
+  archived: "grey",
 };
 
 export default function TaskCard({ task, selected, onClick }: Props) {
@@ -49,14 +49,29 @@ export default function TaskCard({ task, selected, onClick }: Props) {
       isGlass
       isSelected={selected}
       onClick={onClick}
-      style={{ cursor: 'pointer', borderLeft: `3px solid ${task.status === 'in_progress' ? 'var(--accent)' : task.status === 'pr_changes' ? 'var(--yellow)' : task.status === 'pr_open' ? 'var(--green)' : task.status === 'paused' ? 'var(--purple)' : 'transparent'}` }}
+      style={{
+        cursor: "pointer",
+        borderLeft: `3px solid ${task.status === "in_progress" ? "var(--accent)" : task.status === "pr_changes" ? "var(--yellow)" : task.status === "pr_open" ? "var(--green)" : task.status === "paused" ? "var(--purple)" : "transparent"}`,
+      }}
     >
       <CardHeader
-        actions={{ actions: <Label color={statusColors[task.status] || 'grey'}>{statusLabels[task.status] || task.status}</Label> }}
+        actions={{
+          actions: (
+            <Label color={statusColors[task.status] || "grey"}>
+              {statusLabels[task.status] || task.status}
+            </Label>
+          ),
+        }}
       >
         <CardTitle>
           {url ? (
-            <a href={url} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()} style={{ fontWeight: 600 }}>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              style={{ fontWeight: 600 }}
+            >
               {key}
             </a>
           ) : (
@@ -65,10 +80,12 @@ export default function TaskCard({ task, selected, onClick }: Props) {
         </CardTitle>
       </CardHeader>
       <CardBody>
-        <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
           {task.title && (
             <FlexItem>
-              <Content component="p" style={{ margin: 0 }}>{task.title}</Content>
+              <Content component="p" style={{ margin: 0 }}>
+                {task.title}
+              </Content>
             </FlexItem>
           )}
           <FlexItem>
@@ -89,13 +106,20 @@ export default function TaskCard({ task, selected, onClick }: Props) {
           </FlexItem>
           {task.instance_id && (
             <FlexItem>
-              <Label variant="outline" color="grey">{task.instance_id}</Label>
+              <Label variant="outline" color="grey">
+                {task.instance_id}
+              </Label>
             </FlexItem>
           )}
           {task.paused_reason && (
             <FlexItem>
-              <Content component="p" style={{ margin: 0, color: 'var(--yellow)', fontSize: '13px' }}>
-                <Icon status="warning" size="sm"><ExclamationTriangleIcon /></Icon>{' '}
+              <Content
+                component="p"
+                style={{ margin: 0, color: "var(--yellow)", fontSize: "13px" }}
+              >
+                <Icon status="warning" size="sm">
+                  <ExclamationTriangleIcon />
+                </Icon>{" "}
                 {task.paused_reason}
               </Content>
             </FlexItem>
@@ -103,7 +127,8 @@ export default function TaskCard({ task, selected, onClick }: Props) {
           {task.slack_notification && (
             <FlexItem>
               <Label variant="outline" icon={<span>🔔</span>}>
-                {task.slack_notification.event_type.replace(/_/g, ' ')} · {timeAgo(task.slack_notification.sent_at)}
+                {task.slack_notification.event_type.replace(/_/g, " ")} ·{" "}
+                {timeAgo(task.slack_notification.sent_at)}
               </Label>
             </FlexItem>
           )}

--- a/dashboard/src/components/ThemeSelector.tsx
+++ b/dashboard/src/components/ThemeSelector.tsx
@@ -1,47 +1,60 @@
-import { useState, useCallback, useEffect } from 'react';
 import {
+  Content,
+  Divider,
   Dropdown,
   DropdownList,
   MenuToggle,
   MenuToggleElement,
   ToggleGroup,
   ToggleGroupItem,
-  Content,
-  Divider
-} from '@patternfly/react-core';
-import { SunIcon, MoonIcon, AdjustIcon } from '@patternfly/react-icons';
+} from "@patternfly/react-core";
+import { AdjustIcon, MoonIcon, SunIcon } from "@patternfly/react-icons";
+import { useCallback, useEffect, useState } from "react";
 
 export default function ThemeSelector() {
-  const [theme, setTheme] = useState<'default' | 'felt'>(() => (localStorage.getItem('pf-theme') as 'default' | 'felt') || 'default');
-  const [colorScheme, setColorScheme] = useState<'system' | 'light' | 'dark'>(() => (localStorage.getItem('pf-color-scheme') as 'system' | 'light' | 'dark') || 'dark');
-  const [contrastMode, setContrastMode] = useState<'system' | 'default' | 'high-contrast' | 'glass'>(() => (localStorage.getItem('pf-contrast-mode') as 'system' | 'default' | 'high-contrast' | 'glass') || 'default');
+  const [theme, setTheme] = useState<"default" | "felt">(
+    () => (localStorage.getItem("pf-theme") as "default" | "felt") || "default",
+  );
+  const [colorScheme, setColorScheme] = useState<"system" | "light" | "dark">(
+    () => (localStorage.getItem("pf-color-scheme") as "system" | "light" | "dark") || "dark",
+  );
+  const [contrastMode, setContrastMode] = useState<
+    "system" | "default" | "high-contrast" | "glass"
+  >(
+    () =>
+      (localStorage.getItem("pf-contrast-mode") as
+        | "system"
+        | "default"
+        | "high-contrast"
+        | "glass") || "default",
+  );
   const [isOpen, setIsOpen] = useState(false);
 
   const applyThemeClasses = useCallback((t: string, cs: string, cm: string) => {
     const root = document.documentElement;
 
-    root.classList.remove('pf-v6-theme-felt');
-    if (t === 'felt') root.classList.add('pf-v6-theme-felt');
+    root.classList.remove("pf-v6-theme-felt");
+    if (t === "felt") root.classList.add("pf-v6-theme-felt");
 
     let isDark: boolean;
-    if (cs === 'system') {
-      isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (cs === "system") {
+      isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
     } else {
-      isDark = cs === 'dark';
+      isDark = cs === "dark";
     }
-    root.setAttribute('data-theme', isDark ? 'dark' : 'light');
-    root.classList.toggle('pf-v6-theme-dark', isDark);
+    root.setAttribute("data-theme", isDark ? "dark" : "light");
+    root.classList.toggle("pf-v6-theme-dark", isDark);
 
-    root.classList.remove('pf-v6-theme-high-contrast', 'pf-v6-theme-glass');
-    if (cm === 'high-contrast') {
-      root.classList.add('pf-v6-theme-high-contrast');
-    } else if (cm === 'glass') {
-      root.classList.add('pf-v6-theme-glass');
-    } else if (cm === 'system') {
-      if (window.matchMedia('(prefers-contrast: more)').matches) {
-        root.classList.add('pf-v6-theme-high-contrast');
-      } else if (window.matchMedia('(prefers-reduced-transparency: reduce)').matches) {
-        root.classList.add('pf-v6-theme-high-contrast');
+    root.classList.remove("pf-v6-theme-high-contrast", "pf-v6-theme-glass");
+    if (cm === "high-contrast") {
+      root.classList.add("pf-v6-theme-high-contrast");
+    } else if (cm === "glass") {
+      root.classList.add("pf-v6-theme-glass");
+    } else if (cm === "system") {
+      if (window.matchMedia("(prefers-contrast: more)").matches) {
+        root.classList.add("pf-v6-theme-high-contrast");
+      } else if (window.matchMedia("(prefers-reduced-transparency: reduce)").matches) {
+        root.classList.add("pf-v6-theme-high-contrast");
       }
     }
   }, []);
@@ -51,28 +64,28 @@ export default function ThemeSelector() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (colorScheme !== 'system') return;
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = () => applyThemeClasses(theme, 'system', contrastMode);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
+    if (colorScheme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyThemeClasses(theme, "system", contrastMode);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
   }, [colorScheme, theme, contrastMode, applyThemeClasses]);
 
-  const handleThemeChange = (t: 'default' | 'felt') => {
+  const handleThemeChange = (t: "default" | "felt") => {
     setTheme(t);
-    localStorage.setItem('pf-theme', t);
+    localStorage.setItem("pf-theme", t);
     applyThemeClasses(t, colorScheme, contrastMode);
   };
 
-  const handleColorSchemeChange = (cs: 'system' | 'light' | 'dark') => {
+  const handleColorSchemeChange = (cs: "system" | "light" | "dark") => {
     setColorScheme(cs);
-    localStorage.setItem('pf-color-scheme', cs);
+    localStorage.setItem("pf-color-scheme", cs);
     applyThemeClasses(theme, cs, contrastMode);
   };
 
-  const handleContrastChange = (cm: 'system' | 'default' | 'high-contrast' | 'glass') => {
+  const handleContrastChange = (cm: "system" | "default" | "high-contrast" | "glass") => {
     setContrastMode(cm);
-    localStorage.setItem('pf-contrast-mode', cm);
+    localStorage.setItem("pf-contrast-mode", cm);
     applyThemeClasses(theme, colorScheme, cm);
   };
 
@@ -87,32 +100,80 @@ export default function ThemeSelector() {
           isExpanded={isOpen}
           variant="plain"
         >
-          {colorScheme === 'dark' ? <MoonIcon /> : colorScheme === 'system' ? <AdjustIcon /> : <SunIcon />}
+          {colorScheme === "dark" ? (
+            <MoonIcon />
+          ) : colorScheme === "system" ? (
+            <AdjustIcon />
+          ) : (
+            <SunIcon />
+          )}
         </MenuToggle>
       )}
-      popperProps={{ position: 'right' }}
+      popperProps={{ position: "right" }}
     >
       <DropdownList>
-        <div style={{ padding: '16px', minWidth: '280px' }}>
-          <Content component="h4" style={{ marginBottom: '8px' }}>Theme</Content>
+        <div style={{ padding: "16px", minWidth: "280px" }}>
+          <Content component="h4" style={{ marginBottom: "8px" }}>
+            Theme
+          </Content>
           <ToggleGroup aria-label="Theme">
-            <ToggleGroupItem text="Default" isSelected={theme === 'default'} onChange={() => handleThemeChange('default')} />
-            <ToggleGroupItem text="Project Felt" isSelected={theme === 'felt'} onChange={() => handleThemeChange('felt')} />
+            <ToggleGroupItem
+              text="Default"
+              isSelected={theme === "default"}
+              onChange={() => handleThemeChange("default")}
+            />
+            <ToggleGroupItem
+              text="Project Felt"
+              isSelected={theme === "felt"}
+              onChange={() => handleThemeChange("felt")}
+            />
           </ToggleGroup>
-          <Divider style={{ margin: '12px 0' }} />
-          <Content component="h4" style={{ marginBottom: '8px' }}>Color scheme</Content>
+          <Divider style={{ margin: "12px 0" }} />
+          <Content component="h4" style={{ marginBottom: "8px" }}>
+            Color scheme
+          </Content>
           <ToggleGroup aria-label="Color scheme">
-            <ToggleGroupItem text="System" isSelected={colorScheme === 'system'} onChange={() => handleColorSchemeChange('system')} />
-            <ToggleGroupItem text="Light" isSelected={colorScheme === 'light'} onChange={() => handleColorSchemeChange('light')} />
-            <ToggleGroupItem text="Dark" isSelected={colorScheme === 'dark'} onChange={() => handleColorSchemeChange('dark')} />
+            <ToggleGroupItem
+              text="System"
+              isSelected={colorScheme === "system"}
+              onChange={() => handleColorSchemeChange("system")}
+            />
+            <ToggleGroupItem
+              text="Light"
+              isSelected={colorScheme === "light"}
+              onChange={() => handleColorSchemeChange("light")}
+            />
+            <ToggleGroupItem
+              text="Dark"
+              isSelected={colorScheme === "dark"}
+              onChange={() => handleColorSchemeChange("dark")}
+            />
           </ToggleGroup>
-          <Divider style={{ margin: '12px 0' }} />
-          <Content component="h4" style={{ marginBottom: '8px' }}>Contrast mode</Content>
+          <Divider style={{ margin: "12px 0" }} />
+          <Content component="h4" style={{ marginBottom: "8px" }}>
+            Contrast mode
+          </Content>
           <ToggleGroup aria-label="Contrast mode">
-            <ToggleGroupItem text="System" isSelected={contrastMode === 'system'} onChange={() => handleContrastChange('system')} />
-            <ToggleGroupItem text="Default" isSelected={contrastMode === 'default'} onChange={() => handleContrastChange('default')} />
-            <ToggleGroupItem text="High contrast" isSelected={contrastMode === 'high-contrast'} onChange={() => handleContrastChange('high-contrast')} />
-            <ToggleGroupItem text="Glass" isSelected={contrastMode === 'glass'} onChange={() => handleContrastChange('glass')} />
+            <ToggleGroupItem
+              text="System"
+              isSelected={contrastMode === "system"}
+              onChange={() => handleContrastChange("system")}
+            />
+            <ToggleGroupItem
+              text="Default"
+              isSelected={contrastMode === "default"}
+              onChange={() => handleContrastChange("default")}
+            />
+            <ToggleGroupItem
+              text="High contrast"
+              isSelected={contrastMode === "high-contrast"}
+              onChange={() => handleContrastChange("high-contrast")}
+            />
+            <ToggleGroupItem
+              text="Glass"
+              isSelected={contrastMode === "glass"}
+              onChange={() => handleContrastChange("glass")}
+            />
           </ToggleGroup>
         </div>
       </DropdownList>

--- a/dashboard/src/components/Toasts.spec.ts
+++ b/dashboard/src/components/Toasts.spec.ts
@@ -1,71 +1,71 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
-async function waitForWSReady(page: import('@playwright/test').Page) {
+async function waitForWSReady(page: import("@playwright/test").Page) {
   await page.waitForFunction(() => (window as any).__wsListenerCount > 0);
 }
 
-test.describe('Toasts', () => {
-  test('renders nothing when no events', async ({ mount }) => {
-    const root = await mount('Toasts/Default');
-    expect(await root.locator('.pf-v6-c-alert').count()).toBe(0);
+test.describe("Toasts", () => {
+  test("renders nothing when no events", async ({ mount }) => {
+    const root = await mount("Toasts/Default");
+    expect(await root.locator(".pf-v6-c-alert").count()).toBe(0);
   });
 
-  test('renders toast for task_added event', async ({ mount, page }) => {
-    await mount('Toasts/Default');
+  test("renders toast for task_added event", async ({ mount, page }) => {
+    await mount("Toasts/Default");
     await waitForWSReady(page);
     await page.evaluate(() =>
       window.emitWSEvent!({
-        type: 'task_added',
-        data: { external_key: 'RHCLOUD-100', summary: 'New task' },
+        type: "task_added",
+        data: { external_key: "RHCLOUD-100", summary: "New task" },
         timestamp: Date.now(),
-      })
+      }),
     );
-    await expect(page.getByText('Task added')).toBeVisible();
-    await expect(page.getByText('RHCLOUD-100')).toBeVisible();
-    await expect(page.getByText('New task')).toBeVisible();
+    await expect(page.getByText("Task added")).toBeVisible();
+    await expect(page.getByText("RHCLOUD-100")).toBeVisible();
+    await expect(page.getByText("New task")).toBeVisible();
   });
 
-  test('renders toast for task_updated event', async ({ mount, page }) => {
-    await mount('Toasts/Default');
+  test("renders toast for task_updated event", async ({ mount, page }) => {
+    await mount("Toasts/Default");
     await waitForWSReady(page);
     await page.evaluate(() =>
       window.emitWSEvent!({
-        type: 'task_updated',
-        data: { external_key: 'RHCLOUD-200', status: 'in_progress' },
+        type: "task_updated",
+        data: { external_key: "RHCLOUD-200", status: "in_progress" },
         timestamp: Date.now(),
-      })
+      }),
     );
-    await expect(page.getByText('Task updated')).toBeVisible();
-    await expect(page.getByText('RHCLOUD-200')).toBeVisible();
-    await expect(page.getByText('in_progress')).toBeVisible();
+    await expect(page.getByText("Task updated")).toBeVisible();
+    await expect(page.getByText("RHCLOUD-200")).toBeVisible();
+    await expect(page.getByText("in_progress")).toBeVisible();
   });
 
-  test('renders toast for memory_stored event', async ({ mount, page }) => {
-    await mount('Toasts/Default');
+  test("renders toast for memory_stored event", async ({ mount, page }) => {
+    await mount("Toasts/Default");
     await waitForWSReady(page);
     await page.evaluate(() =>
       window.emitWSEvent!({
-        type: 'memory_stored',
-        data: { id: 42, category: 'pattern' },
+        type: "memory_stored",
+        data: { id: 42, category: "pattern" },
         timestamp: Date.now(),
-      })
+      }),
     );
-    await expect(page.getByText('Memory stored')).toBeVisible();
-    await expect(page.getByText('#42')).toBeVisible();
-    await expect(page.getByText('pattern')).toBeVisible();
+    await expect(page.getByText("Memory stored")).toBeVisible();
+    await expect(page.getByText("#42")).toBeVisible();
+    await expect(page.getByText("pattern")).toBeVisible();
   });
 
-  test('ignores bot_status events', async ({ mount, page }) => {
-    const root = await mount('Toasts/Default');
+  test("ignores bot_status events", async ({ mount, page }) => {
+    const root = await mount("Toasts/Default");
     await waitForWSReady(page);
     await page.evaluate(() =>
       window.emitWSEvent!({
-        type: 'bot_status',
-        data: { state: 'working' },
+        type: "bot_status",
+        data: { state: "working" },
         timestamp: Date.now(),
-      })
+      }),
     );
     await page.waitForTimeout(100);
-    expect(await root.locator('.pf-v6-c-alert').count()).toBe(0);
+    expect(await root.locator(".pf-v6-c-alert").count()).toBe(0);
   });
 });

--- a/dashboard/src/components/Toasts.tsx
+++ b/dashboard/src/components/Toasts.tsx
@@ -1,29 +1,27 @@
-import { useEffect, useState, useCallback } from 'react';
-import { useWS } from '../hooks/useWebSocket';
-import { timeAgo } from '../utils';
-import {
-  Alert,
-  AlertGroup,
-  AlertActionCloseButton,
-  AlertVariant
-} from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertGroup, AlertVariant } from "@patternfly/react-core";
+import { useCallback, useEffect, useState } from "react";
+import { useWS } from "../hooks/useWebSocket";
+import { timeAgo } from "../utils";
 
 interface Toast {
   id: number;
   label: string;
   detail: string;
   message: string;
-  variant: 'success' | 'warning' | 'danger' | 'info' | 'custom';
+  variant: "success" | "warning" | "danger" | "info" | "custom";
   timestamp: number;
 }
 
-const eventConfig: Record<string, { label: string; variant: 'success' | 'warning' | 'danger' | 'info' | 'custom' }> = {
-  task_added: { label: 'Task added', variant: 'success' },
-  task_updated: { label: 'Task updated', variant: 'warning' },
-  task_removed: { label: 'Task removed', variant: 'danger' },
-  task_archived: { label: 'Task archived', variant: 'info' },
-  memory_stored: { label: 'Memory stored', variant: 'custom' },
-  memory_deleted: { label: 'Memory deleted', variant: 'danger' },
+const eventConfig: Record<
+  string,
+  { label: string; variant: "success" | "warning" | "danger" | "info" | "custom" }
+> = {
+  task_added: { label: "Task added", variant: "success" },
+  task_updated: { label: "Task updated", variant: "warning" },
+  task_removed: { label: "Task removed", variant: "danger" },
+  task_archived: { label: "Task archived", variant: "info" },
+  memory_stored: { label: "Memory stored", variant: "custom" },
+  memory_deleted: { label: "Memory deleted", variant: "danger" },
 };
 
 let toastIdCounter = 0;
@@ -42,10 +40,8 @@ export default function Toasts() {
       if (!config) return;
 
       const data = event.data || {};
-      const detail =
-        data.external_key || data.title || (data.id ? `#${data.id}` : '');
-      const message =
-        data.summary || data.status || data.category || '';
+      const detail = data.external_key || data.title || (data.id ? `#${data.id}` : "");
+      const message = data.summary || data.status || data.category || "";
 
       const id = ++toastIdCounter;
       const toast: Toast = {
@@ -71,13 +67,13 @@ export default function Toasts() {
         <Alert
           key={toast.id}
           variant={toast.variant as AlertVariant}
-          title={`${toast.label}${toast.detail ? ` — ${toast.detail}` : ''}`}
+          title={`${toast.label}${toast.detail ? ` — ${toast.detail}` : ""}`}
           actionClose={<AlertActionCloseButton onClose={() => removeToast(toast.id)} />}
           timeout={8000}
           onTimeout={() => removeToast(toast.id)}
         >
           {toast.message && <p>{toast.message}</p>}
-          <p style={{ fontSize: '12px', color: 'var(--pf-t--global--text--color--subtle)' }}>
+          <p style={{ fontSize: "12px", color: "var(--pf-t--global--text--color--subtle)" }}>
             {timeAgo(new Date(toast.timestamp).toISOString())}
           </p>
         </Alert>

--- a/dashboard/src/e2e-globals.d.ts
+++ b/dashboard/src/e2e-globals.d.ts
@@ -1,4 +1,4 @@
-import type { WSEvent } from './types';
+import type { WSEvent } from "./types";
 
 declare global {
   interface Window {

--- a/dashboard/src/hooks/useWebSocket.tsx
+++ b/dashboard/src/hooks/useWebSocket.tsx
@@ -1,5 +1,13 @@
-import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
-import type { WSEvent } from '../types';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { WSEvent } from "../types";
 
 interface WSContextValue {
   connected: boolean;
@@ -21,7 +29,7 @@ export function WSProvider({ children }: { children: ReactNode }) {
   const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const connect = useCallback(() => {
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(`${proto}//${location.host}/ws`);
     wsRef.current = ws;
 
@@ -63,9 +71,7 @@ export function WSProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <WSContext.Provider value={{ connected, lastEvent, onEvent }}>
-      {children}
-    </WSContext.Provider>
+    <WSContext.Provider value={{ connected, lastEvent, onEvent }}>{children}</WSContext.Provider>
   );
 }
 

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,15 +1,15 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import '@patternfly/patternfly/patternfly.css';
-import '@patternfly/patternfly/patternfly-addons.css';
-import App from './App';
-import './App.css';
-import { applyStoredTheme } from './utils/applyStoredTheme';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@patternfly/patternfly/patternfly.css";
+import "@patternfly/patternfly/patternfly-addons.css";
+import App from "./App";
+import "./App.css";
+import { applyStoredTheme } from "./utils/applyStoredTheme";
 
 applyStoredTheme();
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 );

--- a/dashboard/src/pages/ArchivedTasks.spec.ts
+++ b/dashboard/src/pages/ArchivedTasks.spec.ts
@@ -1,87 +1,87 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
 function makeArchivedTask(overrides: Record<string, any> = {}) {
   return {
     id: 1,
-    external_key: 'RHCLOUD-001',
-    source_type: 'jira',
+    external_key: "RHCLOUD-001",
+    source_type: "jira",
     source_url: null,
     artifacts: [],
-    status: 'archived',
-    repo: 'frontend',
-    branch: 'main',
-    title: 'Fix login bug',
-    summary: 'Fix login bug',
-    created_at: '2026-07-01T10:00:00Z',
-    last_addressed: '2026-07-01T15:30:00Z',
+    status: "archived",
+    repo: "frontend",
+    branch: "main",
+    title: "Fix login bug",
+    summary: "Fix login bug",
+    created_at: "2026-07-01T10:00:00Z",
+    last_addressed: "2026-07-01T15:30:00Z",
     paused_reason: null,
-    instance_id: 'dev-bot',
+    instance_id: "dev-bot",
     metadata: {},
     slack_notification: null,
     ...overrides,
   };
 }
 
-test.describe('ArchivedTasks page', () => {
-  test('restore: opens dialog and calls unarchiveTask', async ({ mount, page }) => {
-    const task = makeArchivedTask({ id: 10, external_key: 'RHCLOUD-500', title: 'Restore me' });
+test.describe("ArchivedTasks page", () => {
+  test("restore: opens dialog and calls unarchiveTask", async ({ mount, page }) => {
+    const task = makeArchivedTask({ id: 10, external_key: "RHCLOUD-500", title: "Restore me" });
 
-    await page.route('**/api/tasks?*', (route) => {
+    await page.route("**/api/tasks?*", (route) => {
       route.fulfill({ json: { items: [task], total: 1 } });
     });
 
     let restoreCalled = false;
-    await page.route('**/api/tasks/RHCLOUD-500/unarchive', (route) => {
+    await page.route("**/api/tasks/RHCLOUD-500/unarchive", (route) => {
       restoreCalled = true;
       route.fulfill({ json: { unarchived: true } });
     });
 
-    await mount('ArchivedTasks/Default');
-    await page.getByText('Restore me').click();
-    await page.getByRole('button', { name: 'Restore Task' }).click();
-    await page.getByRole('button', { name: 'Restore' }).click();
+    await mount("ArchivedTasks/Default");
+    await page.getByText("Restore me").click();
+    await page.getByRole("button", { name: "Restore Task" }).click();
+    await page.getByRole("button", { name: "Restore" }).click();
     await page.waitForTimeout(200);
 
     expect(restoreCalled).toBe(true);
   });
 
-  test('shows error from JSON error response', async ({ mount, page }) => {
-    const task = makeArchivedTask({ id: 20, external_key: 'RHCLOUD-600', title: 'Error restore' });
+  test("shows error from JSON error response", async ({ mount, page }) => {
+    const task = makeArchivedTask({ id: 20, external_key: "RHCLOUD-600", title: "Error restore" });
 
-    await page.route('**/api/tasks?*', (route) => {
+    await page.route("**/api/tasks?*", (route) => {
       route.fulfill({ json: { items: [task], total: 1 } });
     });
-    await page.route('**/api/tasks/RHCLOUD-600/unarchive', (route) => {
+    await page.route("**/api/tasks/RHCLOUD-600/unarchive", (route) => {
       route.fulfill({
         status: 404,
-        contentType: 'application/json',
-        body: JSON.stringify({ error: 'Task RHCLOUD-600 not found or not archived' }),
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Task RHCLOUD-600 not found or not archived" }),
       });
     });
 
-    await mount('ArchivedTasks/Default');
-    await page.getByText('Error restore').click();
-    await page.getByRole('button', { name: 'Restore Task' }).click();
-    await page.getByRole('button', { name: 'Restore' }).click();
+    await mount("ArchivedTasks/Default");
+    await page.getByText("Error restore").click();
+    await page.getByRole("button", { name: "Restore Task" }).click();
+    await page.getByRole("button", { name: "Restore" }).click();
 
-    await expect(page.getByText('Task RHCLOUD-600 not found or not archived')).toBeVisible();
+    await expect(page.getByText("Task RHCLOUD-600 not found or not archived")).toBeVisible();
   });
 
-  test('shows fallback error for non-JSON response', async ({ mount, page }) => {
-    const task = makeArchivedTask({ id: 30, external_key: 'RHCLOUD-700', title: 'Fallback error' });
+  test("shows fallback error for non-JSON response", async ({ mount, page }) => {
+    const task = makeArchivedTask({ id: 30, external_key: "RHCLOUD-700", title: "Fallback error" });
 
-    await page.route('**/api/tasks?*', (route) => {
+    await page.route("**/api/tasks?*", (route) => {
       route.fulfill({ json: { items: [task], total: 1 } });
     });
-    await page.route('**/api/tasks/RHCLOUD-700/unarchive', (route) => {
-      route.fulfill({ status: 500, body: 'Internal Server Error' });
+    await page.route("**/api/tasks/RHCLOUD-700/unarchive", (route) => {
+      route.fulfill({ status: 500, body: "Internal Server Error" });
     });
 
-    await mount('ArchivedTasks/Default');
-    await page.getByText('Fallback error').click();
-    await page.getByRole('button', { name: 'Restore Task' }).click();
-    await page.getByRole('button', { name: 'Restore' }).click();
+    await mount("ArchivedTasks/Default");
+    await page.getByText("Fallback error").click();
+    await page.getByRole("button", { name: "Restore Task" }).click();
+    await page.getByRole("button", { name: "Restore" }).click();
 
-    await expect(page.getByText('Request failed (500)')).toBeVisible();
+    await expect(page.getByText("Request failed (500)")).toBeVisible();
   });
 });

--- a/dashboard/src/pages/ArchivedTasks.tsx
+++ b/dashboard/src/pages/ArchivedTasks.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useState, useCallback } from 'react';
-import type { Task } from '../types';
-import { fetchTasks, unarchiveTask } from '../api';
-import { useWS } from '../hooks/useWebSocket';
-import TaskCard from '../components/TaskCard';
-import DetailPanel from '../components/DetailPanel';
-import Pagination from '../components/Pagination';
-import { Label, Content } from '@patternfly/react-core';
-import ConfirmDialog from '../components/ConfirmDialog';
+import { Content, Label } from "@patternfly/react-core";
+import { useCallback, useEffect, useState } from "react";
+import { fetchTasks, unarchiveTask } from "../api";
+import ConfirmDialog from "../components/ConfirmDialog";
+import DetailPanel from "../components/DetailPanel";
+import Pagination from "../components/Pagination";
+import TaskCard from "../components/TaskCard";
+import { useWS } from "../hooks/useWebSocket";
+import type { Task } from "../types";
 
 const LIMIT = 20;
 
@@ -21,7 +21,12 @@ export default function ArchivedTasks({ instanceId }: { instanceId?: string }) {
   const { onEvent } = useWS();
 
   const load = useCallback(async () => {
-    const res = await fetchTasks({ status: 'archived', limit: LIMIT, offset, instance_id: instanceId });
+    const res = await fetchTasks({
+      status: "archived",
+      limit: LIMIT,
+      offset,
+      instance_id: instanceId,
+    });
     setTasks(res.items || []);
     setTotal(res.total || 0);
   }, [offset, instanceId]);
@@ -32,7 +37,11 @@ export default function ArchivedTasks({ instanceId }: { instanceId?: string }) {
 
   useEffect(() => {
     return onEvent((event) => {
-      if (event.type === 'task_added' || event.type === 'task_updated' || event.type === 'task_archived') {
+      if (
+        event.type === "task_added" ||
+        event.type === "task_updated" ||
+        event.type === "task_archived"
+      ) {
         load();
       }
     });
@@ -47,7 +56,9 @@ export default function ArchivedTasks({ instanceId }: { instanceId?: string }) {
       try {
         const body = await res.json();
         if (body?.error) msg = body.error;
-      } catch { /* ignore non-JSON */ }
+      } catch {
+        /* ignore non-JSON */
+      }
       setError(msg);
       return;
     }
@@ -58,12 +69,17 @@ export default function ArchivedTasks({ instanceId }: { instanceId?: string }) {
   return (
     <div className="split-layout">
       <div className="split-main">
-        <div style={{ marginBottom: '16px' }}>
-          <Label variant="outline">{total} archived task{total !== 1 ? 's' : ''}</Label>
+        <div style={{ marginBottom: "16px" }}>
+          <Label variant="outline">
+            {total} archived task{total !== 1 ? "s" : ""}
+          </Label>
         </div>
         <div className="card-grid">
           {tasks.length === 0 && (
-            <Content component="p" style={{ color: 'var(--pf-t--global--text--color--subtle, var(--text-dim))' }}>
+            <Content
+              component="p"
+              style={{ color: "var(--pf-t--global--text--color--subtle, var(--text-dim))" }}
+            >
               No archived tasks
             </Content>
           )}
@@ -99,7 +115,7 @@ export default function ArchivedTasks({ instanceId }: { instanceId?: string }) {
       <ConfirmDialog
         open={error !== null}
         title="Error"
-        message={error || ''}
+        message={error || ""}
         confirmLabel="OK"
         onConfirm={() => setError(null)}
         onCancel={() => setError(null)}

--- a/dashboard/src/pages/Costs.spec.ts
+++ b/dashboard/src/pages/Costs.spec.ts
@@ -1,33 +1,72 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
 const defaultAnalytics = {
   summary: {
-    total_cycles: 10, work_cycles: 7, idle_cycles: 3, error_cycles: 0,
-    unique_tickets: 5, total_cost: 12.5, avg_cost_per_work_cycle: 1.79,
-    avg_turns: 8, avg_duration_ms: 300000, repos_touched: 2, tickets_resolved: 5,
+    total_cycles: 10,
+    work_cycles: 7,
+    idle_cycles: 3,
+    error_cycles: 0,
+    unique_tickets: 5,
+    total_cost: 12.5,
+    avg_cost_per_work_cycle: 1.79,
+    avg_turns: 8,
+    avg_duration_ms: 300000,
+    repos_touched: 2,
+    tickets_resolved: 5,
   },
   work_types: [
-    { category: 'new_ticket', cycles: 4, total_cost: 7.0, avg_cost: 1.75, avg_turns: 10, avg_duration_ms: 400000 },
-    { category: 'pr_review', cycles: 2, total_cost: 3.0, avg_cost: 1.5, avg_turns: 6, avg_duration_ms: 200000 },
-    { category: 'follow_up', cycles: 1, total_cost: 2.5, avg_cost: 2.5, avg_turns: 5, avg_duration_ms: 150000 },
+    {
+      category: "new_ticket",
+      cycles: 4,
+      total_cost: 7.0,
+      avg_cost: 1.75,
+      avg_turns: 10,
+      avg_duration_ms: 400000,
+    },
+    {
+      category: "pr_review",
+      cycles: 2,
+      total_cost: 3.0,
+      avg_cost: 1.5,
+      avg_turns: 6,
+      avg_duration_ms: 200000,
+    },
+    {
+      category: "follow_up",
+      cycles: 1,
+      total_cost: 2.5,
+      avg_cost: 2.5,
+      avg_turns: 5,
+      avg_duration_ms: 150000,
+    },
   ],
   repos: [
-    { repo: 'frontend', tickets: 3, cycles: 5, total_cost: 8.0, avg_turns: 9 },
-    { repo: 'backend', tickets: 2, cycles: 5, total_cost: 4.5, avg_turns: 7 },
+    { repo: "frontend", tickets: 3, cycles: 5, total_cost: 8.0, avg_turns: 9 },
+    { repo: "backend", tickets: 2, cycles: 5, total_cost: 4.5, avg_turns: 7 },
   ],
   tickets: [
-    { external_key: 'RHCLOUD-001', title: 'Fix login', status: 'done', repo: 'frontend', total_cycles: 2, impl_cycles: 1, review_cycles: 1, total_cost: 3.5, hours_span: 4 },
+    {
+      external_key: "RHCLOUD-001",
+      title: "Fix login",
+      status: "done",
+      repo: "frontend",
+      total_cycles: 2,
+      impl_cycles: 1,
+      review_cycles: 1,
+      total_cost: 3.5,
+      hours_span: 4,
+    },
   ],
   feedback: { avg_review_rounds: 1.2, zero_review: 3, one_review: 5, multi_review: 2 },
 };
 
 const defaultCycleEntry = {
   id: 1,
-  timestamp: '2026-07-01T10:00:00Z',
-  label: 'cycle-1',
-  session_id: 'sess-1',
-  external_key: 'RHCLOUD-001',
-  source_type: 'jira',
+  timestamp: "2026-07-01T10:00:00Z",
+  label: "cycle-1",
+  session_id: "sess-1",
+  external_key: "RHCLOUD-001",
+  source_type: "jira",
   cost_usd: 0.5,
   num_turns: 5,
   duration_ms: 120000,
@@ -35,47 +74,56 @@ const defaultCycleEntry = {
   output_tokens: 2000,
   cache_read_tokens: 300,
   cache_write_tokens: 100,
-  model: 'claude-sonnet-4-20250514',
+  model: "claude-sonnet-4-20250514",
   is_error: false,
   no_work: false,
-  work_type: 'new_ticket',
-  repo: 'frontend',
+  work_type: "new_ticket",
+  repo: "frontend",
   summary: null,
 };
 
-test.describe('Costs page', () => {
+test.describe("Costs page", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/costs?*', (route) => {
+    await page.route("**/api/costs?*", (route) => {
       route.fulfill({ json: { items: [], daily: [] } });
     });
-    await page.route('**/api/analytics?*', (route) => {
+    await page.route("**/api/analytics?*", (route) => {
       route.fulfill({ json: defaultAnalytics });
     });
   });
 
-  test('renders summary cards from analytics', async ({ mount, page }) => {
-    await mount('Costs/Default');
-    await expect(page.getByText('Tickets Resolved')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('5 unique worked on')).toBeVisible();
-    await expect(page.getByText('Total Cost')).toBeVisible();
-    await expect(page.getByText('$12.50', { exact: true })).toBeVisible();
+  test("renders summary cards from analytics", async ({ mount, page }) => {
+    await mount("Costs/Default");
+    await expect(page.getByText("Tickets Resolved")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("5 unique worked on")).toBeVisible();
+    await expect(page.getByText("Total Cost")).toBeVisible();
+    await expect(page.getByText("$12.50", { exact: true })).toBeVisible();
   });
 
-  test('renders cycle list with mock data', async ({ mount, page }) => {
-    const cycle = { ...defaultCycleEntry, id: 2, external_key: 'RHCLOUD-100', cost_usd: 1.25, num_turns: 7, duration_ms: 180000, output_tokens: 3000, cache_read_tokens: 500 };
-    await page.route('**/api/costs?*', (route) => {
+  test("renders cycle list with mock data", async ({ mount, page }) => {
+    const cycle = {
+      ...defaultCycleEntry,
+      id: 2,
+      external_key: "RHCLOUD-100",
+      cost_usd: 1.25,
+      num_turns: 7,
+      duration_ms: 180000,
+      output_tokens: 3000,
+      cache_read_tokens: 500,
+    };
+    await page.route("**/api/costs?*", (route) => {
       route.fulfill({ json: { items: [cycle], daily: [] } });
     });
 
-    await mount('Costs/Default');
-    await expect(page.getByText('RHCLOUD-100')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('$1.25')).toBeVisible();
-    await expect(page.getByText('7 turns')).toBeVisible();
-    await expect(page.locator('.cycle-row').getByText('New Ticket')).toBeVisible();
+    await mount("Costs/Default");
+    await expect(page.getByText("RHCLOUD-100")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("$1.25")).toBeVisible();
+    await expect(page.getByText("7 turns")).toBeVisible();
+    await expect(page.locator(".cycle-row").getByText("New Ticket")).toBeVisible();
   });
 
-  test('shows empty cycles message when no data', async ({ mount, page }) => {
-    await mount('Costs/Default');
-    await expect(page.getByText('No cycles recorded')).toBeVisible({ timeout: 10000 });
+  test("shows empty cycles message when no data", async ({ mount, page }) => {
+    await mount("Costs/Default");
+    await expect(page.getByText("No cycles recorded")).toBeVisible({ timeout: 10000 });
   });
 });

--- a/dashboard/src/pages/Costs.test.tsx
+++ b/dashboard/src/pages/Costs.test.tsx
@@ -1,18 +1,18 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
-import Costs from './Costs';
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Costs from "./Costs";
 
-vi.mock('../api', () => ({
+vi.mock("../api", () => ({
   fetchCosts: vi.fn(),
   fetchAnalytics: vi.fn(),
 }));
 
-vi.mock('../hooks/useWebSocket', () => ({
+vi.mock("../hooks/useWebSocket", () => ({
   useWS: () => ({ connected: true, lastEvent: null, onEvent: () => () => {} }),
 }));
 
-import { fetchCosts, fetchAnalytics } from '../api';
+import { fetchAnalytics, fetchCosts } from "../api";
 
 const mockFetchCosts = vi.mocked(fetchCosts);
 const mockFetchAnalytics = vi.mocked(fetchAnalytics);
@@ -21,8 +21,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('Costs page', () => {
-  it('handles malformed analytics response', async () => {
+describe("Costs page", () => {
+  it("handles malformed analytics response", async () => {
     // Mock API returns costs but analytics is missing fields
     mockFetchCosts.mockResolvedValue({
       items: [],
@@ -40,7 +40,7 @@ describe('Costs page', () => {
     render(
       <MemoryRouter>
         <Costs />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Should render without crashing even with incomplete data
@@ -49,7 +49,7 @@ describe('Costs page', () => {
     });
   });
 
-  it('handles empty costs response correctly', async () => {
+  it("handles empty costs response correctly", async () => {
     // Mock API returns paginated response with items array
     mockFetchCosts.mockResolvedValue({
       items: [],
@@ -82,7 +82,7 @@ describe('Costs page', () => {
     render(
       <MemoryRouter>
         <Costs />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Should render without crashing
@@ -91,28 +91,28 @@ describe('Costs page', () => {
     });
   });
 
-  it('handles costs with data', async () => {
+  it("handles costs with data", async () => {
     const mockCycles = [
       {
         id: 1,
         cycle_number: 1,
-        external_key: 'RHCLOUD-001',
-        repo: 'test-repo',
-        work_type: 'bug_fix',
-        model: 'claude-opus-4',
+        external_key: "RHCLOUD-001",
+        repo: "test-repo",
+        work_type: "bug_fix",
+        model: "claude-opus-4",
         input_tokens: 1000,
         output_tokens: 500,
         cache_creation_tokens: 0,
         cache_read_tokens: 200,
         cost_usd: 0.05,
         duration_ms: 30000,
-        started_at: '2026-07-24T10:00:00Z',
+        started_at: "2026-07-24T10:00:00Z",
       },
     ];
 
     const mockDaily = [
       {
-        day: '2026-07-24',
+        day: "2026-07-24",
         cycles: 1,
         total_cost: 0.05,
         input_tokens: 1000,
@@ -148,21 +148,30 @@ describe('Costs page', () => {
         repos_touched: 1,
         tickets_resolved: 1,
       },
-      work_types: [{ category: 'other', cycles: 1, total_cost: 0.05, avg_cost: 0.05, avg_turns: 5, avg_duration_ms: 30000 }],
-      repos: [{ repo: 'test-repo', cycles: 1, total_cost: 0.05 }],
-      tickets: [{ external_key: 'RHCLOUD-001', cycles: 1, total_cost: 0.05 }],
+      work_types: [
+        {
+          category: "other",
+          cycles: 1,
+          total_cost: 0.05,
+          avg_cost: 0.05,
+          avg_turns: 5,
+          avg_duration_ms: 30000,
+        },
+      ],
+      repos: [{ repo: "test-repo", cycles: 1, total_cost: 0.05 }],
+      tickets: [{ external_key: "RHCLOUD-001", cycles: 1, total_cost: 0.05 }],
       feedback: [],
     });
 
     render(
       <MemoryRouter>
         <Costs />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Should render cost data
     await waitFor(() => {
-      expect(screen.getByText('RHCLOUD-001')).toBeInTheDocument();
+      expect(screen.getByText("RHCLOUD-001")).toBeInTheDocument();
     });
   });
 });

--- a/dashboard/src/pages/Costs.tsx
+++ b/dashboard/src/pages/Costs.tsx
@@ -1,52 +1,55 @@
-import { useEffect, useState, useCallback } from 'react';
-import {
-  AreaChart,
-  Area,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-  CartesianGrid,
-  Cell,
-  PieChart,
-  Pie,
-} from 'recharts';
-import type { CycleEntry, DailyAggregate, AnalyticsData } from '../types';
-import { fetchCosts, fetchAnalytics } from '../api';
-import { formatDuration, formatTokens, sourceUrl, displayKey } from '../utils';
-import { useWS } from '../hooks/useWebSocket';
 import {
   Alert,
   AlertActionCloseButton,
   Card,
   CardBody,
-  CardTitle,
   CardHeader,
+  CardTitle,
+  Content,
   Flex,
   FlexItem,
   Label,
-  ToggleGroup,
-  ToggleGroupItem,
   MenuToggle,
   MenuToggleElement,
   Select,
   SelectList,
   SelectOption,
-  Content
-} from '@patternfly/react-core';
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@patternfly/react-core";
+import { useCallback, useEffect, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fetchAnalytics, fetchCosts } from "../api";
+import { useWS } from "../hooks/useWebSocket";
+import type { AnalyticsData, CycleEntry, DailyAggregate } from "../types";
+import { displayKey, formatDuration, formatTokens, sourceUrl } from "../utils";
 
 const DAYS_OPTIONS = [7, 14, 30, 90];
 
-type CycleMetric = 'cost' | 'output_tokens' | 'duration' | 'turns';
+type CycleMetric = "cost" | "output_tokens" | "duration" | "turns";
 
-const METRIC_CONFIG: Record<CycleMetric, { label: string; color: string; format: (v: number) => string }> = {
-  cost: { label: 'Cost', color: '#3fb950', format: v => '$' + v.toFixed(2) },
-  output_tokens: { label: 'Output Tokens', color: '#58a6ff', format: v => formatTokens(v) },
-  duration: { label: 'Duration', color: '#d29922', format: v => formatDuration(v) },
-  turns: { label: 'Turns', color: '#bc8cff', format: v => String(v) },
+const METRIC_CONFIG: Record<
+  CycleMetric,
+  { label: string; color: string; format: (v: number) => string }
+> = {
+  cost: { label: "Cost", color: "#3fb950", format: (v) => "$" + v.toFixed(2) },
+  output_tokens: { label: "Output Tokens", color: "#58a6ff", format: (v) => formatTokens(v) },
+  duration: { label: "Duration", color: "#d29922", format: (v) => formatDuration(v) },
+  turns: { label: "Turns", color: "#bc8cff", format: (v) => String(v) },
 };
 
 interface CostsData {
@@ -55,51 +58,83 @@ interface CostsData {
 }
 
 const WORK_TYPE_COLORS: Record<string, string> = {
-  new_ticket: '#3fb950',
-  pr_review: '#58a6ff',
-  ci_fix: '#f85149',
-  investigation: '#d29922',
-  cve: '#f0883e',
-  memory_housekeeping: '#bc8cff',
-  idle: '#484f58',
-  error: '#f85149',
-  other: '#8b949e',
+  new_ticket: "#3fb950",
+  pr_review: "#58a6ff",
+  ci_fix: "#f85149",
+  investigation: "#d29922",
+  cve: "#f0883e",
+  memory_housekeeping: "#bc8cff",
+  idle: "#484f58",
+  error: "#f85149",
+  other: "#8b949e",
 };
 
 const WORK_TYPE_LABELS: Record<string, string> = {
-  new_ticket: 'New Ticket',
-  implement: 'Implement',
-  pr_review: 'PR Review',
-  review: 'Review',
-  ci_fix: 'CI Fix',
-  'ci-fix': 'CI Fix',
-  triage: 'Triage',
-  investigation: 'Investigation',
-  cve: 'CVE',
-  memory_housekeeping: 'Housekeeping',
-  idle: 'Idle',
-  error: 'Error',
-  other: 'Other',
+  new_ticket: "New Ticket",
+  implement: "Implement",
+  pr_review: "PR Review",
+  review: "Review",
+  ci_fix: "CI Fix",
+  "ci-fix": "CI Fix",
+  triage: "Triage",
+  investigation: "Investigation",
+  cve: "CVE",
+  memory_housekeeping: "Housekeeping",
+  idle: "Idle",
+  error: "Error",
+  other: "Other",
 };
 
-const REPO_COLORS = ['#58a6ff', '#3fb950', '#d29922', '#f0883e', '#bc8cff', '#f85149', '#79c0ff', '#56d364', '#e3b341', '#db6d28', '#d2a8ff', '#ff7b72'];
+const REPO_COLORS = [
+  "#58a6ff",
+  "#3fb950",
+  "#d29922",
+  "#f0883e",
+  "#bc8cff",
+  "#f85149",
+  "#79c0ff",
+  "#56d364",
+  "#e3b341",
+  "#db6d28",
+  "#d2a8ff",
+  "#ff7b72",
+];
 
-type DateMode = 'preset' | 'range';
+type DateMode = "preset" | "range";
 
 function CycleChartTooltip({ active, payload }: any) {
   if (!active || !payload?.length) return null;
   const d = payload[0]?.payload;
   if (!d) return null;
-  const status = d.is_error ? 'error' : d.no_work ? 'idle' : 'work';
+  const status = d.is_error ? "error" : d.no_work ? "idle" : "work";
   return (
     <div className="chart-tooltip">
       <div className="chart-tooltip-label">{d.time}</div>
-      {d.external_key && <div style={{ fontWeight: 600 }}>{d.external_key}{d.repo ? ` · ${d.repo}` : ''}</div>}
-      {d.work_type && <div style={{ color: 'var(--accent)' }}>{WORK_TYPE_LABELS[d.work_type] || d.work_type}</div>}
-      <div>${Number(d.cost).toFixed(2)} &middot; {d.turns} turns &middot; {formatDuration(d.duration)}</div>
-      <div>{formatTokens(d.output_tokens)} output &middot; {formatTokens(d.cache_read)} cache</div>
-      {d.summary && <div style={{ color: 'var(--text-dim)', fontSize: 11, marginTop: 2 }}>{d.summary}</div>}
-      <div style={{ color: d.is_error ? 'var(--red)' : d.no_work ? 'var(--text-dim)' : 'var(--green)' }}>{status}</div>
+      {d.external_key && (
+        <div style={{ fontWeight: 600 }}>
+          {d.external_key}
+          {d.repo ? ` · ${d.repo}` : ""}
+        </div>
+      )}
+      {d.work_type && (
+        <div style={{ color: "var(--accent)" }}>{WORK_TYPE_LABELS[d.work_type] || d.work_type}</div>
+      )}
+      <div>
+        ${Number(d.cost).toFixed(2)} &middot; {d.turns} turns &middot; {formatDuration(d.duration)}
+      </div>
+      <div>
+        {formatTokens(d.output_tokens)} output &middot; {formatTokens(d.cache_read)} cache
+      </div>
+      {d.summary && (
+        <div style={{ color: "var(--text-dim)", fontSize: 11, marginTop: 2 }}>{d.summary}</div>
+      )}
+      <div
+        style={{
+          color: d.is_error ? "var(--red)" : d.no_work ? "var(--text-dim)" : "var(--green)",
+        }}
+      >
+        {status}
+      </div>
     </div>
   );
 }
@@ -111,7 +146,8 @@ function DailyChartTooltip({ active, payload, label }: any) {
       <div className="chart-tooltip-label">{label}</div>
       {payload.map((p: any, i: number) => (
         <div key={i} style={{ color: p.color }}>
-          {p.name}: {p.dataKey === 'cost' ? '$' + Number(p.value).toFixed(2) : formatTokens(p.value)}
+          {p.name}:{" "}
+          {p.dataKey === "cost" ? "$" + Number(p.value).toFixed(2) : formatTokens(p.value)}
         </div>
       ))}
     </div>
@@ -124,8 +160,12 @@ function PieTooltip({ active, payload }: any) {
   return (
     <div className="chart-tooltip">
       <div style={{ fontWeight: 600, color: d.payload.fill }}>{d.name}</div>
-      <div>{d.value} cycles · ${d.payload.total_cost?.toFixed(2)}</div>
-      <div style={{ color: 'var(--text-dim)', fontSize: 11 }}>avg ${d.payload.avg_cost?.toFixed(2)}/cycle · {d.payload.avg_turns} turns</div>
+      <div>
+        {d.value} cycles · ${d.payload.total_cost?.toFixed(2)}
+      </div>
+      <div style={{ color: "var(--text-dim)", fontSize: 11 }}>
+        avg ${d.payload.avg_cost?.toFixed(2)}/cycle · {d.payload.avg_turns} turns
+      </div>
     </div>
   );
 }
@@ -133,16 +173,16 @@ function PieTooltip({ active, payload }: any) {
 function CycleDot(props: any) {
   const { cx, cy, payload } = props;
   if (cx == null || cy == null) return null;
-  const wt = payload?.work_type || (payload?.no_work ? 'idle' : payload?.is_error ? 'error' : '');
-  const color = WORK_TYPE_COLORS[wt] || '#8b949e';
+  const wt = payload?.work_type || (payload?.no_work ? "idle" : payload?.is_error ? "error" : "");
+  const color = WORK_TYPE_COLORS[wt] || "#8b949e";
   return <circle cx={cx} cy={cy} r={3} fill={color} stroke={color} strokeWidth={1} opacity={0.9} />;
 }
 
 function CycleActiveDot(props: any) {
   const { cx, cy, payload } = props;
   if (cx == null || cy == null) return null;
-  const wt = payload?.work_type || (payload?.no_work ? 'idle' : payload?.is_error ? 'error' : '');
-  const color = WORK_TYPE_COLORS[wt] || '#8b949e';
+  const wt = payload?.work_type || (payload?.no_work ? "idle" : payload?.is_error ? "error" : "");
+  const color = WORK_TYPE_COLORS[wt] || "#8b949e";
   return (
     <g>
       <circle cx={cx} cy={cy} r={7} fill={color} opacity={0.2} />
@@ -152,67 +192,110 @@ function CycleActiveDot(props: any) {
 }
 
 function CycleRow({ c }: { c: CycleEntry }) {
-  const costColor = c.cost_usd > 2 ? 'var(--red)' : c.cost_usd > 1 ? 'var(--yellow)' : 'var(--green)';
-  const statusLabel = c.is_error ? 'error' : c.no_work ? 'idle' : (WORK_TYPE_LABELS[c.work_type || ''] || c.work_type || 'work');
-  const statusColor = c.is_error ? 'var(--red)' : c.no_work ? 'var(--text-dim)' : 'var(--green)';
+  const costColor =
+    c.cost_usd > 2 ? "var(--red)" : c.cost_usd > 1 ? "var(--yellow)" : "var(--green)";
+  const statusLabel = c.is_error
+    ? "error"
+    : c.no_work
+      ? "idle"
+      : WORK_TYPE_LABELS[c.work_type || ""] || c.work_type || "work";
+  const statusColor = c.is_error ? "var(--red)" : c.no_work ? "var(--text-dim)" : "var(--green)";
   const ts = new Date(c.timestamp);
 
   return (
-    <div className="cycle-row" title={c.summary || ''}>
+    <div className="cycle-row" title={c.summary || ""}>
       <div className="cycle-time" title={c.timestamp}>
-        {ts.toLocaleDateString([], { month: 'short', day: 'numeric' })}{' '}
-        {ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        {ts.toLocaleDateString([], { month: "short", day: "numeric" })}{" "}
+        {ts.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
       </div>
       <div className="cycle-work">
         {displayKey(c) ? (
-          <a href={sourceUrl(c) || '#'} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
+          <a
+            href={sourceUrl(c) || "#"}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+          >
             {displayKey(c)}
           </a>
         ) : (
-          <span style={{ color: 'var(--text-dim)' }}>—</span>
+          <span style={{ color: "var(--text-dim)" }}>—</span>
         )}
         {c.repo && <span className="cycle-repo">{c.repo}</span>}
       </div>
-      <div className="cycle-cost" style={{ color: costColor }}>${c.cost_usd.toFixed(2)}</div>
+      <div className="cycle-cost" style={{ color: costColor }}>
+        ${c.cost_usd.toFixed(2)}
+      </div>
       <div className="cycle-turns">{c.num_turns} turns</div>
       <div className="cycle-duration">{formatDuration(c.duration_ms)}</div>
       <div className="cycle-tokens">
         <span title="Output tokens">{formatTokens(c.output_tokens)} out</span>
-        <span className="cycle-tokens-dim" title="Cache read">{formatTokens(c.cache_read_tokens)} cache</span>
+        <span className="cycle-tokens-dim" title="Cache read">
+          {formatTokens(c.cache_read_tokens)} cache
+        </span>
       </div>
-      <div className="cycle-status" style={{ color: statusColor }}>{statusLabel}</div>
+      <div className="cycle-status" style={{ color: statusColor }}>
+        {statusLabel}
+      </div>
     </div>
   );
 }
 
-function SummaryCard({ value, label, sub, color }: { value: string; label: string; sub?: string; color?: string }) {
+function SummaryCard({
+  value,
+  label,
+  sub,
+  color,
+}: {
+  value: string;
+  label: string;
+  sub?: string;
+  color?: string;
+}) {
   return (
     <Card isCompact isGlass style={color ? { borderLeft: `3px solid ${color}` } : undefined}>
       <CardBody>
-        <Content component="p" style={{ fontSize: '1.5rem', fontWeight: 700, margin: 0, color: color || 'inherit' }}>{value}</Content>
-        <Content component="p" style={{ margin: '4px 0 0', fontWeight: 500 }}>{label}</Content>
-        {sub && <Content component="small" style={{ margin: 0, color: 'var(--pf-t--global--text--color--subtle, var(--text-dim))' }}>{sub}</Content>}
+        <Content
+          component="p"
+          style={{ fontSize: "1.5rem", fontWeight: 700, margin: 0, color: color || "inherit" }}
+        >
+          {value}
+        </Content>
+        <Content component="p" style={{ margin: "4px 0 0", fontWeight: 500 }}>
+          {label}
+        </Content>
+        {sub && (
+          <Content
+            component="small"
+            style={{
+              margin: 0,
+              color: "var(--pf-t--global--text--color--subtle, var(--text-dim))",
+            }}
+          >
+            {sub}
+          </Content>
+        )}
       </CardBody>
     </Card>
   );
 }
 
 export default function Costs({ instanceId }: { instanceId?: string }) {
-  const [dateMode, setDateMode] = useState<DateMode>('preset');
+  const [dateMode, setDateMode] = useState<DateMode>("preset");
   const [days, setDays] = useState(30);
-  const [dateFrom, setDateFrom] = useState('');
-  const [dateTo, setDateTo] = useState('');
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [data, setData] = useState<CostsData | null>(null);
   const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
-  const [metric, setMetric] = useState<CycleMetric>('cost');
+  const [metric, setMetric] = useState<CycleMetric>("cost");
   const [isDaysOpen, setIsDaysOpen] = useState(false);
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
   const { onEvent } = useWS();
 
   const load = useCallback(async () => {
-    const from = dateMode === 'range' ? dateFrom || undefined : undefined;
-    const to = dateMode === 'range' ? dateTo || undefined : undefined;
+    const from = dateMode === "range" ? dateFrom || undefined : undefined;
+    const to = dateMode === "range" ? dateTo || undefined : undefined;
     const [costsRes, analyticsRes] = await Promise.all([
       fetchCosts(days, 500, from, to, instanceId),
       fetchAnalytics(days, from, to, instanceId),
@@ -221,11 +304,13 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
     setAnalytics(analyticsRes);
   }, [days, dateMode, dateFrom, dateTo, instanceId]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    load();
+  }, [load]);
 
   useEffect(() => {
     return onEvent((event) => {
-      if (event.type === 'cycle_recorded') load();
+      if (event.type === "cycle_recorded") load();
     });
   }, [onEvent, load]);
 
@@ -261,7 +346,10 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
     const ts = new Date(c.timestamp);
     return {
       idx: i,
-      time: ts.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ' ' + ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      time:
+        ts.toLocaleDateString([], { month: "short", day: "numeric" }) +
+        " " +
+        ts.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
       cost: c.cost_usd,
       output_tokens: c.output_tokens,
       cache_read: c.cache_read_tokens,
@@ -280,24 +368,31 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
 
   // Daily chart data
   const sorted = [...daily].sort((a, b) => a.day.localeCompare(b.day));
-  const dailyCostData = sorted.map(d => ({ day: d.day.slice(5), cost: Number(d.total_cost.toFixed(2)) }));
-  const dailyTokenData = sorted.map(d => ({ day: d.day.slice(5), output: d.output_tokens, cache_read: d.cache_read }));
+  const dailyCostData = sorted.map((d) => ({
+    day: d.day.slice(5),
+    cost: Number(d.total_cost.toFixed(2)),
+  }));
+  const dailyTokenData = sorted.map((d) => ({
+    day: d.day.slice(5),
+    output: d.output_tokens,
+    cache_read: d.cache_read,
+  }));
 
   // Work type pie data (exclude idle)
   const pieData = work_types
-    .filter(w => w.category !== 'idle' && w.category !== 'error')
-    .map(w => ({
+    .filter((w) => w.category !== "idle" && w.category !== "error")
+    .map((w) => ({
       name: WORK_TYPE_LABELS[w.category] || w.category,
       value: w.cycles,
       total_cost: w.total_cost,
       avg_cost: w.avg_cost,
       avg_turns: w.avg_turns,
-      fill: WORK_TYPE_COLORS[w.category] || '#8b949e',
+      fill: WORK_TYPE_COLORS[w.category] || "#8b949e",
     }));
 
   // Repo bar data
-  const repoBarData = repos.slice(0, 12).map(r => ({
-    repo: r.repo.length > 20 ? r.repo.slice(0, 18) + '...' : r.repo,
+  const repoBarData = repos.slice(0, 12).map((r) => ({
+    repo: r.repo.length > 20 ? r.repo.slice(0, 18) + "..." : r.repo,
     fullRepo: r.repo,
     tickets: r.tickets,
     cycles: r.cycles,
@@ -305,9 +400,9 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
   }));
 
   // Ticket lifecycle stacked bar
-  const ticketBarData = tickets.slice(0, 15).map(t => ({
+  const ticketBarData = tickets.slice(0, 15).map((t) => ({
     key: displayKey(t),
-    title: t.title ? (t.title.length > 40 ? t.title.slice(0, 38) + '...' : t.title) : displayKey(t),
+    title: t.title ? (t.title.length > 40 ? t.title.slice(0, 38) + "..." : t.title) : displayKey(t),
     impl: t.impl_cycles,
     review: t.review_cycles,
     total_cost: t.total_cost,
@@ -324,50 +419,88 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
           isInline
           title={`Showing costs for ${instanceId} only`}
           actionClose={<AlertActionCloseButton onClose={() => setBannerDismissed(true)} />}
-          style={{ marginBottom: '16px' }}
+          style={{ marginBottom: "16px" }}
         >
-          <p>Historical entries recorded before per-instance tracking was enabled are not included.{' '}
-          <a href="#/costs">View all instances</a> for the full aggregated view.</p>
+          <p>
+            Historical entries recorded before per-instance tracking was enabled are not included.{" "}
+            <a href="#/costs">View all instances</a> for the full aggregated view.
+          </p>
         </Alert>
       )}
       {/* Date controls */}
-      <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }} style={{ marginBottom: '16px' }}>
+      <Flex
+        gap={{ default: "gapMd" }}
+        alignItems={{ default: "alignItemsCenter" }}
+        style={{ marginBottom: "16px" }}
+      >
         <FlexItem>
           <ToggleGroup aria-label="Date mode">
-            <ToggleGroupItem text="Preset" isSelected={dateMode === 'preset'} onChange={() => setDateMode('preset')} />
-            <ToggleGroupItem text="Date Range" isSelected={dateMode === 'range'} onChange={() => setDateMode('range')} />
+            <ToggleGroupItem
+              text="Preset"
+              isSelected={dateMode === "preset"}
+              onChange={() => setDateMode("preset")}
+            />
+            <ToggleGroupItem
+              text="Date Range"
+              isSelected={dateMode === "range"}
+              onChange={() => setDateMode("range")}
+            />
           </ToggleGroup>
         </FlexItem>
         <FlexItem>
-          {dateMode === 'preset' ? (
+          {dateMode === "preset" ? (
             <Select
               isOpen={isDaysOpen}
               selected={String(days)}
-              onSelect={(_e, val) => { setDays(Number(val)); setIsDaysOpen(false); }}
+              onSelect={(_e, val) => {
+                setDays(Number(val));
+                setIsDaysOpen(false);
+              }}
               onOpenChange={setIsDaysOpen}
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle ref={toggleRef} onClick={() => setIsDaysOpen(!isDaysOpen)} isExpanded={isDaysOpen}>
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsDaysOpen(!isDaysOpen)}
+                  isExpanded={isDaysOpen}
+                >
                   {days} days
                 </MenuToggle>
               )}
             >
               <SelectList>
-                {DAYS_OPTIONS.map(d => <SelectOption key={d} value={String(d)}>{d} days</SelectOption>)}
+                {DAYS_OPTIONS.map((d) => (
+                  <SelectOption key={d} value={String(d)}>
+                    {d} days
+                  </SelectOption>
+                ))}
               </SelectList>
             </Select>
           ) : (
-            <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+            <Flex gap={{ default: "gapSm" }} alignItems={{ default: "alignItemsCenter" }}>
               <FlexItem>
                 <Label variant="outline">From</Label>
               </FlexItem>
               <FlexItem>
-                <input type="date" value={dateFrom} max={dateTo || todayStr} onChange={e => setDateFrom(e.target.value)} className="date-range-picker-input" />
+                <input
+                  type="date"
+                  value={dateFrom}
+                  max={dateTo || todayStr}
+                  onChange={(e) => setDateFrom(e.target.value)}
+                  className="date-range-picker-input"
+                />
               </FlexItem>
               <FlexItem>
                 <Label variant="outline">To</Label>
               </FlexItem>
               <FlexItem>
-                <input type="date" value={dateTo} min={dateFrom} max={todayStr} onChange={e => setDateTo(e.target.value)} className="date-range-picker-input" />
+                <input
+                  type="date"
+                  value={dateTo}
+                  min={dateFrom}
+                  max={todayStr}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  className="date-range-picker-input"
+                />
               </FlexItem>
             </Flex>
           )}
@@ -376,11 +509,34 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
 
       {/* Summary cards */}
       <div className="summary-grid">
-        <SummaryCard value={String(summary.tickets_resolved)} label="Tickets Resolved" sub={`${summary.unique_tickets} unique worked on`} color="var(--green)" />
-        <SummaryCard value={`$${summary.total_cost.toFixed(2)}`} label="Total Cost" sub={`$${summary.avg_cost_per_work_cycle.toFixed(2)} avg/work cycle`} color="var(--green)" />
-        <SummaryCard value={String(summary.work_cycles)} label="Work Cycles" sub={`${summary.idle_cycles} idle · ${summary.error_cycles} error`} />
-        <SummaryCard value={formatDuration(summary.avg_duration_ms)} label="Avg Cycle Duration" sub={`${summary.avg_turns} avg turns`} />
-        <SummaryCard value={`${feedback.avg_review_rounds}`} label="Avg Review Rounds" sub={`${feedback.zero_review} first-pass · ${feedback.multi_review} multi-round`} color="var(--accent)" />
+        <SummaryCard
+          value={String(summary.tickets_resolved)}
+          label="Tickets Resolved"
+          sub={`${summary.unique_tickets} unique worked on`}
+          color="var(--green)"
+        />
+        <SummaryCard
+          value={`$${summary.total_cost.toFixed(2)}`}
+          label="Total Cost"
+          sub={`$${summary.avg_cost_per_work_cycle.toFixed(2)} avg/work cycle`}
+          color="var(--green)"
+        />
+        <SummaryCard
+          value={String(summary.work_cycles)}
+          label="Work Cycles"
+          sub={`${summary.idle_cycles} idle · ${summary.error_cycles} error`}
+        />
+        <SummaryCard
+          value={formatDuration(summary.avg_duration_ms)}
+          label="Avg Cycle Duration"
+          sub={`${summary.avg_turns} avg turns`}
+        />
+        <SummaryCard
+          value={`${feedback.avg_review_rounds}`}
+          label="Avg Review Rounds"
+          sub={`${feedback.zero_review} first-pass · ${feedback.multi_review} multi-round`}
+          color="var(--accent)"
+        />
         <SummaryCard value={String(summary.repos_touched)} label="Repos Touched" />
       </div>
 
@@ -389,35 +545,39 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
         {/* Work type pie */}
         {pieData.length > 0 && (
           <Card isCompact isGlass>
-            <CardHeader><CardTitle>Work Breakdown</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>Work Breakdown</CardTitle>
+            </CardHeader>
             <CardBody>
-            <ResponsiveContainer width="100%" height={220}>
-              <PieChart>
-                <Pie
-                  data={pieData}
-                  dataKey="value"
-                  nameKey="name"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={80}
-                  innerRadius={40}
-                  paddingAngle={2}
-                  label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(0)}%`}
-                  labelLine={false}
-                >
-                  {pieData.map((d, i) => <Cell key={i} fill={d.fill} />)}
-                </Pie>
-                <Tooltip content={<PieTooltip />} />
-              </PieChart>
-            </ResponsiveContainer>
-            <div className="work-type-legend">
-              {pieData.map((d) => (
-                <span key={d.name} className="cycle-legend-item">
-                  <span className="cycle-legend-dot" style={{ background: d.fill }} />
-                  {d.name}: {d.value} ({`$${d.total_cost.toFixed(2)}`})
-                </span>
-              ))}
-            </div>
+              <ResponsiveContainer width="100%" height={220}>
+                <PieChart>
+                  <Pie
+                    data={pieData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    innerRadius={40}
+                    paddingAngle={2}
+                    label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(0)}%`}
+                    labelLine={false}
+                  >
+                    {pieData.map((d, i) => (
+                      <Cell key={i} fill={d.fill} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<PieTooltip />} />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="work-type-legend">
+                {pieData.map((d) => (
+                  <span key={d.name} className="cycle-legend-item">
+                    <span className="cycle-legend-dot" style={{ background: d.fill }} />
+                    {d.name}: {d.value} ({`$${d.total_cost.toFixed(2)}`})
+                  </span>
+                ))}
+              </div>
             </CardBody>
           </Card>
         )}
@@ -425,29 +585,48 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
         {/* Repo breakdown bar */}
         {repoBarData.length > 0 && (
           <Card isCompact isGlass>
-            <CardHeader><CardTitle>Repos</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>Repos</CardTitle>
+            </CardHeader>
             <CardBody>
-            <ResponsiveContainer width="100%" height={220}>
-              <BarChart data={repoBarData} layout="vertical" margin={{ left: 10 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" horizontal={false} />
-                <XAxis type="number" stroke="var(--text-dim)" fontSize={11} />
-                <YAxis type="category" dataKey="repo" stroke="var(--text-dim)" fontSize={11} width={140} tick={{ fill: 'var(--text-dim)' }} />
-                <Tooltip content={({ active, payload }) => {
-                  if (!active || !payload?.length) return null;
-                  const d = payload[0]?.payload;
-                  return (
-                    <div className="chart-tooltip">
-                      <div style={{ fontWeight: 600 }}>{d.fullRepo}</div>
-                      <div>{d.tickets} tickets · {d.cycles} cycles</div>
-                      <div style={{ color: 'var(--green)' }}>${d.total_cost.toFixed(2)}</div>
-                    </div>
-                  );
-                }} />
-                <Bar dataKey="cycles" name="Cycles" radius={[0, 4, 4, 0]}>
-                  {repoBarData.map((_, i) => <Cell key={i} fill={REPO_COLORS[i % REPO_COLORS.length]} />)}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+              <ResponsiveContainer width="100%" height={220}>
+                <BarChart data={repoBarData} layout="vertical" margin={{ left: 10 }}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="rgba(48,54,61,0.5)"
+                    horizontal={false}
+                  />
+                  <XAxis type="number" stroke="var(--text-dim)" fontSize={11} />
+                  <YAxis
+                    type="category"
+                    dataKey="repo"
+                    stroke="var(--text-dim)"
+                    fontSize={11}
+                    width={140}
+                    tick={{ fill: "var(--text-dim)" }}
+                  />
+                  <Tooltip
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null;
+                      const d = payload[0]?.payload;
+                      return (
+                        <div className="chart-tooltip">
+                          <div style={{ fontWeight: 600 }}>{d.fullRepo}</div>
+                          <div>
+                            {d.tickets} tickets · {d.cycles} cycles
+                          </div>
+                          <div style={{ color: "var(--green)" }}>${d.total_cost.toFixed(2)}</div>
+                        </div>
+                      );
+                    }}
+                  />
+                  <Bar dataKey="cycles" name="Cycles" radius={[0, 4, 4, 0]}>
+                    {repoBarData.map((_, i) => (
+                      <Cell key={i} fill={REPO_COLORS[i % REPO_COLORS.length]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
             </CardBody>
           </Card>
         )}
@@ -455,118 +634,200 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
 
       {/* Ticket lifecycle */}
       {ticketBarData.length > 0 && (
-        <Card isCompact isGlass style={{ marginBottom: '16px' }}>
-          <CardHeader><CardTitle>Ticket Lifecycle — Cycles per Ticket</CardTitle></CardHeader>
+        <Card isCompact isGlass style={{ marginBottom: "16px" }}>
+          <CardHeader>
+            <CardTitle>Ticket Lifecycle — Cycles per Ticket</CardTitle>
+          </CardHeader>
           <CardBody>
-          <div style={{ fontSize: 12, color: 'var(--text-dim)', marginBottom: 8 }}>
-            Implementation vs review cycles. Hover for cost & time details.
-          </div>
-          <ResponsiveContainer width="100%" height={Math.max(200, ticketBarData.length * 28 + 40)}>
-            <BarChart data={ticketBarData} layout="vertical" margin={{ left: 10 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" horizontal={false} />
-              <XAxis type="number" stroke="var(--text-dim)" fontSize={11} allowDecimals={false} />
-              <YAxis type="category" dataKey="key" stroke="var(--text-dim)" fontSize={11} width={130} tick={{ fill: 'var(--accent)' }} />
-              <Tooltip
-                cursor={{ fill: 'rgba(255,255,255,0.03)' }}
-                content={({ active, payload }) => {
-                  if (!active || !payload?.length) return null;
-                  const d = payload[0]?.payload;
-                  const hoveredKey = payload.find(p => p.value && Number(p.value) > 0)?.dataKey;
-                  return (
-                    <div className="chart-tooltip">
-                      <div style={{ fontWeight: 600 }}>{d.key}</div>
-                      <div style={{ fontSize: 11, color: 'var(--text-dim)', maxWidth: 250 }}>{d.title}</div>
-                      <div style={{ marginTop: 4 }}>
-                        <span style={{ color: WORK_TYPE_COLORS.new_ticket, fontWeight: hoveredKey === 'impl' ? 700 : 400 }}>
-                          {d.impl} impl
-                        </span>
-                        {' + '}
-                        <span style={{ color: WORK_TYPE_COLORS.pr_review, fontWeight: hoveredKey === 'review' ? 700 : 400 }}>
-                          {d.review} review
-                        </span>
-                        {' = '}{d.impl + d.review} total
+            <div style={{ fontSize: 12, color: "var(--text-dim)", marginBottom: 8 }}>
+              Implementation vs review cycles. Hover for cost & time details.
+            </div>
+            <ResponsiveContainer
+              width="100%"
+              height={Math.max(200, ticketBarData.length * 28 + 40)}
+            >
+              <BarChart data={ticketBarData} layout="vertical" margin={{ left: 10 }}>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="rgba(48,54,61,0.5)"
+                  horizontal={false}
+                />
+                <XAxis type="number" stroke="var(--text-dim)" fontSize={11} allowDecimals={false} />
+                <YAxis
+                  type="category"
+                  dataKey="key"
+                  stroke="var(--text-dim)"
+                  fontSize={11}
+                  width={130}
+                  tick={{ fill: "var(--accent)" }}
+                />
+                <Tooltip
+                  cursor={{ fill: "rgba(255,255,255,0.03)" }}
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const d = payload[0]?.payload;
+                    const hoveredKey = payload.find((p) => p.value && Number(p.value) > 0)?.dataKey;
+                    return (
+                      <div className="chart-tooltip">
+                        <div style={{ fontWeight: 600 }}>{d.key}</div>
+                        <div style={{ fontSize: 11, color: "var(--text-dim)", maxWidth: 250 }}>
+                          {d.title}
+                        </div>
+                        <div style={{ marginTop: 4 }}>
+                          <span
+                            style={{
+                              color: WORK_TYPE_COLORS.new_ticket,
+                              fontWeight: hoveredKey === "impl" ? 700 : 400,
+                            }}
+                          >
+                            {d.impl} impl
+                          </span>
+                          {" + "}
+                          <span
+                            style={{
+                              color: WORK_TYPE_COLORS.pr_review,
+                              fontWeight: hoveredKey === "review" ? 700 : 400,
+                            }}
+                          >
+                            {d.review} review
+                          </span>
+                          {" = "}
+                          {d.impl + d.review} total
+                        </div>
+                        <div style={{ color: "var(--green)" }}>${d.total_cost.toFixed(2)}</div>
+                        {d.hours > 0 && (
+                          <div style={{ color: "var(--text-dim)" }}>
+                            {d.hours.toFixed(1)}h elapsed
+                          </div>
+                        )}
                       </div>
-                      <div style={{ color: 'var(--green)' }}>${d.total_cost.toFixed(2)}</div>
-                      {d.hours > 0 && <div style={{ color: 'var(--text-dim)' }}>{d.hours.toFixed(1)}h elapsed</div>}
-                    </div>
-                  );
-                }}
-              />
-              <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Bar dataKey="impl" name="Implementation" stackId="a" fill={WORK_TYPE_COLORS.new_ticket} radius={[0, 0, 0, 0]} />
-              <Bar dataKey="review" name="Review" stackId="a" fill={WORK_TYPE_COLORS.pr_review} radius={[0, 4, 4, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
+                    );
+                  }}
+                />
+                <Legend wrapperStyle={{ fontSize: 11 }} />
+                <Bar
+                  dataKey="impl"
+                  name="Implementation"
+                  stackId="a"
+                  fill={WORK_TYPE_COLORS.new_ticket}
+                  radius={[0, 0, 0, 0]}
+                />
+                <Bar
+                  dataKey="review"
+                  name="Review"
+                  stackId="a"
+                  fill={WORK_TYPE_COLORS.pr_review}
+                  radius={[0, 4, 4, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
           </CardBody>
         </Card>
       )}
 
       {/* Per-Cycle Chart */}
-      <Card isCompact isGlass style={{ marginBottom: '16px' }}>
+      <Card isCompact isGlass style={{ marginBottom: "16px" }}>
         <CardBody>
-        <div className="cycle-header-row">
-          <h3>Cycles</h3>
-          <div className="cycle-summary-inline">
-            <span>{cycles.length} total</span>
-            <span className="dot-sep" />
-            <span style={{ color: 'var(--green)' }}>{summary.work_cycles} work</span>
-            <span className="dot-sep" />
-            <span style={{ color: 'var(--text-dim)' }}>{summary.idle_cycles} idle</span>
-            {summary.error_cycles > 0 && <><span className="dot-sep" /><span style={{ color: 'var(--red)' }}>{summary.error_cycles} error</span></>}
-            <span className="dot-sep" />
-            <span style={{ color: 'var(--green)' }}>${summary.total_cost.toFixed(2)} total</span>
-            <span className="dot-sep" />
-            <span>${summary.work_cycles > 0 ? summary.avg_cost_per_work_cycle.toFixed(2) : '0.00'} avg/work</span>
-          </div>
-        </div>
-
-        <ToggleGroup aria-label="Metric" style={{ marginBottom: '12px' }}>
-          {(Object.keys(METRIC_CONFIG) as CycleMetric[]).map(m => (
-            <ToggleGroupItem key={m} text={METRIC_CONFIG[m].label} isSelected={m === metric} onChange={() => setMetric(m)} />
-          ))}
-        </ToggleGroup>
-
-        {cycleChartData.length > 1 && (
-          <>
-            <ResponsiveContainer width="100%" height={180}>
-              <AreaChart data={cycleChartData}>
-                <defs>
-                  <linearGradient id="cycleGrad" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor={mc.color} stopOpacity={0.3} />
-                    <stop offset="95%" stopColor={mc.color} stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" />
-                <XAxis dataKey="time" stroke="var(--text-dim)" fontSize={10} interval="preserveStartEnd" tick={false} />
-                <YAxis stroke="var(--text-dim)" fontSize={10} tickFormatter={mc.format} width={60} />
-                <Tooltip content={<CycleChartTooltip />} />
-                <Area type="monotone" dataKey={metric} stroke={mc.color} fill="url(#cycleGrad)" strokeWidth={2} dot={<CycleDot />} activeDot={<CycleActiveDot />} />
-              </AreaChart>
-            </ResponsiveContainer>
-            <div className="cycle-chart-legend">
-              {Object.entries(WORK_TYPE_LABELS).map(([key, label]) => (
-                <span key={key} className="cycle-legend-item">
-                  <span className="cycle-legend-dot" style={{ background: WORK_TYPE_COLORS[key] }} />
-                  {label}
-                </span>
-              ))}
+          <div className="cycle-header-row">
+            <h3>Cycles</h3>
+            <div className="cycle-summary-inline">
+              <span>{cycles.length} total</span>
+              <span className="dot-sep" />
+              <span style={{ color: "var(--green)" }}>{summary.work_cycles} work</span>
+              <span className="dot-sep" />
+              <span style={{ color: "var(--text-dim)" }}>{summary.idle_cycles} idle</span>
+              {summary.error_cycles > 0 && (
+                <>
+                  <span className="dot-sep" />
+                  <span style={{ color: "var(--red)" }}>{summary.error_cycles} error</span>
+                </>
+              )}
+              <span className="dot-sep" />
+              <span style={{ color: "var(--green)" }}>${summary.total_cost.toFixed(2)} total</span>
+              <span className="dot-sep" />
+              <span>
+                ${summary.work_cycles > 0 ? summary.avg_cost_per_work_cycle.toFixed(2) : "0.00"}{" "}
+                avg/work
+              </span>
             </div>
-          </>
-        )}
-
-        <div className="cycle-list">
-          <div className="cycle-row cycle-row-header">
-            <div>Time</div>
-            <div>Work</div>
-            <div>Cost</div>
-            <div>Turns</div>
-            <div>Duration</div>
-            <div>Tokens</div>
-            <div>Type</div>
           </div>
-          {cycles.length === 0 && <div className="empty-state">No cycles recorded</div>}
-          {cycles.map(c => <CycleRow key={c.id} c={c} />)}
-        </div>
+
+          <ToggleGroup aria-label="Metric" style={{ marginBottom: "12px" }}>
+            {(Object.keys(METRIC_CONFIG) as CycleMetric[]).map((m) => (
+              <ToggleGroupItem
+                key={m}
+                text={METRIC_CONFIG[m].label}
+                isSelected={m === metric}
+                onChange={() => setMetric(m)}
+              />
+            ))}
+          </ToggleGroup>
+
+          {cycleChartData.length > 1 && (
+            <>
+              <ResponsiveContainer width="100%" height={180}>
+                <AreaChart data={cycleChartData}>
+                  <defs>
+                    <linearGradient id="cycleGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor={mc.color} stopOpacity={0.3} />
+                      <stop offset="95%" stopColor={mc.color} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" />
+                  <XAxis
+                    dataKey="time"
+                    stroke="var(--text-dim)"
+                    fontSize={10}
+                    interval="preserveStartEnd"
+                    tick={false}
+                  />
+                  <YAxis
+                    stroke="var(--text-dim)"
+                    fontSize={10}
+                    tickFormatter={mc.format}
+                    width={60}
+                  />
+                  <Tooltip content={<CycleChartTooltip />} />
+                  <Area
+                    type="monotone"
+                    dataKey={metric}
+                    stroke={mc.color}
+                    fill="url(#cycleGrad)"
+                    strokeWidth={2}
+                    dot={<CycleDot />}
+                    activeDot={<CycleActiveDot />}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+              <div className="cycle-chart-legend">
+                {Object.entries(WORK_TYPE_LABELS).map(([key, label]) => (
+                  <span key={key} className="cycle-legend-item">
+                    <span
+                      className="cycle-legend-dot"
+                      style={{ background: WORK_TYPE_COLORS[key] }}
+                    />
+                    {label}
+                  </span>
+                ))}
+              </div>
+            </>
+          )}
+
+          <div className="cycle-list">
+            <div className="cycle-row cycle-row-header">
+              <div>Time</div>
+              <div>Work</div>
+              <div>Cost</div>
+              <div>Turns</div>
+              <div>Duration</div>
+              <div>Tokens</div>
+              <div>Type</div>
+            </div>
+            {cycles.length === 0 && <div className="empty-state">No cycles recorded</div>}
+            {cycles.map((c) => (
+              <CycleRow key={c.id} c={c} />
+            ))}
+          </div>
         </CardBody>
       </Card>
 
@@ -585,49 +846,81 @@ export default function Costs({ instanceId }: { instanceId?: string }) {
           </div>
           <div className="costs-charts">
             <Card isCompact isGlass>
-              <CardHeader><CardTitle>Cost per Day</CardTitle></CardHeader>
+              <CardHeader>
+                <CardTitle>Cost per Day</CardTitle>
+              </CardHeader>
               <CardBody>
-              <ResponsiveContainer width="100%" height={200}>
-                <AreaChart data={dailyCostData}>
-                  <defs>
-                    <linearGradient id="dailyCostGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#3fb950" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="#3fb950" stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" />
-                  <XAxis dataKey="day" stroke="var(--text-dim)" fontSize={11} />
-                  <YAxis stroke="var(--text-dim)" fontSize={11} tickFormatter={v => '$' + v} />
-                  <Tooltip content={<DailyChartTooltip />} />
-                  <Area type="monotone" dataKey="cost" name="Cost ($)" stroke="#3fb950" fill="url(#dailyCostGrad)" strokeWidth={2} dot={{ r: 3, fill: '#3fb950' }} />
-                </AreaChart>
-              </ResponsiveContainer>
+                <ResponsiveContainer width="100%" height={200}>
+                  <AreaChart data={dailyCostData}>
+                    <defs>
+                      <linearGradient id="dailyCostGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#3fb950" stopOpacity={0.3} />
+                        <stop offset="95%" stopColor="#3fb950" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" />
+                    <XAxis dataKey="day" stroke="var(--text-dim)" fontSize={11} />
+                    <YAxis stroke="var(--text-dim)" fontSize={11} tickFormatter={(v) => "$" + v} />
+                    <Tooltip content={<DailyChartTooltip />} />
+                    <Area
+                      type="monotone"
+                      dataKey="cost"
+                      name="Cost ($)"
+                      stroke="#3fb950"
+                      fill="url(#dailyCostGrad)"
+                      strokeWidth={2}
+                      dot={{ r: 3, fill: "#3fb950" }}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
               </CardBody>
             </Card>
             <Card isCompact isGlass>
-              <CardHeader><CardTitle>Tokens per Day</CardTitle></CardHeader>
+              <CardHeader>
+                <CardTitle>Tokens per Day</CardTitle>
+              </CardHeader>
               <CardBody>
-              <ResponsiveContainer width="100%" height={200}>
-                <AreaChart data={dailyTokenData}>
-                  <defs>
-                    <linearGradient id="dailyOutGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#3fb950" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="#3fb950" stopOpacity={0} />
-                    </linearGradient>
-                    <linearGradient id="dailyCacheGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#58a6ff" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="#58a6ff" stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" />
-                  <XAxis dataKey="day" stroke="var(--text-dim)" fontSize={11} />
-                  <YAxis stroke="var(--text-dim)" fontSize={11} tickFormatter={v => formatTokens(v)} />
-                  <Tooltip content={<DailyChartTooltip />} />
-                  <Legend wrapperStyle={{ fontSize: 11 }} />
-                  <Area type="monotone" dataKey="output" name="Output" stroke="#3fb950" fill="url(#dailyOutGrad)" strokeWidth={2} dot={{ r: 3, fill: '#3fb950' }} />
-                  <Area type="monotone" dataKey="cache_read" name="Cache Read" stroke="#58a6ff" fill="url(#dailyCacheGrad)" strokeWidth={2} dot={{ r: 3, fill: '#58a6ff' }} />
-                </AreaChart>
-              </ResponsiveContainer>
+                <ResponsiveContainer width="100%" height={200}>
+                  <AreaChart data={dailyTokenData}>
+                    <defs>
+                      <linearGradient id="dailyOutGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#3fb950" stopOpacity={0.3} />
+                        <stop offset="95%" stopColor="#3fb950" stopOpacity={0} />
+                      </linearGradient>
+                      <linearGradient id="dailyCacheGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#58a6ff" stopOpacity={0.3} />
+                        <stop offset="95%" stopColor="#58a6ff" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(48,54,61,0.5)" />
+                    <XAxis dataKey="day" stroke="var(--text-dim)" fontSize={11} />
+                    <YAxis
+                      stroke="var(--text-dim)"
+                      fontSize={11}
+                      tickFormatter={(v) => formatTokens(v)}
+                    />
+                    <Tooltip content={<DailyChartTooltip />} />
+                    <Legend wrapperStyle={{ fontSize: 11 }} />
+                    <Area
+                      type="monotone"
+                      dataKey="output"
+                      name="Output"
+                      stroke="#3fb950"
+                      fill="url(#dailyOutGrad)"
+                      strokeWidth={2}
+                      dot={{ r: 3, fill: "#3fb950" }}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="cache_read"
+                      name="Cache Read"
+                      stroke="#58a6ff"
+                      fill="url(#dailyCacheGrad)"
+                      strokeWidth={2}
+                      dot={{ r: 3, fill: "#58a6ff" }}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
               </CardBody>
             </Card>
           </div>

--- a/dashboard/src/pages/CycleRuns.spec.ts
+++ b/dashboard/src/pages/CycleRuns.spec.ts
@@ -1,91 +1,102 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
 const defaultGroup = {
   task_id: 42,
-  external_key: 'RHCLOUD-100',
-  title: 'Fix login bug',
+  external_key: "RHCLOUD-100",
+  title: "Fix login bug",
   cycle_count: 5,
-  latest_started_at: '2026-07-01T10:00:00Z',
+  latest_started_at: "2026-07-01T10:00:00Z",
   total_cost_usd: 2.5,
 };
 
 const defaultRun = {
   id: 10,
   task_id: 42,
-  cycle_type: 'task_work',
-  started_at: '2026-07-01T10:00:00Z',
-  finished_at: '2026-07-01T10:05:00Z',
+  cycle_type: "task_work",
+  started_at: "2026-07-01T10:00:00Z",
+  finished_at: "2026-07-01T10:05:00Z",
   tool_calls: 5,
   tokens_used: 2000,
   cost_usd: 0.5,
   has_transcript: false,
-  instance_id: 'dev-bot',
+  instance_id: "dev-bot",
   progress: null,
 };
 
-test.describe('CycleRuns page', () => {
+test.describe("CycleRuns page", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/cycle-runs/by-task*', (route) => {
+    await page.route("**/api/cycle-runs/by-task*", (route) => {
       route.fulfill({ json: { items: [], total: 0 } });
     });
-    await page.route('**/api/cycle-runs?*', (route) => {
+    await page.route("**/api/cycle-runs?*", (route) => {
       route.fulfill({ json: { items: [], total: 0 } });
     });
   });
 
-  test('shows empty state when no groups', async ({ mount, page }) => {
-    await mount('CycleRuns/Default');
-    await expect(page.getByText('No cycle runs found')).toBeVisible();
+  test("shows empty state when no groups", async ({ mount, page }) => {
+    await mount("CycleRuns/Default");
+    await expect(page.getByText("No cycle runs found")).toBeVisible();
   });
 
-  test('renders task groups from API', async ({ mount, page }) => {
-    const group = { ...defaultGroup, external_key: 'RHCLOUD-100', title: 'Fix login', cycle_count: 5 };
-    await page.route('**/api/cycle-runs/by-task*', (route) => {
+  test("renders task groups from API", async ({ mount, page }) => {
+    const group = {
+      ...defaultGroup,
+      external_key: "RHCLOUD-100",
+      title: "Fix login",
+      cycle_count: 5,
+    };
+    await page.route("**/api/cycle-runs/by-task*", (route) => {
       route.fulfill({ json: { items: [group], total: 1 } });
     });
 
-    await mount('CycleRuns/Default');
-    await expect(page.getByText('RHCLOUD-100')).toBeVisible();
-    await expect(page.getByText('Fix login')).toBeVisible();
-    await expect(page.getByText('5 cycles')).toBeVisible();
+    await mount("CycleRuns/Default");
+    await expect(page.getByText("RHCLOUD-100")).toBeVisible();
+    await expect(page.getByText("Fix login")).toBeVisible();
+    await expect(page.getByText("5 cycles")).toBeVisible();
   });
 
-  test('passes instance_id to fetchCycleRunsByTask', async ({ mount, page }) => {
-    let requestUrl = '';
-    await page.route('**/api/cycle-runs/by-task*', (route) => {
+  test("passes instance_id to fetchCycleRunsByTask", async ({ mount, page }) => {
+    let requestUrl = "";
+    await page.route("**/api/cycle-runs/by-task*", (route) => {
       requestUrl = route.request().url();
       route.fulfill({ json: { items: [], total: 0 } });
     });
 
-    await mount('CycleRuns/WithInstanceId');
+    await mount("CycleRuns/WithInstanceId");
     await page.waitForTimeout(200);
 
-    expect(requestUrl).toContain('instance_id=prod-bot');
+    expect(requestUrl).toContain("instance_id=prod-bot");
   });
 
-  test('expands group and loads cycle runs on click', async ({ mount, page }) => {
-    await page.route('**/api/cycle-runs/by-task*', (route) => {
+  test("expands group and loads cycle runs on click", async ({ mount, page }) => {
+    await page.route("**/api/cycle-runs/by-task*", (route) => {
       route.fulfill({ json: { items: [defaultGroup], total: 1 } });
     });
-    await page.route('**/api/cycle-runs?*', (route) => {
+    await page.route("**/api/cycle-runs?*", (route) => {
       route.fulfill({ json: { items: [defaultRun], total: 1 } });
     });
 
-    await mount('CycleRuns/Default');
-    await page.getByText('Fix login bug').click();
+    await mount("CycleRuns/Default");
+    await page.getByText("Fix login bug").click();
 
-    await expect(page.getByText('#10')).toBeVisible();
-    await expect(page.getByText('Work')).toBeVisible();
+    await expect(page.getByText("#10")).toBeVisible();
+    await expect(page.getByText("Work")).toBeVisible();
   });
 
-  test('renders orphan cycles group label', async ({ mount, page }) => {
-    const orphanGroup = { ...defaultGroup, task_id: null, external_key: null, title: null, cycle_count: 2 };
-    await page.route('**/api/cycle-runs/by-task*', (route) => {
+  test("renders orphan cycles group label", async ({ mount, page }) => {
+    const orphanGroup = {
+      ...defaultGroup,
+      task_id: null,
+      external_key: null,
+      title: null,
+      cycle_count: 2,
+    };
+    await page.route("**/api/cycle-runs/by-task*", (route) => {
       route.fulfill({ json: { items: [orphanGroup], total: 1 } });
     });
 
-    await mount('CycleRuns/Default');
-    await expect(page.getByText('Orphan cycles')).toBeVisible();
-    await expect(page.getByText('2 cycles')).toBeVisible();
+    await mount("CycleRuns/Default");
+    await expect(page.getByText("Orphan cycles")).toBeVisible();
+    await expect(page.getByText("2 cycles")).toBeVisible();
   });
 });

--- a/dashboard/src/pages/CycleRuns.test.tsx
+++ b/dashboard/src/pages/CycleRuns.test.tsx
@@ -1,19 +1,19 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import CycleRuns from './CycleRuns';
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CycleRuns from "./CycleRuns";
 
-vi.mock('../api', () => ({
+vi.mock("../api", () => ({
   fetchCycleRunsByTask: vi.fn(),
   fetchCycleRuns: vi.fn(),
   fetchCycleRunTranscript: vi.fn(),
 }));
 
-vi.mock('../hooks/useWebSocket', () => ({
+vi.mock("../hooks/useWebSocket", () => ({
   useWS: () => ({ connected: true, lastEvent: null, onEvent: () => () => {} }),
 }));
 
-import { fetchCycleRunsByTask, fetchCycleRuns } from '../api';
+import { fetchCycleRuns, fetchCycleRunsByTask } from "../api";
 
 const mockFetchCycleRunsByTask = vi.mocked(fetchCycleRunsByTask);
 const mockFetchCycleRuns = vi.mocked(fetchCycleRuns);
@@ -22,8 +22,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('CycleRuns page', () => {
-  it('handles empty cycle runs response correctly', async () => {
+describe("CycleRuns page", () => {
+  it("handles empty cycle runs response correctly", async () => {
     // Mock API returns paginated response with items array
     mockFetchCycleRunsByTask.mockResolvedValue({
       items: [],
@@ -33,34 +33,34 @@ describe('CycleRuns page', () => {
     });
 
     render(
-      <MemoryRouter initialEntries={['/instances/dev-bot/cycles']}>
+      <MemoryRouter initialEntries={["/instances/dev-bot/cycles"]}>
         <Routes>
           <Route path="/instances/:instanceId/cycles" element={<CycleRuns />} />
         </Routes>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Should render empty state without crashing
     await waitFor(() => {
-      expect(screen.getByText('No cycle runs found')).toBeInTheDocument();
+      expect(screen.getByText("No cycle runs found")).toBeInTheDocument();
     });
   });
 
-  it('handles cycle runs with task groups', async () => {
+  it("handles cycle runs with task groups", async () => {
     const mockGroups = [
       {
         task_id: 1,
-        external_key: 'RHCLOUD-001',
-        summary: 'Fix login bug',
+        external_key: "RHCLOUD-001",
+        summary: "Fix login bug",
         cycle_count: 3,
-        last_cycle_start: '2026-07-24T10:00:00Z',
+        last_cycle_start: "2026-07-24T10:00:00Z",
       },
       {
         task_id: 2,
-        external_key: 'RHCLOUD-002',
-        summary: 'Add dark mode',
+        external_key: "RHCLOUD-002",
+        summary: "Add dark mode",
         cycle_count: 1,
-        last_cycle_start: '2026-07-24T09:00:00Z',
+        last_cycle_start: "2026-07-24T09:00:00Z",
       },
     ];
 
@@ -79,17 +79,17 @@ describe('CycleRuns page', () => {
     });
 
     render(
-      <MemoryRouter initialEntries={['/instances/dev-bot/cycles']}>
+      <MemoryRouter initialEntries={["/instances/dev-bot/cycles"]}>
         <Routes>
           <Route path="/instances/:instanceId/cycles" element={<CycleRuns />} />
         </Routes>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Should render both task groups
     await waitFor(() => {
-      expect(screen.getByText('RHCLOUD-001')).toBeInTheDocument();
-      expect(screen.getByText('RHCLOUD-002')).toBeInTheDocument();
+      expect(screen.getByText("RHCLOUD-001")).toBeInTheDocument();
+      expect(screen.getByText("RHCLOUD-002")).toBeInTheDocument();
     });
   });
 });

--- a/dashboard/src/pages/CycleRuns.tsx
+++ b/dashboard/src/pages/CycleRuns.tsx
@@ -1,38 +1,37 @@
-import { useEffect, useState, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import Markdown from 'react-markdown';
-import type { CycleRun, TaskCycleGroup } from '../types';
-import { fetchCycleRuns, fetchCycleRunsByTask, fetchCycleRunTranscript } from '../api';
-import { useWS } from '../hooks/useWebSocket';
-import CycleRunCard from '../components/CycleRunCard';
-import { timeAgo, formatDuration, formatTokens, sourceUrl, displayKey } from '../utils';
 import {
+  Button,
   Card,
+  CardBody,
   CardHeader,
   CardTitle,
-  CardBody,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Divider,
   Flex,
   FlexItem,
   Label,
   LabelGroup,
-  Button,
-  Content,
-  Divider,
-  DescriptionList,
-  DescriptionListGroup,
-  DescriptionListTerm,
-  DescriptionListDescription,
   SearchInput,
   ToggleGroup,
-  ToggleGroupItem
-} from '@patternfly/react-core';
-import { DownloadIcon, ExpandIcon, CompressIcon, TimesIcon } from '@patternfly/react-icons';
-
-import JSZip from 'jszip';
+  ToggleGroupItem,
+} from "@patternfly/react-core";
+import { CompressIcon, DownloadIcon, ExpandIcon, TimesIcon } from "@patternfly/react-icons";
+import JSZip from "jszip";
+import { useCallback, useEffect, useState } from "react";
+import Markdown from "react-markdown";
+import { useSearchParams } from "react-router-dom";
+import { fetchCycleRuns, fetchCycleRunsByTask, fetchCycleRunTranscript } from "../api";
+import CycleRunCard from "../components/CycleRunCard";
+import { useWS } from "../hooks/useWebSocket";
+import type { CycleRun, TaskCycleGroup } from "../types";
+import { displayKey, formatDuration, formatTokens, sourceUrl, timeAgo } from "../utils";
 
 function downloadBlob(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
+  const a = document.createElement("a");
   a.href = url;
   a.download = filename;
   a.click();
@@ -40,13 +39,17 @@ function downloadBlob(blob: Blob, filename: string) {
 }
 
 function downloadText(content: string, filename: string) {
-  downloadBlob(new Blob([content], { type: 'application/x-ndjson' }), filename);
+  downloadBlob(new Blob([content], { type: "application/x-ndjson" }), filename);
 }
 
-async function downloadAllTranscripts(taskId: number | null, key: string | null, instanceId?: string) {
-  const params: { task_id?: number | 'none'; instance_id?: string; limit: number } = { limit: 100 };
+async function downloadAllTranscripts(
+  taskId: number | null,
+  key: string | null,
+  instanceId?: string,
+) {
+  const params: { task_id?: number | "none"; instance_id?: string; limit: number } = { limit: 100 };
   if (taskId != null) params.task_id = taskId;
-  else if (!key) params.task_id = 'none';
+  else if (!key) params.task_id = "none";
   if (instanceId) params.instance_id = instanceId;
   const res = await fetchCycleRuns(params);
   const runs: CycleRun[] = res.items || [];
@@ -55,15 +58,15 @@ async function downloadAllTranscripts(taskId: number | null, key: string | null,
   for (const run of runs) {
     try {
       const text = await fetchCycleRunTranscript(run.id);
-      const ts = run.started_at.replace(/[:.]/g, '-').slice(0, 19);
+      const ts = run.started_at.replace(/[:.]/g, "-").slice(0, 19);
       zip.file(`cycle-${run.id}-${run.cycle_type}-${ts}.jsonl`, text);
     } catch {
       // skip cycles without transcript
     }
   }
 
-  const label = key || (taskId != null ? `task-${taskId}` : 'orphan');
-  const blob = await zip.generateAsync({ type: 'blob' });
+  const label = key || (taskId != null ? `task-${taskId}` : "orphan");
+  const blob = await zip.generateAsync({ type: "blob" });
   downloadBlob(blob, `transcripts-${label}.zip`);
 }
 
@@ -77,15 +80,20 @@ interface ParsedEntry {
 
 function parseTranscript(raw: string): ParsedEntry[] {
   const entries: ParsedEntry[] = [];
-  for (const line of raw.trim().split('\n')) {
+  for (const line of raw.trim().split("\n")) {
     let data: any;
     try {
       data = JSON.parse(line);
     } catch {
       continue;
     }
-    const lineType = data.type || '';
-    if (!data.message || lineType === 'queue-operation' || lineType === 'last-prompt' || lineType === 'attachment') {
+    const lineType = data.type || "";
+    if (
+      !data.message ||
+      lineType === "queue-operation" ||
+      lineType === "last-prompt" ||
+      lineType === "attachment"
+    ) {
       continue;
     }
     const msg = data.message;
@@ -93,31 +101,60 @@ function parseTranscript(raw: string): ParsedEntry[] {
     const blocks = Array.isArray(msg.content) ? msg.content : [];
 
     for (const block of blocks) {
-      if (!block || typeof block !== 'object') continue;
-      const bt = block.type || '';
+      if (!block || typeof block !== "object") continue;
+      const bt = block.type || "";
 
-      if (bt === 'text') {
-        const text = block.text || '';
+      if (bt === "text") {
+        const text = block.text || "";
         if (text.trim()) {
-          entries.push({ role, blockType: 'text', label: '', content: text, isLarge: text.length > 500 });
+          entries.push({
+            role,
+            blockType: "text",
+            label: "",
+            content: text,
+            isLarge: text.length > 500,
+          });
         }
-      } else if (bt === 'thinking') {
-        const text = block.thinking || '';
+      } else if (bt === "thinking") {
+        const text = block.thinking || "";
         if (text.trim()) {
-          entries.push({ role: 'thinking', blockType: 'thinking', label: '', content: text, isLarge: text.length > 300 });
+          entries.push({
+            role: "thinking",
+            blockType: "thinking",
+            label: "",
+            content: text,
+            isLarge: text.length > 300,
+          });
         }
-      } else if (bt === 'tool_use') {
-        const name = block.name || '?';
+      } else if (bt === "tool_use") {
+        const name = block.name || "?";
         const input = block.input || {};
-        const summary = Object.entries(input).slice(0, 3).map(([k, v]) => `${k}=${String(v).slice(0, 60)}`).join(', ');
-        entries.push({ role: 'tool', blockType: 'tool_use', label: name, content: summary, isLarge: false });
-      } else if (bt === 'tool_result') {
-        let content = block.content || '';
+        const summary = Object.entries(input)
+          .slice(0, 3)
+          .map(([k, v]) => `${k}=${String(v).slice(0, 60)}`)
+          .join(", ");
+        entries.push({
+          role: "tool",
+          blockType: "tool_use",
+          label: name,
+          content: summary,
+          isLarge: false,
+        });
+      } else if (bt === "tool_result") {
+        let content = block.content || "";
         if (Array.isArray(content)) {
-          content = content.map((c: any) => typeof c === 'string' ? c : c.text || JSON.stringify(c)).join('\n');
+          content = content
+            .map((c: any) => (typeof c === "string" ? c : c.text || JSON.stringify(c)))
+            .join("\n");
         }
-        const text = typeof content === 'string' ? content : JSON.stringify(content);
-        entries.push({ role: 'result', blockType: 'tool_result', label: '', content: text, isLarge: text.length > 300 });
+        const text = typeof content === "string" ? content : JSON.stringify(content);
+        entries.push({
+          role: "result",
+          blockType: "tool_result",
+          label: "",
+          content: text,
+          isLarge: text.length > 300,
+        });
       }
     }
   }
@@ -128,24 +165,30 @@ const transcriptCache = new Map<number, string>();
 
 function Highlight({ text, search }: { text: string; search: string }) {
   if (!search) return <>{text}</>;
-  const parts = text.split(new RegExp(`(${search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
+  const parts = text.split(new RegExp(`(${search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi"));
   return (
     <>
       {parts.map((part, i) =>
         part.toLowerCase() === search.toLowerCase() ? (
-          <mark key={i} className="search-highlight">{part}</mark>
+          <mark key={i} className="search-highlight">
+            {part}
+          </mark>
         ) : (
           <span key={i}>{part}</span>
-        )
+        ),
       )}
     </>
   );
 }
 
-function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onRequestFullscreen?: () => void }) {
-  const [transcript, setTranscript] = useState<string | null>(
-    transcriptCache.get(runId) ?? null
-  );
+function TranscriptViewer({
+  runId,
+  onRequestFullscreen,
+}: {
+  runId: number;
+  onRequestFullscreen?: () => void;
+}) {
+  const [transcript, setTranscript] = useState<string | null>(transcriptCache.get(runId) ?? null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [rawMode, setRawMode] = useState(false);
@@ -153,13 +196,15 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
     const cached = transcriptCache.get(runId);
     if (cached) {
       const largeIds = new Set<number>();
-      parseTranscript(cached).forEach((e, i) => { if (e.isLarge) largeIds.add(i); });
+      parseTranscript(cached).forEach((e, i) => {
+        if (e.isLarge) largeIds.add(i);
+      });
       return largeIds;
     }
     return new Set();
   });
   const [showThinking, setShowThinking] = useState(false);
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState("");
 
   const load = async () => {
     setLoading(true);
@@ -170,10 +215,12 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
       setTranscript(text);
       const parsed = parseTranscript(text);
       const largeIds = new Set<number>();
-      parsed.forEach((e, i) => { if (e.isLarge) largeIds.add(i); });
+      parsed.forEach((e, i) => {
+        if (e.isLarge) largeIds.add(i);
+      });
       setCollapsed(largeIds);
     } catch (e: any) {
-      setError(e.message || 'Failed to load transcript');
+      setError(e.message || "Failed to load transcript");
     } finally {
       setLoading(false);
     }
@@ -181,19 +228,31 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
 
   if (transcript === null && !loading && !error) {
     return (
-      <Button variant="secondary" onClick={load}>Load Transcript</Button>
+      <Button variant="secondary" onClick={load}>
+        Load Transcript
+      </Button>
     );
   }
   if (loading) return <Content component="p">Loading transcript...</Content>;
-  if (error) return <Content component="p" style={{ color: 'var(--pf-t--global--color--status--danger--default)' }}>{error}</Content>;
+  if (error)
+    return (
+      <Content
+        component="p"
+        style={{ color: "var(--pf-t--global--color--status--danger--default)" }}
+      >
+        {error}
+      </Content>
+    );
   if (!transcript) return null;
 
   const entries = parseTranscript(transcript);
   const searchLower = search.toLowerCase();
-  let visible = showThinking ? entries : entries.filter((e) => e.blockType !== 'thinking');
+  let visible = showThinking ? entries : entries.filter((e) => e.blockType !== "thinking");
   if (search) {
     visible = visible.filter(
-      (e) => e.content.toLowerCase().includes(searchLower) || e.label.toLowerCase().includes(searchLower)
+      (e) =>
+        e.content.toLowerCase().includes(searchLower) ||
+        e.label.toLowerCase().includes(searchLower),
     );
   }
 
@@ -208,7 +267,11 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
 
   return (
     <div className="transcript-viewer">
-      <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} style={{ marginBottom: '8px' }}>
+      <Flex
+        alignItems={{ default: "alignItemsCenter" }}
+        gap={{ default: "gapSm" }}
+        style={{ marginBottom: "8px" }}
+      >
         <FlexItem>
           <Label variant="outline">{visible.length} entries</Label>
         </FlexItem>
@@ -217,19 +280,38 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
             placeholder="Search transcript..."
             value={search}
             onChange={(_e, val) => setSearch(val)}
-            onClear={() => setSearch('')}
+            onClear={() => setSearch("")}
             onFocus={() => onRequestFullscreen?.()}
           />
         </FlexItem>
         <FlexItem>
-          <Button variant="plain" size="sm" onClick={() => downloadText(transcript, `cycle-${runId}.jsonl`)} title="Download transcript">
+          <Button
+            variant="plain"
+            size="sm"
+            onClick={() => downloadText(transcript, `cycle-${runId}.jsonl`)}
+            title="Download transcript"
+          >
             <DownloadIcon />
           </Button>
         </FlexItem>
         <FlexItem style={{ flexShrink: 0 }}>
           <ToggleGroup aria-label="View options">
-            <ToggleGroupItem text="Thinking" isSelected={showThinking} onChange={() => { setShowThinking(!showThinking); setRawMode(false); }} />
-            <ToggleGroupItem text="Raw" isSelected={rawMode} onChange={() => { setRawMode(!rawMode); setShowThinking(false); }} />
+            <ToggleGroupItem
+              text="Thinking"
+              isSelected={showThinking}
+              onChange={() => {
+                setShowThinking(!showThinking);
+                setRawMode(false);
+              }}
+            />
+            <ToggleGroupItem
+              text="Raw"
+              isSelected={rawMode}
+              onChange={() => {
+                setRawMode(!rawMode);
+                setShowThinking(false);
+              }}
+            />
           </ToggleGroup>
         </FlexItem>
       </Flex>
@@ -241,7 +323,10 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
             const isCollapsed = collapsed.has(i) && !search;
             return (
               <div key={i} className={`transcript-line role-${entry.role}`}>
-                <div className="transcript-line-header" onClick={() => entry.isLarge && toggleCollapse(i)}>
+                <div
+                  className="transcript-line-header"
+                  onClick={() => entry.isLarge && toggleCollapse(i)}
+                >
                   <span className="transcript-role">{entry.role}</span>
                   {entry.label && (
                     <span className="transcript-tool-name">
@@ -249,11 +334,11 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
                     </span>
                   )}
                   {entry.isLarge && !search && (
-                    <span className="transcript-toggle">{collapsed.has(i) ? '[+]' : '[-]'}</span>
+                    <span className="transcript-toggle">{collapsed.has(i) ? "[+]" : "[-]"}</span>
                   )}
                 </div>
-                {!isCollapsed && (
-                  entry.blockType === 'text' || entry.blockType === 'thinking' ? (
+                {!isCollapsed &&
+                  (entry.blockType === "text" || entry.blockType === "thinking" ? (
                     <div className="transcript-line-md">
                       {search ? (
                         <pre className="transcript-line-content">
@@ -267,8 +352,7 @@ function TranscriptViewer({ runId, onRequestFullscreen }: { runId: number; onReq
                     <pre className="transcript-line-content">
                       <Highlight text={entry.content.slice(0, 3000)} search={search} />
                     </pre>
-                  )
-                )}
+                  ))}
               </div>
             );
           })}
@@ -296,20 +380,28 @@ function CycleRunDetail({
       : null;
 
   return (
-    <Card isGlass className={fullscreen ? 'detail-fullscreen' : ''}>
+    <Card isGlass className={fullscreen ? "detail-fullscreen" : ""}>
       <CardHeader
-        actions={{ actions: (
-          <Flex gap={{ default: 'gapSm' }}>
-            <FlexItem>
-              <Button variant="plain" onClick={onToggleFullscreen} title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
-                {fullscreen ? <CompressIcon /> : <ExpandIcon />}
-              </Button>
-            </FlexItem>
-            <FlexItem>
-              <Button variant="plain" onClick={onClose}><TimesIcon /></Button>
-            </FlexItem>
-          </Flex>
-        ) }}
+        actions={{
+          actions: (
+            <Flex gap={{ default: "gapSm" }}>
+              <FlexItem>
+                <Button
+                  variant="plain"
+                  onClick={onToggleFullscreen}
+                  title={fullscreen ? "Exit fullscreen" : "Fullscreen"}
+                >
+                  {fullscreen ? <CompressIcon /> : <ExpandIcon />}
+                </Button>
+              </FlexItem>
+              <FlexItem>
+                <Button variant="plain" onClick={onClose}>
+                  <TimesIcon />
+                </Button>
+              </FlexItem>
+            </Flex>
+          ),
+        }}
       >
         <CardTitle>Cycle #{run.id}</CardTitle>
       </CardHeader>
@@ -318,7 +410,7 @@ function CycleRunDetail({
           <DescriptionListGroup>
             <DescriptionListTerm>Type</DescriptionListTerm>
             <DescriptionListDescription>
-              <Label color="blue">{run.cycle_type.replace(/_/g, ' ').toUpperCase()}</Label>
+              <Label color="blue">{run.cycle_type.replace(/_/g, " ").toUpperCase()}</Label>
             </DescriptionListDescription>
           </DescriptionListGroup>
           {run.instance_id && (
@@ -329,7 +421,9 @@ function CycleRunDetail({
           )}
           <DescriptionListGroup>
             <DescriptionListTerm>Started</DescriptionListTerm>
-            <DescriptionListDescription title={run.started_at}>{timeAgo(run.started_at)}</DescriptionListDescription>
+            <DescriptionListDescription title={run.started_at}>
+              {timeAgo(run.started_at)}
+            </DescriptionListDescription>
           </DescriptionListGroup>
           {duration != null && (
             <DescriptionListGroup>
@@ -346,14 +440,16 @@ function CycleRunDetail({
           {run.tokens_used != null && (
             <DescriptionListGroup>
               <DescriptionListTerm>Tokens</DescriptionListTerm>
-              <DescriptionListDescription>{formatTokens(run.tokens_used)}</DescriptionListDescription>
+              <DescriptionListDescription>
+                {formatTokens(run.tokens_used)}
+              </DescriptionListDescription>
             </DescriptionListGroup>
           )}
         </DescriptionList>
 
         {Object.keys(progress).length > 0 && (
           <>
-            <Divider style={{ margin: '16px 0' }} />
+            <Divider style={{ margin: "16px 0" }} />
             <Content component="h4">Progress</Content>
             <DescriptionList isCompact>
               {progress.last_step && (
@@ -385,7 +481,9 @@ function CycleRunDetail({
                   <DescriptionListTerm>Files</DescriptionListTerm>
                   <DescriptionListDescription>
                     {(progress.files_changed as string[]).map((f: string, i: number) => (
-                      <div key={i}><code>{f}</code></div>
+                      <div key={i}>
+                        <code>{f}</code>
+                      </div>
                     ))}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
@@ -408,18 +506,26 @@ function CycleRunDetail({
 
         {run.input_prompt && (
           <>
-            <Divider style={{ margin: '16px 0' }} />
+            <Divider style={{ margin: "16px 0" }} />
             <Content component="h4">Input Prompt</Content>
             <pre className="input-prompt-content">{run.input_prompt}</pre>
           </>
         )}
 
-        <Divider style={{ margin: '16px 0' }} />
+        <Divider style={{ margin: "16px 0" }} />
         <Content component="h4">Transcript</Content>
         {run.has_transcript ? (
-          <TranscriptViewer runId={run.id} onRequestFullscreen={() => { if (!fullscreen) onToggleFullscreen(); }} />
+          <TranscriptViewer
+            runId={run.id}
+            onRequestFullscreen={() => {
+              if (!fullscreen) onToggleFullscreen();
+            }}
+          />
         ) : (
-          <Content component="p" style={{ color: 'var(--pf-t--global--text--color--subtle, var(--text-dim))' }}>
+          <Content
+            component="p"
+            style={{ color: "var(--pf-t--global--text--color--subtle, var(--text-dim))" }}
+          >
             No transcript available for this cycle run.
           </Content>
         )}
@@ -441,7 +547,7 @@ function TaskGroupCard({
 }) {
   const key = displayKey(group);
   const url = sourceUrl(group);
-  const label = key || (group.task_id != null ? `Task #${group.task_id}` : 'Orphan cycles');
+  const label = key || (group.task_id != null ? `Task #${group.task_id}` : "Orphan cycles");
   const [downloading, setDownloading] = useState(false);
 
   const handleDownload = async (e: React.MouseEvent) => {
@@ -455,34 +561,47 @@ function TaskGroupCard({
   };
 
   return (
-    <Card isCompact isGlass isSelected={expanded} onClick={onClick} style={{ cursor: 'pointer', marginBottom: '8px' }}>
+    <Card
+      isCompact
+      isGlass
+      isSelected={expanded}
+      onClick={onClick}
+      style={{ cursor: "pointer", marginBottom: "8px" }}
+    >
       <CardHeader
-        actions={{ actions: (
-          <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-            {group.transcript_count > 0 && (
+        actions={{
+          actions: (
+            <Flex alignItems={{ default: "alignItemsCenter" }} gap={{ default: "gapSm" }}>
+              {group.transcript_count > 0 && (
+                <FlexItem>
+                  <Button
+                    variant="plain"
+                    size="sm"
+                    onClick={handleDownload}
+                    isDisabled={downloading}
+                    title="Download all transcripts as ZIP"
+                  >
+                    {downloading ? "..." : <DownloadIcon />}
+                  </Button>
+                </FlexItem>
+              )}
               <FlexItem>
-                <Button
-                  variant="plain"
-                  size="sm"
-                  onClick={handleDownload}
-                  isDisabled={downloading}
-                  title="Download all transcripts as ZIP"
-                >
-                  {downloading ? '...' : <DownloadIcon />}
-                </Button>
+                <Label variant="outline">{group.cycle_count} cycles</Label>
               </FlexItem>
-            )}
-            <FlexItem>
-              <Label variant="outline">{group.cycle_count} cycles</Label>
-            </FlexItem>
-          </Flex>
-        ) }}
+            </Flex>
+          ),
+        }}
       >
         <CardTitle>
-          <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+          <Flex alignItems={{ default: "alignItemsCenter" }} gap={{ default: "gapSm" }}>
             <FlexItem>
               {key ? (
-                <a href={url || '#'} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
+                <a
+                  href={url || "#"}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   {key}
                 </a>
               ) : (
@@ -498,18 +617,26 @@ function TaskGroupCard({
         </CardTitle>
       </CardHeader>
       <CardBody>
-        <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
           {group.title && (
             <FlexItem>
-              <Content component="p" style={{ margin: 0 }}>{group.title}</Content>
+              <Content component="p" style={{ margin: 0 }}>
+                {group.title}
+              </Content>
             </FlexItem>
           )}
           <FlexItem>
             <LabelGroup>
               {group.repo && <Label variant="outline">{group.repo}</Label>}
-              {group.total_tokens != null && <Label variant="outline">{formatTokens(group.total_tokens)} tokens</Label>}
-              {group.transcript_count > 0 && <Label variant="outline">{group.transcript_count} transcripts</Label>}
-              {group.last_cycle && <Label variant="outline">last {timeAgo(group.last_cycle)}</Label>}
+              {group.total_tokens != null && (
+                <Label variant="outline">{formatTokens(group.total_tokens)} tokens</Label>
+              )}
+              {group.transcript_count > 0 && (
+                <Label variant="outline">{group.transcript_count} transcripts</Label>
+              )}
+              {group.last_cycle && (
+                <Label variant="outline">last {timeAgo(group.last_cycle)}</Label>
+              )}
             </LabelGroup>
           </FlexItem>
         </Flex>
@@ -522,7 +649,7 @@ function groupKey(g: TaskCycleGroup): string {
   if (g.task_id != null) return `t:${g.task_id}`;
   const key = g.external_key;
   if (key) return `k:${key}`;
-  return 'orphan';
+  return "orphan";
 }
 
 export default function CycleRuns({ instanceId }: { instanceId?: string }) {
@@ -537,10 +664,10 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
   useEffect(() => {
     if (!fullscreen) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setFullscreen(false);
+      if (e.key === "Escape") setFullscreen(false);
     };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, [fullscreen]);
 
   const { onEvent } = useWS();
@@ -550,33 +677,38 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
     setGroups(data?.items || []);
   }, [instanceId]);
 
-  const loadCyclesForTask = useCallback(async (taskId: number | null, orphan = false, showLoading = true) => {
-    if (showLoading) setLoadingRuns(true);
-    try {
-      const params: { task_id?: number | 'none'; instance_id?: string; limit: number } = { limit: 50 };
-      if (taskId != null) params.task_id = taskId;
-      else if (orphan) params.task_id = 'none';
-      if (instanceId) params.instance_id = instanceId;
-      const res = await fetchCycleRuns(params);
-      setRuns(res.items || []);
-      return res.items || [];
-    } finally {
-      if (showLoading) setLoadingRuns(false);
-    }
-  }, [instanceId]);
+  const loadCyclesForTask = useCallback(
+    async (taskId: number | null, orphan = false, showLoading = true) => {
+      if (showLoading) setLoadingRuns(true);
+      try {
+        const params: { task_id?: number | "none"; instance_id?: string; limit: number } = {
+          limit: 50,
+        };
+        if (taskId != null) params.task_id = taskId;
+        else if (orphan) params.task_id = "none";
+        if (instanceId) params.instance_id = instanceId;
+        const res = await fetchCycleRuns(params);
+        setRuns(res.items || []);
+        return res.items || [];
+      } finally {
+        if (showLoading) setLoadingRuns(false);
+      }
+    },
+    [instanceId],
+  );
 
   useEffect(() => {
     loadGroups();
   }, [loadGroups]);
 
   useEffect(() => {
-    const cycleParam = searchParams.get('cycle');
-    const taskParam = searchParams.get('task_id');
+    const cycleParam = searchParams.get("cycle");
+    const taskParam = searchParams.get("task_id");
     if (cycleParam && groups.length > 0 && !selectedRun) {
       const cycleId = parseInt(cycleParam);
       const tid = taskParam ? parseInt(taskParam) : null;
       const match = groups.find((g) => g.task_id === tid);
-      setExpandedGroupKey(match ? groupKey(match) : tid != null ? `t:${tid}` : 'orphan');
+      setExpandedGroupKey(match ? groupKey(match) : tid != null ? `t:${tid}` : "orphan");
       loadCyclesForTask(tid, tid == null, false).then((items) => {
         const found = items.find((r: CycleRun) => r.id === cycleId);
         if (found) setSelectedRun(found);
@@ -586,7 +718,7 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
 
   useEffect(() => {
     return onEvent((event) => {
-      if (event.type === 'cycle_run_added') {
+      if (event.type === "cycle_run_added") {
         loadGroups();
         if (expandedGroupKey) {
           const expanded = groups.find((g) => groupKey(g) === expandedGroupKey);
@@ -619,9 +751,9 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
     setSelectedRun(run);
     setFullscreen(false);
     const params = new URLSearchParams(searchParams);
-    params.set('cycle', String(run.id));
-    if (run.task_id != null) params.set('task_id', String(run.task_id));
-    else params.delete('task_id');
+    params.set("cycle", String(run.id));
+    if (run.task_id != null) params.set("task_id", String(run.task_id));
+    else params.delete("task_id");
     setSearchParams(params, { replace: true });
   };
 
@@ -629,8 +761,8 @@ export default function CycleRuns({ instanceId }: { instanceId?: string }) {
     setSelectedRun(null);
     setFullscreen(false);
     const params = new URLSearchParams(searchParams);
-    params.delete('cycle');
-    params.delete('task_id');
+    params.delete("cycle");
+    params.delete("task_id");
     setSearchParams(params, { replace: true });
   };
 

--- a/dashboard/src/pages/EmbeddingMap.tsx
+++ b/dashboard/src/pages/EmbeddingMap.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
-import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import type { EmbeddingPoint, Memory } from '../types';
-import { fetchEmbeddings, fetchMemory } from '../api';
-import DetailPanel from '../components/DetailPanel';
-import { deleteMemory } from '../api';
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { deleteMemory, fetchEmbeddings, fetchMemory } from "../api";
+import DetailPanel from "../components/DetailPanel";
+import type { EmbeddingPoint, Memory } from "../types";
 
 const CATEGORY_COLORS: Record<string, number> = {
   learning: 0x3fb950,
@@ -40,7 +39,7 @@ export default function EmbeddingMap() {
       60,
       container.clientWidth / container.clientHeight,
       0.1,
-      1000
+      1000,
     );
     camera.position.set(3, 3, 3);
 
@@ -65,11 +64,12 @@ export default function EmbeddingMap() {
       new THREE.Vector3(0, 0, axisLen),
     ];
     axisDirections.forEach((dir, i) => {
-      const geo = new THREE.BufferGeometry().setFromPoints([
-        new THREE.Vector3(0, 0, 0),
-        dir,
-      ]);
-      const mat = new THREE.LineBasicMaterial({ color: axisColors[i], opacity: 0.3, transparent: true });
+      const geo = new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0, 0, 0), dir]);
+      const mat = new THREE.LineBasicMaterial({
+        color: axisColors[i],
+        opacity: 0.3,
+        transparent: true,
+      });
       scene.add(new THREE.Line(geo, mat));
     });
 
@@ -94,8 +94,8 @@ export default function EmbeddingMap() {
         if (idx !== hoveredIndex) {
           hoveredIndex = idx;
           const pt = pointData[idx];
-          tooltip.style.display = 'block';
-          tooltip.innerHTML = `<strong>${pt.title}</strong><br/><span class="viz-tooltip-cat">${pt.category.replace(/_/g, ' ')}</span>`;
+          tooltip.style.display = "block";
+          tooltip.innerHTML = `<strong>${pt.title}</strong><br/><span class="viz-tooltip-cat">${pt.category.replace(/_/g, " ")}</span>`;
           // Dim others, highlight hovered
           spheres.forEach((s, i) => {
             const mat = s.material as THREE.MeshBasicMaterial;
@@ -108,11 +108,11 @@ export default function EmbeddingMap() {
             }
           });
         }
-        tooltip.style.left = e.clientX - container.getBoundingClientRect().left + 12 + 'px';
-        tooltip.style.top = e.clientY - container.getBoundingClientRect().top - 10 + 'px';
+        tooltip.style.left = e.clientX - container.getBoundingClientRect().left + 12 + "px";
+        tooltip.style.top = e.clientY - container.getBoundingClientRect().top - 10 + "px";
       } else if (hoveredIndex !== -1) {
         hoveredIndex = -1;
-        tooltip.style.display = 'none';
+        tooltip.style.display = "none";
         spheres.forEach((s) => {
           const mat = s.material as THREE.MeshBasicMaterial;
           mat.opacity = 0.85;
@@ -137,8 +137,8 @@ export default function EmbeddingMap() {
       }
     };
 
-    container.addEventListener('mousemove', onMouseMove);
-    container.addEventListener('click', onClick);
+    container.addEventListener("mousemove", onMouseMove);
+    container.addEventListener("click", onClick);
 
     const onResize = () => {
       if (disposed) return;
@@ -146,7 +146,7 @@ export default function EmbeddingMap() {
       camera.updateProjectionMatrix();
       renderer.setSize(container.clientWidth, container.clientHeight);
     };
-    window.addEventListener('resize', onResize);
+    window.addEventListener("resize", onResize);
 
     const resizeObserver = new ResizeObserver(onResize);
     resizeObserver.observe(container);
@@ -170,7 +170,11 @@ export default function EmbeddingMap() {
       });
 
       // Lines between nearby same-category points
-      const lineMat = new THREE.LineBasicMaterial({ color: 0x30363d, opacity: 0.3, transparent: true });
+      const lineMat = new THREE.LineBasicMaterial({
+        color: 0x30363d,
+        opacity: 0.3,
+        transparent: true,
+      });
       for (let i = 0; i < points.length; i++) {
         for (let j = i + 1; j < points.length; j++) {
           if (points[i].category !== points[j].category) continue;
@@ -202,9 +206,9 @@ export default function EmbeddingMap() {
     cleanupRef.current = () => {
       disposed = true;
       cancelAnimationFrame(animId);
-      container.removeEventListener('mousemove', onMouseMove);
-      container.removeEventListener('click', onClick);
-      window.removeEventListener('resize', onResize);
+      container.removeEventListener("mousemove", onMouseMove);
+      container.removeEventListener("click", onClick);
+      window.removeEventListener("resize", onResize);
       resizeObserver.disconnect();
       controls.dispose();
       renderer.dispose();
@@ -238,18 +242,18 @@ export default function EmbeddingMap() {
   return (
     <div className="split-layout viz-layout">
       <div className="viz-container" ref={containerRef}>
-        <div className="viz-tooltip" ref={tooltipRef} style={{ display: 'none' }} />
+        <div className="viz-tooltip" ref={tooltipRef} style={{ display: "none" }} />
         <div className="viz-legend">
           <div className="viz-legend-item">
-            <span className="viz-dot" style={{ background: '#3fb950' }} />
+            <span className="viz-dot" style={{ background: "#3fb950" }} />
             learning
           </div>
           <div className="viz-legend-item">
-            <span className="viz-dot" style={{ background: '#d29922' }} />
+            <span className="viz-dot" style={{ background: "#d29922" }} />
             review feedback
           </div>
           <div className="viz-legend-item">
-            <span className="viz-dot" style={{ background: '#58a6ff' }} />
+            <span className="viz-dot" style={{ background: "#58a6ff" }} />
             codebase pattern
           </div>
         </div>

--- a/dashboard/src/pages/Instances.spec.ts
+++ b/dashboard/src/pages/Instances.spec.ts
@@ -1,95 +1,112 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
 function makeInstance(overrides: Record<string, any> = {}) {
   return {
-    instance_id: 'dev-bot',
-    state: 'idle',
-    message: '',
+    instance_id: "dev-bot",
+    state: "idle",
+    message: "",
     external_key: null,
     source_type: null,
     source_url: null,
     repo: null,
     cycle_start: null,
-    updated_at: '2026-07-01T10:00:00Z',
+    updated_at: "2026-07-01T10:00:00Z",
     active_tasks: 2,
     max_tasks: 10,
     ...overrides,
   };
 }
 
-test.describe('Instances page', () => {
+test.describe("Instances page", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/instances', (route) => {
+    await page.route("**/api/instances", (route) => {
       route.fulfill({ json: [] });
     });
   });
 
-  test('shows empty state when no instances', async ({ mount, page }) => {
-    await mount('Instances/Default');
-    await expect(page.getByText('No bot instances found')).toBeVisible();
+  test("shows empty state when no instances", async ({ mount, page }) => {
+    await mount("Instances/Default");
+    await expect(page.getByText("No bot instances found")).toBeVisible();
   });
 
-  test('renders instance cards with state badges', async ({ mount, page }) => {
-    const inst = makeInstance({ instance_id: 'prod-bot', state: 'working', message: 'Working on task', active_tasks: 3 });
-    await page.route('**/api/instances', (route) => {
-      route.fulfill({ json: [inst] });
-    });
-
-    await mount('Instances/Default');
-    await expect(page.getByText('prod-bot')).toBeVisible();
-    await expect(page.getByText('WORKING', { exact: true })).toBeVisible();
-    await expect(page.getByText('Working on task')).toBeVisible();
-    await expect(page.getByText('3/10 tasks')).toBeVisible();
-  });
-
-  test('renders external key link for jira instance', async ({ mount, page }) => {
+  test("renders instance cards with state badges", async ({ mount, page }) => {
     const inst = makeInstance({
-      instance_id: 'jira-bot',
-      state: 'working',
-      external_key: 'RHCLOUD-500',
-      source_type: 'jira',
-      repo: 'org/repo',
+      instance_id: "prod-bot",
+      state: "working",
+      message: "Working on task",
+      active_tasks: 3,
     });
-    await page.route('**/api/instances', (route) => {
+    await page.route("**/api/instances", (route) => {
       route.fulfill({ json: [inst] });
     });
 
-    await mount('Instances/Default');
-    const link = page.getByRole('link', { name: 'RHCLOUD-500' });
-    await expect(link).toHaveAttribute('href', 'https://redhat.atlassian.net/browse/RHCLOUD-500');
-    await expect(page.getByText('org/repo')).toBeVisible();
+    await mount("Instances/Default");
+    await expect(page.getByText("prod-bot")).toBeVisible();
+    await expect(page.getByText("WORKING", { exact: true })).toBeVisible();
+    await expect(page.getByText("Working on task")).toBeVisible();
+    await expect(page.getByText("3/10 tasks")).toBeVisible();
   });
 
-  test('renders sleep state for instance with stale updated_at', async ({ mount, page }) => {
-    const inst = makeInstance({ instance_id: 'sleep-bot', state: 'idle', updated_at: '2020-01-01T00:00:00Z' });
-    await page.route('**/api/instances', (route) => {
+  test("renders external key link for jira instance", async ({ mount, page }) => {
+    const inst = makeInstance({
+      instance_id: "jira-bot",
+      state: "working",
+      external_key: "RHCLOUD-500",
+      source_type: "jira",
+      repo: "org/repo",
+    });
+    await page.route("**/api/instances", (route) => {
       route.fulfill({ json: [inst] });
     });
 
-    await mount('Instances/Default');
-    await expect(page.getByText('SLEEP', { exact: true })).toBeVisible();
+    await mount("Instances/Default");
+    const link = page.getByRole("link", { name: "RHCLOUD-500" });
+    await expect(link).toHaveAttribute("href", "https://redhat.atlassian.net/browse/RHCLOUD-500");
+    await expect(page.getByText("org/repo")).toBeVisible();
+  });
+
+  test("renders sleep state for instance with stale updated_at", async ({ mount, page }) => {
+    const inst = makeInstance({
+      instance_id: "sleep-bot",
+      state: "idle",
+      updated_at: "2020-01-01T00:00:00Z",
+    });
+    await page.route("**/api/instances", (route) => {
+      route.fulfill({ json: [inst] });
+    });
+
+    await mount("Instances/Default");
+    await expect(page.getByText("SLEEP", { exact: true })).toBeVisible();
     await expect(page.getByText("Bot hasn't checked in recently")).toBeVisible();
   });
 
-  test('does not show sleep for working instance even with stale updated_at', async ({ mount, page }) => {
-    const inst = makeInstance({ instance_id: 'busy-bot', state: 'working', message: 'On it', updated_at: '2020-01-01T00:00:00Z' });
-    await page.route('**/api/instances', (route) => {
+  test("does not show sleep for working instance even with stale updated_at", async ({
+    mount,
+    page,
+  }) => {
+    const inst = makeInstance({
+      instance_id: "busy-bot",
+      state: "working",
+      message: "On it",
+      updated_at: "2020-01-01T00:00:00Z",
+    });
+    await page.route("**/api/instances", (route) => {
       route.fulfill({ json: [inst] });
     });
 
-    await mount('Instances/Default');
-    await expect(page.getByText('WORKING', { exact: true })).toBeVisible();
-    await expect(page.getByText('On it')).toBeVisible();
+    await mount("Instances/Default");
+    await expect(page.getByText("WORKING", { exact: true })).toBeVisible();
+    await expect(page.getByText("On it")).toBeVisible();
   });
 
-  test('renders error state badge', async ({ mount, page }) => {
-    const inst = makeInstance({ instance_id: 'err-bot', state: 'error', message: 'Failed' });
-    await page.route('**/api/instances', (route) => {
+  test("renders error state badge", async ({ mount, page }) => {
+    const inst = makeInstance({ instance_id: "err-bot", state: "error", message: "Failed" });
+    await page.route("**/api/instances", (route) => {
       route.fulfill({ json: [inst] });
     });
 
-    await mount('Instances/Default');
-    await expect(page.getByText('ERROR')).toBeVisible();
-    await expect(page.getByText('Failed')).toBeVisible();
+    await mount("Instances/Default");
+    await expect(page.getByText("ERROR")).toBeVisible();
+    await expect(page.getByText("Failed")).toBeVisible();
   });
 });

--- a/dashboard/src/pages/Instances.tsx
+++ b/dashboard/src/pages/Instances.tsx
@@ -1,24 +1,31 @@
-import { useEffect, useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-import type { BotInstance } from '../types';
-import { fetchInstances } from '../api';
-import { useWS } from '../hooks/useWebSocket';
-import { timeAgo, sourceUrl, displayKey, effectiveState, stateLabelColor, stateIconStatus } from '../utils';
 import {
   Card,
-  CardHeader,
-  CardTitle,
   CardBody,
   CardFooter,
-  LabelGroup,
-  Label,
-  Flex,
-  FlexItem,
+  CardHeader,
+  CardTitle,
   Content,
   Divider,
-  Icon
-} from '@patternfly/react-core';
-import { CircleIcon } from '@patternfly/react-icons';
+  Flex,
+  FlexItem,
+  Icon,
+  Label,
+  LabelGroup,
+} from "@patternfly/react-core";
+import { CircleIcon } from "@patternfly/react-icons";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchInstances } from "../api";
+import { useWS } from "../hooks/useWebSocket";
+import type { BotInstance } from "../types";
+import {
+  displayKey,
+  effectiveState,
+  sourceUrl,
+  stateIconStatus,
+  stateLabelColor,
+  timeAgo,
+} from "../utils";
 
 export default function Instances() {
   const [instances, setInstances] = useState<BotInstance[]>([]);
@@ -40,7 +47,7 @@ export default function Instances() {
 
   useEffect(() => {
     return onEvent((event) => {
-      if (event.type === 'bot_status') {
+      if (event.type === "bot_status") {
         const id = event.data.instance_id;
         setInstances((prev) => {
           if (!id) return prev;
@@ -53,7 +60,11 @@ export default function Instances() {
           return [...prev, { ...event.data, active_tasks: 0, max_tasks: 10 }];
         });
       }
-      if (event.type === 'task_added' || event.type === 'task_updated' || event.type === 'task_archived') {
+      if (
+        event.type === "task_added" ||
+        event.type === "task_updated" ||
+        event.type === "task_archived"
+      ) {
         load();
       }
     });
@@ -61,67 +72,94 @@ export default function Instances() {
 
   return (
     <div>
-      {instances.length === 0 && (
-        <div className="empty-state">No bot instances found</div>
-      )}
+      {instances.length === 0 && <div className="empty-state">No bot instances found</div>}
       <div className="instance-grid">
         {instances.map((inst) => {
           const state = effectiveState(inst);
           return (
-          <div key={inst.instance_id}>
-            <Card isCompact isGlass style={{ cursor: 'pointer' }} onClick={() => navigate(`/instances/${encodeURIComponent(inst.instance_id)}/tasks`)}>
-            <CardHeader
-              actions={{ actions: <Label color={stateLabelColor(state)}>{state.toUpperCase()}</Label> }}
-            >
-              <CardTitle>
-                <Flex alignItems={{ default: 'alignItemsFlexStart' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }} style={{ minWidth: 0 }}>
-                  <FlexItem style={{ flexShrink: 0 }}>
-                    <Icon status={stateIconStatus(state)}>
-                      <CircleIcon />
-                    </Icon>
-                  </FlexItem>
-                  <FlexItem style={{ minWidth: 0, overflowWrap: 'break-word', wordBreak: 'break-word' }}>
-                    {inst.instance_id.length > 65 ? `${inst.instance_id.slice(0, 65)}…` : inst.instance_id}
-                  </FlexItem>
-                </Flex>
-              </CardTitle>
-            </CardHeader>
-            <CardBody>
-              <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
-                <Content component="p" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: 'var(--pf-t--global--text--color--subtle)' }}>
-                  {state === 'sleep' ? "Bot hasn't checked in recently" : inst.message}
-                </Content>
-                <LabelGroup>
-                  {displayKey(inst) && (
-                    <Label
-                      color="blue"
-                      href={sourceUrl(inst) || '#'}
-                      onClick={(e) => e.stopPropagation()}
+            <div key={inst.instance_id}>
+              <Card
+                isCompact
+                isGlass
+                style={{ cursor: "pointer" }}
+                onClick={() => navigate(`/instances/${encodeURIComponent(inst.instance_id)}/tasks`)}
+              >
+                <CardHeader
+                  actions={{
+                    actions: <Label color={stateLabelColor(state)}>{state.toUpperCase()}</Label>,
+                  }}
+                >
+                  <CardTitle>
+                    <Flex
+                      alignItems={{ default: "alignItemsFlexStart" }}
+                      gap={{ default: "gapSm" }}
+                      flexWrap={{ default: "nowrap" }}
+                      style={{ minWidth: 0 }}
                     >
-                      {displayKey(inst)}
+                      <FlexItem style={{ flexShrink: 0 }}>
+                        <Icon status={stateIconStatus(state)}>
+                          <CircleIcon />
+                        </Icon>
+                      </FlexItem>
+                      <FlexItem
+                        style={{ minWidth: 0, overflowWrap: "break-word", wordBreak: "break-word" }}
+                      >
+                        {inst.instance_id.length > 65
+                          ? `${inst.instance_id.slice(0, 65)}…`
+                          : inst.instance_id}
+                      </FlexItem>
+                    </Flex>
+                  </CardTitle>
+                </CardHeader>
+                <CardBody>
+                  <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
+                    <Content
+                      component="p"
+                      style={{
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        color: "var(--pf-t--global--text--color--subtle)",
+                      }}
+                    >
+                      {state === "sleep" ? "Bot hasn't checked in recently" : inst.message}
+                    </Content>
+                    <LabelGroup>
+                      {displayKey(inst) && (
+                        <Label
+                          color="blue"
+                          href={sourceUrl(inst) || "#"}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {displayKey(inst)}
+                        </Label>
+                      )}
+                      {inst.repo && (
+                        <Label color="grey" variant="outline">
+                          {inst.repo}
+                        </Label>
+                      )}
+                    </LabelGroup>
+                  </Flex>
+                </CardBody>
+                <Divider />
+                <CardFooter>
+                  <Flex
+                    justifyContent={{ default: "justifyContentSpaceBetween" }}
+                    alignItems={{ default: "alignItemsCenter" }}
+                  >
+                    <Label variant="outline">
+                      {inst.active_tasks}/{inst.max_tasks} tasks
                     </Label>
-                  )}
-                  {inst.repo && (
-                    <Label color="grey" variant="outline">
-                      {inst.repo}
-                    </Label>
-                  )}
-                </LabelGroup>
-              </Flex>
-            </CardBody>
-            <Divider />
-            <CardFooter>
-              <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }} alignItems={{ default: 'alignItemsCenter' }}>
-                <Label variant="outline">{inst.active_tasks}/{inst.max_tasks} tasks</Label>
-                <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-                  <Content>
-                    <small title={inst.updated_at}>{timeAgo(inst.updated_at)}</small>
-                  </Content>
-                </Flex>
-              </Flex>
-            </CardFooter>
-          </Card>
-          </div>
+                    <Flex alignItems={{ default: "alignItemsCenter" }} gap={{ default: "gapSm" }}>
+                      <Content>
+                        <small title={inst.updated_at}>{timeAgo(inst.updated_at)}</small>
+                      </Content>
+                    </Flex>
+                  </Flex>
+                </CardFooter>
+              </Card>
+            </div>
           );
         })}
       </div>

--- a/dashboard/src/pages/Memories.tsx
+++ b/dashboard/src/pages/Memories.tsx
@@ -1,9 +1,3 @@
-import { useEffect, useState, useCallback } from 'react';
-import type { Memory } from '../types';
-import { fetchMemories, deleteMemory, fetchStats, fetchTags } from '../api';
-import MemoryCard from '../components/MemoryCard';
-import DetailPanel from '../components/DetailPanel';
-import Pagination from '../components/Pagination';
 import {
   Flex,
   FlexItem,
@@ -11,14 +5,20 @@ import {
   MenuToggleElement,
   Select,
   SelectList,
-  SelectOption
-} from '@patternfly/react-core';
+  SelectOption,
+} from "@patternfly/react-core";
+import { useCallback, useEffect, useState } from "react";
+import { deleteMemory, fetchMemories, fetchStats, fetchTags } from "../api";
+import DetailPanel from "../components/DetailPanel";
+import MemoryCard from "../components/MemoryCard";
+import Pagination from "../components/Pagination";
+import type { Memory } from "../types";
 
 const CATEGORY_OPTIONS = [
-  { value: '', label: 'All Categories' },
-  { value: 'learning', label: 'Learning' },
-  { value: 'review_feedback', label: 'Review Feedback' },
-  { value: 'codebase_pattern', label: 'Codebase Pattern' },
+  { value: "", label: "All Categories" },
+  { value: "learning", label: "Learning" },
+  { value: "review_feedback", label: "Review Feedback" },
+  { value: "codebase_pattern", label: "Codebase Pattern" },
 ];
 
 const LIMIT = 20;
@@ -26,9 +26,9 @@ const LIMIT = 20;
 export default function Memories() {
   const [memories, setMemories] = useState<Memory[]>([]);
   const [total, setTotal] = useState(0);
-  const [category, setCategory] = useState('');
-  const [repo, setRepo] = useState('');
-  const [tag, setTag] = useState('');
+  const [category, setCategory] = useState("");
+  const [repo, setRepo] = useState("");
+  const [tag, setTag] = useState("");
   const [offset, setOffset] = useState(0);
   const [selected, setSelected] = useState<Memory | null>(null);
   const [repos, setRepos] = useState<string[]>([]);
@@ -38,13 +38,17 @@ export default function Memories() {
   const [isTagOpen, setIsTagOpen] = useState(false);
 
   useEffect(() => {
-    fetchStats().then((s: any) => {
-      if (s.repos) setRepos(s.repos);
-    }).catch(() => {});
-    fetchTags().then((t: any) => {
-      if (Array.isArray(t)) setTags(t);
-      else if (t?.tags) setTags(t.tags);
-    }).catch(() => {});
+    fetchStats()
+      .then((s: any) => {
+        if (s.repos) setRepos(s.repos);
+      })
+      .catch(() => {});
+    fetchTags()
+      .then((t: any) => {
+        if (Array.isArray(t)) setTags(t);
+        else if (t?.tags) setTags(t.tags);
+      })
+      .catch(() => {});
   }, []);
 
   const load = useCallback(async () => {
@@ -69,29 +73,40 @@ export default function Memories() {
     load();
   };
 
-  const categoryLabel = CATEGORY_OPTIONS.find((o) => o.value === category)?.label || 'All Categories';
-  const repoLabel = repo || 'All Repos';
-  const tagLabel = tag || 'All Tags';
+  const categoryLabel =
+    CATEGORY_OPTIONS.find((o) => o.value === category)?.label || "All Categories";
+  const repoLabel = repo || "All Repos";
+  const tagLabel = tag || "All Tags";
 
   return (
     <div className="split-layout">
       <div className="split-main">
-        <Flex gap={{ default: 'gapSm' }} style={{ marginBottom: '16px' }}>
+        <Flex gap={{ default: "gapSm" }} style={{ marginBottom: "16px" }}>
           <FlexItem>
             <Select
               isOpen={isCategoryOpen}
               selected={category}
-              onSelect={(_e, val) => { setCategory(val as string); setOffset(0); setIsCategoryOpen(false); }}
+              onSelect={(_e, val) => {
+                setCategory(val as string);
+                setOffset(0);
+                setIsCategoryOpen(false);
+              }}
               onOpenChange={setIsCategoryOpen}
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle ref={toggleRef} onClick={() => setIsCategoryOpen(!isCategoryOpen)} isExpanded={isCategoryOpen}>
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsCategoryOpen(!isCategoryOpen)}
+                  isExpanded={isCategoryOpen}
+                >
                   {categoryLabel}
                 </MenuToggle>
               )}
             >
               <SelectList>
                 {CATEGORY_OPTIONS.map((o) => (
-                  <SelectOption key={o.value} value={o.value}>{o.label}</SelectOption>
+                  <SelectOption key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectOption>
                 ))}
               </SelectList>
             </Select>
@@ -100,10 +115,18 @@ export default function Memories() {
             <Select
               isOpen={isRepoOpen}
               selected={repo}
-              onSelect={(_e, val) => { setRepo(val as string); setOffset(0); setIsRepoOpen(false); }}
+              onSelect={(_e, val) => {
+                setRepo(val as string);
+                setOffset(0);
+                setIsRepoOpen(false);
+              }}
               onOpenChange={setIsRepoOpen}
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle ref={toggleRef} onClick={() => setIsRepoOpen(!isRepoOpen)} isExpanded={isRepoOpen}>
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsRepoOpen(!isRepoOpen)}
+                  isExpanded={isRepoOpen}
+                >
                   {repoLabel}
                 </MenuToggle>
               )}
@@ -111,7 +134,9 @@ export default function Memories() {
               <SelectList>
                 <SelectOption value="">All Repos</SelectOption>
                 {repos.map((r) => (
-                  <SelectOption key={r} value={r}>{r}</SelectOption>
+                  <SelectOption key={r} value={r}>
+                    {r}
+                  </SelectOption>
                 ))}
               </SelectList>
             </Select>
@@ -120,10 +145,18 @@ export default function Memories() {
             <Select
               isOpen={isTagOpen}
               selected={tag}
-              onSelect={(_e, val) => { setTag(val as string); setOffset(0); setIsTagOpen(false); }}
+              onSelect={(_e, val) => {
+                setTag(val as string);
+                setOffset(0);
+                setIsTagOpen(false);
+              }}
               onOpenChange={setIsTagOpen}
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle ref={toggleRef} onClick={() => setIsTagOpen(!isTagOpen)} isExpanded={isTagOpen}>
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsTagOpen(!isTagOpen)}
+                  isExpanded={isTagOpen}
+                >
                   {tagLabel}
                 </MenuToggle>
               )}
@@ -131,7 +164,9 @@ export default function Memories() {
               <SelectList>
                 <SelectOption value="">All Tags</SelectOption>
                 {tags.map((t) => (
-                  <SelectOption key={t} value={t}>{t}</SelectOption>
+                  <SelectOption key={t} value={t}>
+                    {t}
+                  </SelectOption>
                 ))}
               </SelectList>
             </Select>

--- a/dashboard/src/pages/Search.tsx
+++ b/dashboard/src/pages/Search.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react';
-import type { Memory } from '../types';
-import { searchMemories, deleteMemory } from '../api';
-import MemoryCard from '../components/MemoryCard';
-import DetailPanel from '../components/DetailPanel';
-import { SearchInput } from '@patternfly/react-core';
+import { SearchInput } from "@patternfly/react-core";
+import { useState } from "react";
+import { deleteMemory, searchMemories } from "../api";
+import DetailPanel from "../components/DetailPanel";
+import MemoryCard from "../components/MemoryCard";
+import type { Memory } from "../types";
 
 export default function Search() {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState("");
   const [results, setResults] = useState<Memory[]>([]);
   const [searched, setSearched] = useState(false);
   const [selected, setSelected] = useState<Memory | null>(null);
@@ -28,19 +28,17 @@ export default function Search() {
   return (
     <div className="split-layout">
       <div className="split-main">
-        <div style={{ marginBottom: '16px' }}>
+        <div style={{ marginBottom: "16px" }}>
           <SearchInput
             placeholder="Search memories..."
             value={query}
             onChange={(_e, val) => setQuery(val)}
             onSearch={doSearch}
-            onClear={() => setQuery('')}
+            onClear={() => setQuery("")}
           />
         </div>
         <div className="card-grid">
-          {searched && results.length === 0 && (
-            <div className="empty-state">No results found</div>
-          )}
+          {searched && results.length === 0 && <div className="empty-state">No results found</div>}
           {results.map((m) => (
             <MemoryCard
               key={m.id}

--- a/dashboard/src/pages/Tasks.spec.ts
+++ b/dashboard/src/pages/Tasks.spec.ts
@@ -1,83 +1,88 @@
-import { test, expect } from '../../e2e/fixtures';
+import { expect, test } from "../../e2e/fixtures";
 
 function makeTask(overrides: Record<string, any> = {}) {
   return {
     id: 1,
-    external_key: 'RHCLOUD-001',
-    source_type: 'jira',
+    external_key: "RHCLOUD-001",
+    source_type: "jira",
     source_url: null,
     artifacts: [],
-    status: 'in_progress',
-    repo: 'frontend',
-    branch: 'main',
-    title: 'Fix login bug',
-    summary: 'Fix login bug',
-    created_at: '2026-07-01T10:00:00Z',
-    last_addressed: '2026-07-01T15:30:00Z',
+    status: "in_progress",
+    repo: "frontend",
+    branch: "main",
+    title: "Fix login bug",
+    summary: "Fix login bug",
+    created_at: "2026-07-01T10:00:00Z",
+    last_addressed: "2026-07-01T15:30:00Z",
     paused_reason: null,
-    instance_id: 'dev-bot',
+    instance_id: "dev-bot",
     metadata: {},
     slack_notification: null,
     ...overrides,
   };
 }
 
-test.describe('Tasks page — dialog flows', () => {
-  test('pause: opens dialog, submits reason, calls pauseTask', async ({ mount, page }) => {
-    const task = makeTask({ external_key: 'RHCLOUD-100', title: 'Fix bug' });
+test.describe("Tasks page — dialog flows", () => {
+  test("pause: opens dialog, submits reason, calls pauseTask", async ({ mount, page }) => {
+    const task = makeTask({ external_key: "RHCLOUD-100", title: "Fix bug" });
 
-    await page.route('**/api/tasks?*', (route) => {
+    await page.route("**/api/tasks?*", (route) => {
       route.fulfill({ json: { items: [task], total: 1 } });
     });
 
     let pauseCalled = false;
-    await page.route('**/api/tasks/RHCLOUD-100/pause', (route) => {
+    await page.route("**/api/tasks/RHCLOUD-100/pause", (route) => {
       pauseCalled = true;
       route.fulfill({ json: { ok: true } });
     });
 
-    await mount('Tasks/Default');
-    await page.getByText('Fix bug').click();
-    await page.getByRole('button', { name: 'Pause Task' }).click();
-    await page.getByPlaceholder('e.g. Waiting for design review').fill('blocked on UX');
-    await page.getByRole('button', { name: 'Pause' }).click();
+    await mount("Tasks/Default");
+    await page.getByText("Fix bug").click();
+    await page.getByRole("button", { name: "Pause Task" }).click();
+    await page.getByPlaceholder("e.g. Waiting for design review").fill("blocked on UX");
+    await page.getByRole("button", { name: "Pause" }).click();
     await page.waitForTimeout(200);
 
     expect(pauseCalled).toBe(true);
   });
 
-  test('unpause: opens dialog and calls unpauseTask', async ({ mount, page }) => {
-    const task = makeTask({ status: 'paused', external_key: 'RHCLOUD-200', title: 'Paused task', paused_reason: 'waiting' });
+  test("unpause: opens dialog and calls unpauseTask", async ({ mount, page }) => {
+    const task = makeTask({
+      status: "paused",
+      external_key: "RHCLOUD-200",
+      title: "Paused task",
+      paused_reason: "waiting",
+    });
 
-    await page.route('**/api/tasks?*', (route) => {
+    await page.route("**/api/tasks?*", (route) => {
       route.fulfill({ json: { items: [task], total: 1 } });
     });
 
     let unpauseCalled = false;
-    await page.route('**/api/tasks/RHCLOUD-200/unpause', (route) => {
+    await page.route("**/api/tasks/RHCLOUD-200/unpause", (route) => {
       unpauseCalled = true;
       route.fulfill({ json: { ok: true } });
     });
 
-    await mount('Tasks/Default');
-    await page.getByText('Paused task').click();
-    await page.getByRole('button', { name: 'Unpause Task' }).click();
-    await page.getByRole('button', { name: 'Unpause' }).click();
+    await mount("Tasks/Default");
+    await page.getByText("Paused task").click();
+    await page.getByRole("button", { name: "Unpause Task" }).click();
+    await page.getByRole("button", { name: "Unpause" }).click();
     await page.waitForTimeout(200);
 
     expect(unpauseCalled).toBe(true);
   });
 
-  test('archive: opens danger dialog and calls deleteTask', async ({ mount, page }) => {
-    const task = makeTask({ external_key: 'RHCLOUD-300', title: 'Archive me' });
+  test("archive: opens danger dialog and calls deleteTask", async ({ mount, page }) => {
+    const task = makeTask({ external_key: "RHCLOUD-300", title: "Archive me" });
 
-    await page.route('**/api/tasks?*', (route) => {
+    await page.route("**/api/tasks?*", (route) => {
       route.fulfill({ json: { items: [task], total: 1 } });
     });
 
     let deleteCalled = false;
-    await page.route('**/api/tasks/RHCLOUD-300', (route) => {
-      if (route.request().method() === 'DELETE') {
+    await page.route("**/api/tasks/RHCLOUD-300", (route) => {
+      if (route.request().method() === "DELETE") {
         deleteCalled = true;
         route.fulfill({ json: { ok: true } });
       } else {
@@ -85,10 +90,10 @@ test.describe('Tasks page — dialog flows', () => {
       }
     });
 
-    await mount('Tasks/Default');
-    await page.getByText('Archive me').click();
-    await page.getByRole('button', { name: 'Archive Task' }).click();
-    const archiveBtn = page.getByRole('button', { name: 'Archive' });
+    await mount("Tasks/Default");
+    await page.getByText("Archive me").click();
+    await page.getByRole("button", { name: "Archive Task" }).click();
+    const archiveBtn = page.getByRole("button", { name: "Archive" });
     await expect(archiveBtn).toHaveClass(/pf-m-danger/);
     await archiveBtn.click();
     await page.waitForTimeout(200);
@@ -96,25 +101,25 @@ test.describe('Tasks page — dialog flows', () => {
     expect(deleteCalled).toBe(true);
   });
 
-  test('shows error dialog when API returns an error', async ({ mount, page }) => {
-    const task = makeTask({ status: 'paused', external_key: 'RHCLOUD-400', title: 'Error task' });
+  test("shows error dialog when API returns an error", async ({ mount, page }) => {
+    const task = makeTask({ status: "paused", external_key: "RHCLOUD-400", title: "Error task" });
 
-    await page.route('**/api/tasks?*', (route) => {
+    await page.route("**/api/tasks?*", (route) => {
       route.fulfill({ json: { items: [task], total: 1 } });
     });
-    await page.route('**/api/tasks/RHCLOUD-400/unpause', (route) => {
+    await page.route("**/api/tasks/RHCLOUD-400/unpause", (route) => {
       route.fulfill({
         status: 404,
-        contentType: 'application/json',
-        body: JSON.stringify({ error: 'Task RHCLOUD-400 not found or not paused' }),
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Task RHCLOUD-400 not found or not paused" }),
       });
     });
 
-    await mount('Tasks/Default');
-    await page.getByText('Error task').click();
-    await page.getByRole('button', { name: 'Unpause Task' }).click();
-    await page.getByRole('button', { name: 'Unpause' }).click();
+    await mount("Tasks/Default");
+    await page.getByText("Error task").click();
+    await page.getByRole("button", { name: "Unpause Task" }).click();
+    await page.getByRole("button", { name: "Unpause" }).click();
 
-    await expect(page.getByText('Task RHCLOUD-400 not found or not paused')).toBeVisible();
+    await expect(page.getByText("Task RHCLOUD-400 not found or not paused")).toBeVisible();
   });
 });

--- a/dashboard/src/pages/Tasks.tsx
+++ b/dashboard/src/pages/Tasks.tsx
@@ -1,40 +1,40 @@
-import { useEffect, useState, useCallback } from 'react';
-import type { Task } from '../types';
-import { fetchTasks, deleteTask, pauseTask, unpauseTask } from '../api';
-import { useWS } from '../hooks/useWebSocket';
-import TaskCard from '../components/TaskCard';
-import DetailPanel from '../components/DetailPanel';
-import Pagination from '../components/Pagination';
 import {
   MenuToggle,
   MenuToggleElement,
   Select,
   SelectList,
-  SelectOption
-} from '@patternfly/react-core';
-import ConfirmDialog from '../components/ConfirmDialog';
+  SelectOption,
+} from "@patternfly/react-core";
+import { useCallback, useEffect, useState } from "react";
+import { deleteTask, fetchTasks, pauseTask, unpauseTask } from "../api";
+import ConfirmDialog from "../components/ConfirmDialog";
+import DetailPanel from "../components/DetailPanel";
+import Pagination from "../components/Pagination";
+import TaskCard from "../components/TaskCard";
+import { useWS } from "../hooks/useWebSocket";
+import type { Task } from "../types";
 
 const STATUS_OPTIONS = [
-  { value: '', label: 'All' },
-  { value: 'in_progress', label: 'In Progress' },
-  { value: 'pr_open', label: 'PR Open' },
-  { value: 'pr_changes', label: 'PR Changes' },
-  { value: 'paused', label: 'Paused' },
-  { value: 'done', label: 'Done' },
+  { value: "", label: "All" },
+  { value: "in_progress", label: "In Progress" },
+  { value: "pr_open", label: "PR Open" },
+  { value: "pr_changes", label: "PR Changes" },
+  { value: "paused", label: "Paused" },
+  { value: "done", label: "Done" },
 ];
 
 const LIMIT = 20;
 
 type DialogState =
-  | { action: 'pause'; key: string }
-  | { action: 'unpause'; key: string }
-  | { action: 'archive'; key: string }
+  | { action: "pause"; key: string }
+  | { action: "unpause"; key: string }
+  | { action: "archive"; key: string }
   | null;
 
 export default function Tasks({ instanceId }: { instanceId?: string }) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [total, setTotal] = useState(0);
-  const [status, setStatus] = useState('');
+  const [status, setStatus] = useState("");
   const [offset, setOffset] = useState(0);
   const [selected, setSelected] = useState<Task | null>(null);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
@@ -46,7 +46,7 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
   const load = useCallback(async () => {
     const res = await fetchTasks({
       status: status || undefined,
-      exclude_status: status ? undefined : 'archived',
+      exclude_status: status ? undefined : "archived",
       limit: LIMIT,
       offset,
       instance_id: instanceId,
@@ -61,7 +61,11 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
 
   useEffect(() => {
     return onEvent((event) => {
-      if (event.type === 'task_added' || event.type === 'task_updated' || event.type === 'task_archived') {
+      if (
+        event.type === "task_added" ||
+        event.type === "task_updated" ||
+        event.type === "task_archived"
+      ) {
         load();
       }
     });
@@ -74,7 +78,9 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
       try {
         const body = await res.json();
         if (body?.error) msg = body.error;
-      } catch { /* ignore non-JSON */ }
+      } catch {
+        /* ignore non-JSON */
+      }
       setError(msg);
       return false;
     }
@@ -85,13 +91,13 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
     if (!dialog) return;
     let ok = false;
     switch (dialog.action) {
-      case 'pause':
+      case "pause":
         ok = await runAction(() => pauseTask(dialog.key, inputValue?.trim() || undefined));
         break;
-      case 'unpause':
+      case "unpause":
         ok = await runAction(() => unpauseTask(dialog.key));
         break;
-      case 'archive':
+      case "archive":
         ok = await runAction(() => deleteTask(dialog.key));
         break;
     }
@@ -103,33 +109,33 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
   };
 
   const dialogProps = () => {
-    if (!dialog) return { title: '', message: '' };
+    if (!dialog) return { title: "", message: "" };
     switch (dialog.action) {
-      case 'pause':
+      case "pause":
         return {
-          title: 'Pause task',
+          title: "Pause task",
           message: `Pause ${dialog.key}? The bot will skip it until unpaused.`,
-          confirmLabel: 'Pause',
-          inputLabel: 'Reason (optional)',
-          inputPlaceholder: 'e.g. Waiting for design review',
+          confirmLabel: "Pause",
+          inputLabel: "Reason (optional)",
+          inputPlaceholder: "e.g. Waiting for design review",
         };
-      case 'unpause':
+      case "unpause":
         return {
-          title: 'Unpause task',
+          title: "Unpause task",
           message: `Unpause ${dialog.key}? The bot may pick it up again.`,
-          confirmLabel: 'Unpause',
+          confirmLabel: "Unpause",
         };
-      case 'archive':
+      case "archive":
         return {
-          title: 'Archive task',
+          title: "Archive task",
           message: `Archive ${dialog.key}? The bot will stop tracking it.`,
-          confirmLabel: 'Archive',
-          variant: 'danger' as const,
+          confirmLabel: "Archive",
+          variant: "danger" as const,
         };
     }
   };
 
-  const currentLabel = STATUS_OPTIONS.find((o) => o.value === status)?.label || 'All';
+  const currentLabel = STATUS_OPTIONS.find((o) => o.value === status)?.label || "All";
 
   return (
     <div className="split-layout">
@@ -138,17 +144,27 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
           <Select
             isOpen={isFilterOpen}
             selected={status}
-            onSelect={(_e, val) => { setStatus(val as string); setOffset(0); setIsFilterOpen(false); }}
+            onSelect={(_e, val) => {
+              setStatus(val as string);
+              setOffset(0);
+              setIsFilterOpen(false);
+            }}
             onOpenChange={setIsFilterOpen}
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-              <MenuToggle ref={toggleRef} onClick={() => setIsFilterOpen(!isFilterOpen)} isExpanded={isFilterOpen}>
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsFilterOpen(!isFilterOpen)}
+                isExpanded={isFilterOpen}
+              >
                 {currentLabel}
               </MenuToggle>
             )}
           >
             <SelectList>
               {STATUS_OPTIONS.map((o) => (
-                <SelectOption key={o.value} value={o.value}>{o.label}</SelectOption>
+                <SelectOption key={o.value} value={o.value}>
+                  {o.label}
+                </SelectOption>
               ))}
             </SelectList>
           </Select>
@@ -172,9 +188,9 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
             type="task"
             task={selected}
             onClose={() => setSelected(null)}
-            onDelete={(key) => setDialog({ action: 'archive', key })}
-            onPause={(key) => setDialog({ action: 'pause', key })}
-            onUnpause={(key) => setDialog({ action: 'unpause', key })}
+            onDelete={(key) => setDialog({ action: "archive", key })}
+            onPause={(key) => setDialog({ action: "pause", key })}
+            onUnpause={(key) => setDialog({ action: "unpause", key })}
           />
         </div>
       )}
@@ -187,7 +203,7 @@ export default function Tasks({ instanceId }: { instanceId?: string }) {
       <ConfirmDialog
         open={error !== null}
         title="Error"
-        message={error || ''}
+        message={error || ""}
         confirmLabel="OK"
         onConfirm={() => setError(null)}
         onCancel={() => setError(null)}

--- a/dashboard/src/test/fixtures.json
+++ b/dashboard/src/test/fixtures.json
@@ -29,10 +29,7 @@
       "instance_id": "dev-bot",
       "metadata": {
         "priority": "high",
-        "labels": [
-          "bug",
-          "p1"
-        ]
+        "labels": ["bug", "p1"]
       },
       "slack_notification": {
         "event_type": "task_started",
@@ -69,10 +66,7 @@
       "instance_id": "dev-bot",
       "metadata": {
         "priority": "high",
-        "labels": [
-          "bug",
-          "p1"
-        ]
+        "labels": ["bug", "p1"]
       },
       "slack_notification": null
     },
@@ -105,10 +99,7 @@
       "instance_id": "dev-bot",
       "metadata": {
         "priority": "high",
-        "labels": [
-          "bug",
-          "p1"
-        ]
+        "labels": ["bug", "p1"]
       },
       "slack_notification": null
     },
@@ -141,10 +132,7 @@
       "instance_id": "dev-bot",
       "metadata": {
         "priority": "high",
-        "labels": [
-          "bug",
-          "p1"
-        ]
+        "labels": ["bug", "p1"]
       },
       "slack_notification": {
         "event_type": "task_started",
@@ -181,10 +169,7 @@
       "instance_id": "dev-bot",
       "metadata": {
         "priority": "high",
-        "labels": [
-          "bug",
-          "p1"
-        ]
+        "labels": ["bug", "p1"]
       },
       "slack_notification": null
     },
@@ -217,10 +202,7 @@
       "instance_id": "dev-bot",
       "metadata": {
         "priority": "high",
-        "labels": [
-          "bug",
-          "p1"
-        ]
+        "labels": ["bug", "p1"]
       },
       "slack_notification": null
     }
@@ -234,10 +216,7 @@
       "source_type": "jira",
       "title": "Login timeout issue",
       "content": "Users experiencing timeout after 5min idle",
-      "tags": [
-        "auth",
-        "timeout"
-      ],
+      "tags": ["auth", "timeout"],
       "created_at": "2026-07-01T10:00:00Z",
       "metadata": {
         "importance": "high"
@@ -251,10 +230,7 @@
       "source_type": null,
       "title": "Auth flow design",
       "content": "New OAuth2 flow with PKCE extension",
-      "tags": [
-        "security",
-        "oauth"
-      ],
+      "tags": ["security", "oauth"],
       "created_at": "2026-07-02T10:00:00Z",
       "metadata": {
         "importance": "high"
@@ -268,10 +244,7 @@
       "source_type": null,
       "title": "Framework choice",
       "content": "Chose React over Vue for better TypeScript support",
-      "tags": [
-        "react",
-        "typescript"
-      ],
+      "tags": ["react", "typescript"],
       "created_at": "2026-07-03T10:00:00Z",
       "metadata": {
         "importance": "high"
@@ -285,10 +258,7 @@
       "source_type": null,
       "title": "Database connection pooling",
       "content": "Increased pool size to 50 to handle load spikes",
-      "tags": [
-        "database",
-        "performance"
-      ],
+      "tags": ["database", "performance"],
       "created_at": "2026-07-04T10:00:00Z",
       "metadata": {
         "importance": "high"
@@ -511,9 +481,7 @@
       "content": "Users timeout after idle",
       "category": "bug",
       "repo": "frontend",
-      "tags": [
-        "auth"
-      ],
+      "tags": ["auth"],
       "x": 0.1,
       "y": 0.2,
       "z": 0.3
@@ -524,9 +492,7 @@
       "content": "OAuth2 with PKCE",
       "category": "architecture",
       "repo": "backend",
-      "tags": [
-        "security"
-      ],
+      "tags": ["security"],
       "x": 0.4,
       "y": 0.5,
       "z": 0.2
@@ -537,9 +503,7 @@
       "content": "React over Vue",
       "category": "decision",
       "repo": "frontend",
-      "tags": [
-        "react"
-      ],
+      "tags": ["react"],
       "x": 0.7,
       "y": 0.1,
       "z": 0.4

--- a/dashboard/src/test/helpers.ts
+++ b/dashboard/src/test/helpers.ts
@@ -1,16 +1,16 @@
 import type {
-  Task,
-  CycleRun,
-  TaskCycleGroup,
+  AnalyticsData,
   BotInstance,
   BotStatus,
   CycleEntry,
+  CycleRun,
   DailyAggregate,
-  AnalyticsData,
-} from '../types';
-import fixtures from './fixtures.json';
+  Task,
+  TaskCycleGroup,
+} from "../types";
+import fixtures from "./fixtures.json";
 
-const defaultTask: Task = fixtures.tasks['RHCLOUD-001'] as Task;
+const defaultTask: Task = fixtures.tasks["RHCLOUD-001"] as Task;
 const defaultCycleRun: CycleRun = fixtures.cycleRuns[0] as CycleRun;
 const defaultCycleEntry: CycleEntry = fixtures.costs[0] as CycleEntry;
 const defaultBotStatus: BotStatus = fixtures.botStatus as BotStatus;
@@ -30,8 +30,8 @@ export function makeTaskCycleGroup(overrides: Partial<TaskCycleGroup> = {}): Tas
 
 export function makeBotInstance(overrides: Partial<BotInstance> = {}): BotInstance {
   return {
-    instance_id: defaultBotStatus.instance_id ?? 'dev-bot',
-    state: 'idle',
+    instance_id: defaultBotStatus.instance_id ?? "dev-bot",
+    state: "idle",
     message: defaultBotStatus.message,
     external_key: defaultBotStatus.external_key,
     source_type: defaultBotStatus.source_type,
@@ -55,7 +55,7 @@ export function makeCycleEntry(overrides: Partial<CycleEntry> = {}): CycleEntry 
 
 export function makeDailyAggregate(overrides: Partial<DailyAggregate> = {}): DailyAggregate {
   return {
-    day: '2025-07-01',
+    day: "2025-07-01",
     cycles: 10,
     total_cost: 5.5,
     input_tokens: 10000,

--- a/dashboard/src/test/schema-conformance.test.ts
+++ b/dashboard/src/test/schema-conformance.test.ts
@@ -6,36 +6,36 @@
  * the Python backend and the React dashboard.
  */
 
-import Ajv from 'ajv';
-import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { parse } from 'yaml';
-import { describe, expect, it } from 'vitest';
-import fixtures from './fixtures.json';
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import fixtures from "./fixtures.json";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
-const specPath = resolve(thisDir, '../../../shared/openapi.yaml');
-const spec = parse(readFileSync(specPath, 'utf8'));
+const specPath = resolve(thisDir, "../../../shared/openapi.yaml");
+const spec = parse(readFileSync(specPath, "utf8"));
 const schemas = spec.components.schemas as Record<string, any>;
 
 function resolveRefs(schema: any, allSchemas: Record<string, any>): any {
   if (Array.isArray(schema)) return schema.map((item) => resolveRefs(item, allSchemas));
-  if (typeof schema !== 'object' || schema === null) return schema;
-  if ('$ref' in schema) {
-    const refName = (schema.$ref as string).split('/').pop()!;
+  if (typeof schema !== "object" || schema === null) return schema;
+  if ("$ref" in schema) {
+    const refName = (schema.$ref as string).split("/").pop()!;
     return resolveRefs(allSchemas[refName], allSchemas);
   }
   const result: Record<string, any> = {};
   for (const [k, v] of Object.entries(schema)) {
-    if (k === 'nullable' && v === true) continue;
+    if (k === "nullable" && v === true) continue;
     result[k] = resolveRefs(v, allSchemas);
   }
   if (schema.nullable === true) {
-    if ('type' in result) {
-      result.type = [result.type, 'null'];
-    } else if ('allOf' in result) {
-      result.oneOf = [...result.allOf, { type: 'null' }];
+    if ("type" in result) {
+      result.type = [result.type, "null"];
+    } else if ("allOf" in result) {
+      result.oneOf = [...result.allOf, { type: "null" }];
       delete result.allOf;
     }
   }
@@ -49,97 +49,97 @@ function compileSchema(name: string) {
   return ajv.compile(resolved);
 }
 
-const validateTask = compileSchema('TaskItem');
-const validateMemory = compileSchema('MemoryItem');
-const validateCycleRun = compileSchema('CycleRunItem');
-const validateCycleEntry = compileSchema('CycleEntryItem');
-const validatePaginated = compileSchema('PaginatedResponse');
-const validateCostsResponse = compileSchema('CostsResponse');
+const validateTask = compileSchema("TaskItem");
+const validateMemory = compileSchema("MemoryItem");
+const validateCycleRun = compileSchema("CycleRunItem");
+const validateCycleEntry = compileSchema("CycleEntryItem");
+const validatePaginated = compileSchema("PaginatedResponse");
+const validateCostsResponse = compileSchema("CostsResponse");
 
 function expectValid(validate: ReturnType<typeof ajv.compile>, data: unknown, label: string) {
   const valid = validate(data);
   if (!valid) {
-    const errors = validate.errors?.map((e) => `${e.instancePath} ${e.message}`).join('; ');
+    const errors = validate.errors?.map((e) => `${e.instancePath} ${e.message}`).join("; ");
     expect.fail(`${label}: ${errors}`);
   }
 }
 
-describe('Task item schema conformance', () => {
-  it.each(Object.entries(fixtures.tasks))('task %s matches schema', (key, task) => {
+describe("Task item schema conformance", () => {
+  it.each(Object.entries(fixtures.tasks))("task %s matches schema", (key, task) => {
     expectValid(validateTask, task, `task ${key}`);
   });
 
-  it('task has jira_key matching external_key', () => {
-    const task = fixtures.tasks['RHCLOUD-001'] as Record<string, unknown>;
+  it("task has jira_key matching external_key", () => {
+    const task = fixtures.tasks["RHCLOUD-001"] as Record<string, unknown>;
     expect(task.jira_key).toBe(task.external_key);
   });
 });
 
-describe('Memory item schema conformance', () => {
-  it.each(fixtures.memories.map((m, i) => [i, m]))('memory %i matches schema', (idx, memory) => {
+describe("Memory item schema conformance", () => {
+  it.each(fixtures.memories.map((m, i) => [i, m]))("memory %i matches schema", (idx, memory) => {
     expectValid(validateMemory, memory, `memory ${idx}`);
   });
 });
 
-describe('Cycle run item schema conformance', () => {
-  it.each(fixtures.cycleRuns.map((cr, i) => [i, cr]))('cycleRun %i matches schema', (idx, run) => {
+describe("Cycle run item schema conformance", () => {
+  it.each(fixtures.cycleRuns.map((cr, i) => [i, cr]))("cycleRun %i matches schema", (idx, run) => {
     expectValid(validateCycleRun, run, `cycleRun ${idx}`);
   });
 });
 
-describe('Cycle entry (cost) item schema conformance', () => {
-  it.each(fixtures.costs.map((c, i) => [i, c]))('cost %i matches schema', (idx, cost) => {
+describe("Cycle entry (cost) item schema conformance", () => {
+  it.each(fixtures.costs.map((c, i) => [i, c]))("cost %i matches schema", (idx, cost) => {
     expectValid(validateCycleEntry, cost, `cost ${idx}`);
   });
 });
 
-describe('Paginated envelope schema conformance', () => {
-  it('tasks paginated envelope', () => {
+describe("Paginated envelope schema conformance", () => {
+  it("tasks paginated envelope", () => {
     const envelope = {
       items: Object.values(fixtures.tasks),
       total: Object.keys(fixtures.tasks).length,
       limit: 20,
       offset: 0,
     };
-    expectValid(validatePaginated, envelope, 'tasks envelope');
+    expectValid(validatePaginated, envelope, "tasks envelope");
   });
 
-  it('memories paginated envelope', () => {
+  it("memories paginated envelope", () => {
     const envelope = {
       items: fixtures.memories,
       total: fixtures.memories.length,
       limit: 20,
       offset: 0,
     };
-    expectValid(validatePaginated, envelope, 'memories envelope');
+    expectValid(validatePaginated, envelope, "memories envelope");
   });
 
-  it('cycle runs paginated envelope', () => {
+  it("cycle runs paginated envelope", () => {
     const envelope = {
       items: fixtures.cycleRuns,
       total: fixtures.cycleRuns.length,
       limit: 50,
       offset: 0,
     };
-    expectValid(validatePaginated, envelope, 'cycle runs envelope');
+    expectValid(validatePaginated, envelope, "cycle runs envelope");
   });
 
-  it('rejects extra fields in envelope', () => {
+  it("rejects extra fields in envelope", () => {
     const bad = { items: [], total: 0, limit: 20, offset: 0, extra: true };
     expect(validatePaginated(bad)).toBe(false);
   });
 });
 
-describe('Costs response schema conformance', () => {
-  it('costs response with daily data', () => {
+describe("Costs response schema conformance", () => {
+  it("costs response with daily data", () => {
     const response = {
       items: fixtures.costs,
       daily: fixtures.dailyCosts,
     };
-    expectValid(validateCostsResponse, response, 'costs response');
+    expectValid(validateCostsResponse, response, "costs response");
   });
 
-  it('rejects paginated fields on costs', () => {
+  it("rejects paginated fields on costs", () => {
     const bad = { items: [], daily: [], total: 0, limit: 200, offset: 0 };
     expect(validateCostsResponse(bad)).toBe(false);
   });

--- a/dashboard/src/test/setup.ts
+++ b/dashboard/src/test/setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/vitest';
+import "@testing-library/jest-dom/vitest";

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -10,7 +10,7 @@ export interface Task {
   source_type: string;
   source_url: string | null;
   artifacts: Array<{ name: string; url: string; type: string }>;
-  status: 'in_progress' | 'pr_open' | 'pr_changes' | 'paused' | 'done' | 'archived';
+  status: "in_progress" | "pr_open" | "pr_changes" | "paused" | "done" | "archived";
   repo: string;
   branch: string;
   title: string | null;
@@ -39,7 +39,7 @@ export interface Memory {
 
 export interface BotInstance {
   instance_id: string;
-  state: 'working' | 'idle' | 'error' | 'sleep' | 'unknown';
+  state: "working" | "idle" | "error" | "sleep" | "unknown";
   message: string;
   external_key: string | null;
   source_type: string | null;
@@ -52,7 +52,7 @@ export interface BotInstance {
 }
 
 export interface BotStatus {
-  state: 'working' | 'idle' | 'error' | 'sleep' | 'unknown';
+  state: "working" | "idle" | "error" | "sleep" | "unknown";
   message: string;
   external_key: string | null;
   source_type: string | null;

--- a/dashboard/src/utils.test.ts
+++ b/dashboard/src/utils.test.ts
@@ -1,130 +1,141 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { timeAgo, formatDuration, formatTokens, sourceUrl, displayKey, effectiveState } from './utils';
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  displayKey,
+  effectiveState,
+  formatDuration,
+  formatTokens,
+  sourceUrl,
+  timeAgo,
+} from "./utils";
 
-describe('timeAgo', () => {
+describe("timeAgo", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it('returns "just now" for less than 60 seconds ago', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-01T12:00:30Z'));
-    expect(timeAgo('2025-01-01T12:00:00Z')).toBe('just now');
+    vi.setSystemTime(new Date("2025-01-01T12:00:30Z"));
+    expect(timeAgo("2025-01-01T12:00:00Z")).toBe("just now");
   });
 
   it('returns "Xm ago" for less than 1 hour ago', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-01T12:25:00Z'));
-    expect(timeAgo('2025-01-01T12:00:00Z')).toBe('25m ago');
+    vi.setSystemTime(new Date("2025-01-01T12:25:00Z"));
+    expect(timeAgo("2025-01-01T12:00:00Z")).toBe("25m ago");
   });
 
   it('returns "Xh ago" for less than 1 day ago', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-01T15:00:00Z'));
-    expect(timeAgo('2025-01-01T12:00:00Z')).toBe('3h ago');
+    vi.setSystemTime(new Date("2025-01-01T15:00:00Z"));
+    expect(timeAgo("2025-01-01T12:00:00Z")).toBe("3h ago");
   });
 
   it('returns "Xd ago" for 1 day or more ago', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-03T12:00:00Z'));
-    expect(timeAgo('2025-01-01T12:00:00Z')).toBe('2d ago');
+    vi.setSystemTime(new Date("2025-01-03T12:00:00Z"));
+    expect(timeAgo("2025-01-01T12:00:00Z")).toBe("2d ago");
   });
 });
 
-describe('formatDuration', () => {
-  it('formats seconds only', () => {
-    expect(formatDuration(45000)).toBe('45s');
+describe("formatDuration", () => {
+  it("formats seconds only", () => {
+    expect(formatDuration(45000)).toBe("45s");
   });
 
-  it('formats minutes and seconds', () => {
-    expect(formatDuration(125000)).toBe('2m 5s');
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(125000)).toBe("2m 5s");
   });
 
-  it('formats hours and minutes', () => {
-    expect(formatDuration(3720000)).toBe('1h 2m');
-  });
-});
-
-describe('formatTokens', () => {
-  it('formats millions', () => {
-    expect(formatTokens(1500000)).toBe('1.5M');
-  });
-
-  it('formats thousands', () => {
-    expect(formatTokens(2500)).toBe('2.5K');
-  });
-
-  it('formats small numbers as-is', () => {
-    expect(formatTokens(42)).toBe('42');
+  it("formats hours and minutes", () => {
+    expect(formatDuration(3720000)).toBe("1h 2m");
   });
 });
 
-describe('sourceUrl', () => {
-  it('returns source_url when set', () => {
-    expect(
-      sourceUrl({ source_url: 'https://example.com', source_type: 'jira', external_key: 'X-1' }),
-    ).toBe('https://example.com');
+describe("formatTokens", () => {
+  it("formats millions", () => {
+    expect(formatTokens(1500000)).toBe("1.5M");
   });
 
-  it('constructs jira URL from external_key when source_type is jira', () => {
-    expect(
-      sourceUrl({ source_url: null, source_type: 'jira', external_key: 'RHCLOUD-123' }),
-    ).toBe('https://redhat.atlassian.net/browse/RHCLOUD-123');
+  it("formats thousands", () => {
+    expect(formatTokens(2500)).toBe("2.5K");
   });
 
-  it('returns null when no external_key', () => {
-    expect(sourceUrl({ source_url: null, source_type: 'jira', external_key: null })).toBeNull();
+  it("formats small numbers as-is", () => {
+    expect(formatTokens(42)).toBe("42");
+  });
+});
+
+describe("sourceUrl", () => {
+  it("returns source_url when set", () => {
+    expect(
+      sourceUrl({ source_url: "https://example.com", source_type: "jira", external_key: "X-1" }),
+    ).toBe("https://example.com");
   });
 
-  it('returns null for non-jira without source_url', () => {
+  it("constructs jira URL from external_key when source_type is jira", () => {
+    expect(sourceUrl({ source_url: null, source_type: "jira", external_key: "RHCLOUD-123" })).toBe(
+      "https://redhat.atlassian.net/browse/RHCLOUD-123",
+    );
+  });
+
+  it("returns null when no external_key", () => {
+    expect(sourceUrl({ source_url: null, source_type: "jira", external_key: null })).toBeNull();
+  });
+
+  it("returns null for non-jira without source_url", () => {
     expect(
-      sourceUrl({ source_url: null, source_type: 'github', external_key: 'org/repo#42' }),
+      sourceUrl({ source_url: null, source_type: "github", external_key: "org/repo#42" }),
     ).toBeNull();
   });
 });
 
-describe('displayKey', () => {
-  it('returns external_key when present', () => {
-    expect(displayKey({ external_key: 'RHCLOUD-001' })).toBe('RHCLOUD-001');
+describe("displayKey", () => {
+  it("returns external_key when present", () => {
+    expect(displayKey({ external_key: "RHCLOUD-001" })).toBe("RHCLOUD-001");
   });
 
-  it('returns empty string when no external_key', () => {
-    expect(displayKey({ external_key: null })).toBe('');
+  it("returns empty string when no external_key", () => {
+    expect(displayKey({ external_key: null })).toBe("");
   });
 });
 
-describe('effectiveState', () => {
+describe("effectiveState", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('returns working as-is', () => {
-    expect(effectiveState({ state: 'working', updated_at: '2025-01-01T00:00:00Z' })).toBe('working');
+  it("returns working as-is", () => {
+    expect(effectiveState({ state: "working", updated_at: "2025-01-01T00:00:00Z" })).toBe(
+      "working",
+    );
   });
 
-  it('returns error as-is', () => {
-    expect(effectiveState({ state: 'error', updated_at: '2025-01-01T00:00:00Z' })).toBe('error');
+  it("returns error as-is", () => {
+    expect(effectiveState({ state: "error", updated_at: "2025-01-01T00:00:00Z" })).toBe("error");
   });
 
-  it('returns idle when updated_at is recent', () => {
+  it("returns idle when updated_at is recent", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-01T12:00:30Z'));
-    expect(effectiveState({ state: 'idle', updated_at: '2025-01-01T12:00:00Z' })).toBe('idle');
+    vi.setSystemTime(new Date("2025-01-01T12:00:30Z"));
+    expect(effectiveState({ state: "idle", updated_at: "2025-01-01T12:00:00Z" })).toBe("idle");
   });
 
-  it('returns sleep when updated_at is stale and state is idle', () => {
+  it("returns sleep when updated_at is stale and state is idle", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-01T12:05:00Z'));
-    expect(effectiveState({ state: 'idle', updated_at: '2025-01-01T12:00:00Z' })).toBe('sleep');
+    vi.setSystemTime(new Date("2025-01-01T12:05:00Z"));
+    expect(effectiveState({ state: "idle", updated_at: "2025-01-01T12:00:00Z" })).toBe("sleep");
   });
 
-  it('returns idle when no timestamps available', () => {
-    expect(effectiveState({ state: 'idle' })).toBe('idle');
+  it("returns idle when no timestamps available", () => {
+    expect(effectiveState({ state: "idle" })).toBe("idle");
   });
 
-  it('does not convert working to sleep even if stale', () => {
+  it("does not convert working to sleep even if stale", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-01T12:05:00Z'));
-    expect(effectiveState({ state: 'working', updated_at: '2025-01-01T11:00:00Z' })).toBe('working');
+    vi.setSystemTime(new Date("2025-01-01T12:05:00Z"));
+    expect(effectiveState({ state: "working", updated_at: "2025-01-01T11:00:00Z" })).toBe(
+      "working",
+    );
   });
 });

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -1,27 +1,27 @@
 export function timeAgo(iso: string): string {
   const s = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
-  if (s < 60) return 'just now';
-  if (s < 3600) return Math.floor(s / 60) + 'm ago';
-  if (s < 86400) return Math.floor(s / 3600) + 'h ago';
-  return Math.floor(s / 86400) + 'd ago';
+  if (s < 60) return "just now";
+  if (s < 3600) return Math.floor(s / 60) + "m ago";
+  if (s < 86400) return Math.floor(s / 3600) + "h ago";
+  return Math.floor(s / 86400) + "d ago";
 }
 
 export function formatDuration(ms: number): string {
   const s = Math.floor(ms / 1000);
-  if (s < 60) return s + 's';
+  if (s < 60) return s + "s";
   const m = Math.floor(s / 60);
-  if (m < 60) return m + 'm ' + (s % 60) + 's';
+  if (m < 60) return m + "m " + (s % 60) + "s";
   const h = Math.floor(m / 60);
-  return h + 'h ' + (m % 60) + 'm';
+  return h + "h " + (m % 60) + "m";
 }
 
 export function formatTokens(n: number): string {
-  if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
-  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + "K";
   return String(Math.round(n));
 }
 
-const JIRA_BASE = 'https://redhat.atlassian.net/browse/';
+const JIRA_BASE = "https://redhat.atlassian.net/browse/";
 
 interface SourceLike {
   source_url?: string | null;
@@ -32,43 +32,43 @@ interface SourceLike {
 export function sourceUrl(item: SourceLike): string | null {
   if (item.source_url) return item.source_url;
   if (!item.external_key) return null;
-  if (item.source_type === 'jira') return JIRA_BASE + item.external_key;
+  if (item.source_type === "jira") return JIRA_BASE + item.external_key;
   return null;
 }
 
 export function displayKey(item: SourceLike): string {
-  return item.external_key || '';
+  return item.external_key || "";
 }
 
 const SLEEP_THRESHOLD_MS = 60_000; // 60 seconds
 
-export type DisplayState = 'working' | 'idle' | 'error' | 'sleep' | 'unknown';
+export type DisplayState = "working" | "idle" | "error" | "sleep" | "unknown";
 
 export function effectiveState(instance: { state: string; updated_at?: string }): DisplayState {
-  if (instance.state === 'idle' && instance.updated_at) {
+  if (instance.state === "idle" && instance.updated_at) {
     const age = Date.now() - new Date(instance.updated_at).getTime();
-    if (age > SLEEP_THRESHOLD_MS) return 'sleep';
+    if (age > SLEEP_THRESHOLD_MS) return "sleep";
   }
   return instance.state as DisplayState;
 }
 
-export function stateLabelColor(state: DisplayState): 'orange' | 'red' | 'green' | 'grey' {
-  if (state === 'working') return 'orange';
-  if (state === 'error') return 'red';
-  if (state === 'idle') return 'green';
-  return 'grey';
+export function stateLabelColor(state: DisplayState): "orange" | "red" | "green" | "grey" {
+  if (state === "working") return "orange";
+  if (state === "error") return "red";
+  if (state === "idle") return "green";
+  return "grey";
 }
 
-export function stateIconStatus(state: DisplayState): 'warning' | 'danger' | 'success' | 'custom' {
-  if (state === 'working') return 'warning';
-  if (state === 'error') return 'danger';
-  if (state === 'idle') return 'success';
-  return 'custom';
+export function stateIconStatus(state: DisplayState): "warning" | "danger" | "success" | "custom" {
+  if (state === "working") return "warning";
+  if (state === "error") return "danger";
+  if (state === "idle") return "success";
+  return "custom";
 }
 
 export function stateBorderColor(state: DisplayState): string {
-  if (state === 'working') return 'var(--yellow)';
-  if (state === 'error') return 'var(--red)';
-  if (state === 'idle') return 'var(--green)';
-  return 'var(--text-dim)';
+  if (state === "working") return "var(--yellow)";
+  if (state === "error") return "var(--red)";
+  if (state === "idle") return "var(--green)";
+  return "var(--text-dim)";
 }

--- a/dashboard/src/utils/applyStoredTheme.ts
+++ b/dashboard/src/utils/applyStoredTheme.ts
@@ -1,14 +1,16 @@
 export function applyStoredTheme() {
-  const scheme = localStorage.getItem('pf-color-scheme') || 'dark';
-  const theme = localStorage.getItem('pf-theme') || 'default';
-  const contrast = localStorage.getItem('pf-contrast-mode') || 'default';
+  const scheme = localStorage.getItem("pf-color-scheme") || "dark";
+  const theme = localStorage.getItem("pf-theme") || "default";
+  const contrast = localStorage.getItem("pf-contrast-mode") || "default";
 
-  const isDark = scheme === 'dark' || (scheme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const isDark =
+    scheme === "dark" ||
+    (scheme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
 
   const root = document.documentElement;
-  root.classList.toggle('pf-v6-theme-dark', isDark);
-  root.setAttribute('data-theme', isDark ? 'dark' : 'light');
-  if (theme === 'felt') root.classList.add('pf-v6-theme-felt');
-  if (contrast === 'high-contrast') root.classList.add('pf-v6-theme-high-contrast');
-  if (contrast === 'glass') root.classList.add('pf-v6-theme-glass');
+  root.classList.toggle("pf-v6-theme-dark", isDark);
+  root.setAttribute("data-theme", isDark ? "dark" : "light");
+  if (theme === "felt") root.classList.add("pf-v6-theme-felt");
+  if (contrast === "high-contrast") root.classList.add("pf-v6-theme-high-contrast");
+  if (contrast === "glass") root.classList.add("pf-v6-theme-glass");
 }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,22 +1,22 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    setupFiles: ['./src/test/setup.ts'],
-    exclude: ['**/*.spec.ts', 'node_modules'],
+    setupFiles: ["./src/test/setup.ts"],
+    exclude: ["**/*.spec.ts", "node_modules"],
   },
   build: {
-    outDir: '../memory-server/bot_memory_server/static',
+    outDir: "../memory-server/bot_memory_server/static",
     emptyOutDir: false,
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8080',
-      '/ws': { target: 'ws://localhost:8080', ws: true },
+      "/api": "http://localhost:8080",
+      "/ws": { target: "ws://localhost:8080", ws: true },
     },
   },
-})
+});

--- a/dashboard/vite.gallery.config.ts
+++ b/dashboard/vite.gallery.config.ts
@@ -1,22 +1,22 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import path from 'path';
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { defineConfig } from "vite";
 
-const mockWSPath = path.resolve(__dirname, 'e2e/mockWebSocket.tsx');
+const mockWSPath = path.resolve(__dirname, "e2e/mockWebSocket.tsx");
 
 export default defineConfig({
   plugins: [
     {
-      name: 'mock-websocket',
-      enforce: 'pre',
+      name: "mock-websocket",
+      enforce: "pre",
       resolveId(source) {
-        if (source.endsWith('/hooks/useWebSocket') || source.endsWith('/hooks/useWebSocket.tsx')) {
+        if (source.endsWith("/hooks/useWebSocket") || source.endsWith("/hooks/useWebSocket.tsx")) {
           return mockWSPath;
         }
       },
     },
     react(),
   ],
-  root: '.',
+  root: ".",
   server: { port: 5174 },
 });


### PR DESCRIPTION
Summary:
- Establish shared repository-wide TypeScript formatting and linting with Biome.
- Run the Biome gate through Make, pre-commit, CI, and master branch protection.
- Rename the dashboard type-check script and update local/CI verification.

Validation:
- `make verify` — passed: 952 Python tests passed, 3 skipped, 2 xfailed, 1 xpassed; Go vet/tests, Biome, dashboard typecheck/build/tests passed.
- Pre-push Ruff format check — passed.

---

### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->

Adds one shared Biome check for repository TypeScript, makes it part of local verification and pre-commit, and requires its unfiltered pull-request status in master branch protection. Renames the dashboard `lint` script to `typecheck` to reflect its actual behavior.

[REHOR-147](https://issues.redhat.com/browse/REHOR-147)

---

 After merge, repository admin must run:

 ```bash
   scripts/apply_branch_protection.sh
 ```

 Or apply equivalent settings through GitHub API/UI. Then verify:

 ```bash
   scripts/check_branch_protection.sh
 ```
 
---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

Dashboard TypeScript tooling, repository verification, pre-commit hooks, and GitHub Actions branch-protection checks. No runtime consumer changes.

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

Git revert is sufficient; remove the Biome gate and restore the previous dashboard script name and branch-protection configuration.

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: [Pi](https://pi.dev) — gpt-5.6-luna high
