### PR TITLE
feat: allow profile-specific runner builds

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -87,10 +87,14 @@ COPY dev-bot/dev-proxy/ dev-proxy/
 # Instance files — COPY early so install-envs.sh can read instance.yaml
 COPY instance/ /home/botuser/app/instance/
 
-# Env presets — selective install based on instance.yaml envs list
+# Env presets — selective install based on selected instance.yaml envs list.
+# Set INSTANCE_CONFIG_PATH to one profile (for example instance/rbac-config).
+# Empty value keeps multi-profile union behavior.
 COPY dev-bot/presets/ presets/
 ARG GOVERSIONS="1.24.13 1.25.13"
 ENV GOVERSIONS="${GOVERSIONS}"
+ARG INSTANCE_CONFIG_PATH=""
+ENV INSTANCE_CONFIG_PATH="${INSTANCE_CONFIG_PATH}"
 RUN bash presets/install-envs.sh
 
 ENV HOME=/home/botuser

--- a/README.md
+++ b/README.md
@@ -246,6 +246,19 @@ mkdir -p instance
 docker build -f dev-bot/Dockerfile.runner -t my-bot-instance:local .
 ```
 
+For a runner repo with multiple profiles, select one profile at build time:
+
+```bash
+docker build \
+  --build-arg INSTANCE_CONFIG_PATH=instance/rbac-config \
+  -f dev-bot/Dockerfile.runner \
+  -t my-bot-instance:local .
+```
+
+The selected profile alone controls env-preset installation. Without this build
+arg, the image installs the union of envs from all `instance/*/agent/instance.yaml`
+files. Runtime profile selection still uses `BOT_CONFIG_PATH`.
+
 To update to the latest dev-bot: `git submodule update --remote dev-bot`
 
 ## Running the services

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -185,7 +185,19 @@ for pf in /etc/profile.d/*.sh; do [ -f "$pf" ] && . "$pf" || true; done
 
 # Run env preset entrypoint scripts — only for installed envs
 INSTALLED_ENVS=""
-for cfg in instance/*/agent/instance.yaml; do
+CONFIG_FILES=()
+if [ -n "${INSTANCE_CONFIG_PATH:-}" ]; then
+    if [[ "$INSTANCE_CONFIG_PATH" == instance/* ]]; then
+        CONFIG_FILES=("$INSTANCE_CONFIG_PATH/agent/instance.yaml")
+    else
+        CONFIG_FILES=("instance/$INSTANCE_CONFIG_PATH/agent/instance.yaml")
+    fi
+else
+    shopt -s nullglob
+    CONFIG_FILES=(instance/*/agent/instance.yaml)
+    shopt -u nullglob
+fi
+for cfg in "${CONFIG_FILES[@]}"; do
     [ -f "$cfg" ] || continue
     INSTALLED_ENVS="$INSTALLED_ENVS $(sed -n '/^envs:/,/^[^ ]/{ s/^  - //p }' "$cfg")"
 done

--- a/presets/install-envs.sh
+++ b/presets/install-envs.sh
@@ -8,8 +8,31 @@ set -e
 
 ENVS=""
 FOUND_CONFIG=false
-for cfg in instance/*/agent/instance.yaml; do
-    [ -f "$cfg" ] || continue
+
+CONFIG_FILES=()
+if [ -n "${INSTANCE_CONFIG_PATH:-}" ]; then
+    case "$INSTANCE_CONFIG_PATH" in
+        /*|*..*)
+            echo "[install-envs] Invalid INSTANCE_CONFIG_PATH: $INSTANCE_CONFIG_PATH" >&2
+            exit 1
+            ;;
+    esac
+    if [[ "$INSTANCE_CONFIG_PATH" == instance/* ]]; then
+        CONFIG_FILES=("$INSTANCE_CONFIG_PATH/agent/instance.yaml")
+    else
+        CONFIG_FILES=("instance/$INSTANCE_CONFIG_PATH/agent/instance.yaml")
+    fi
+    if [ ! -f "${CONFIG_FILES[0]}" ]; then
+        echo "[install-envs] Config not found: ${CONFIG_FILES[0]}" >&2
+        exit 1
+    fi
+else
+    shopt -s nullglob
+    CONFIG_FILES=(instance/*/agent/instance.yaml)
+    shopt -u nullglob
+fi
+
+for cfg in "${CONFIG_FILES[@]}"; do
     FOUND_CONFIG=true
     ENVS="$ENVS $(sed -n '/^envs:/,/^[^ ]/{ s/^  - //p }' "$cfg")"
 done


### PR DESCRIPTION
### Description

Add opt-in `INSTANCE_CONFIG_PATH` build argument for multi-profile runner repositories. Selected builds install and initialize only requested profile env presets; omitted argument preserves existing union behavior.

No Jira ticket supplied.

### Blast radius

Runner images using `Dockerfile.runner`; existing consumers unchanged unless they pass new build argument.

### Rollback plan

Git revert is sufficient. Removing `INSTANCE_CONFIG_PATH` restores existing union behavior.

### Checklist
- [x] Tested shell syntax with `bash -n presets/install-envs.sh entrypoint.sh`
- [x] Config tests pass: `pytest -q bot/tests/test_instance_config.py` (23 passed)
- [x] No breaking changes to existing consumers
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images remain pinned as before

### AI disclosure

Assisted by: Claude Code