### PR TITLE
chore(deps): refresh UBI9 Go toolset digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Dev proxy — build custom Caddy from source on UBI (passes EC)
-FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:8d2d83261cbc8854b8c93b1237d7d4aa0069bdb93e2974d980bc7788db56f8f4 AS dev-proxy-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:5e68f09a652ac6627a83c57655e42e24575efb278b54336039c9308607fc6b21 AS dev-proxy-builder
 COPY dev-proxy/ /tmp/dev-proxy/
 RUN cd /tmp/dev-proxy \
     && go build -o /tmp/caddy .
 
 # Build executor thin client (gh/glab shim that forwards via UDS to proxy sidecar)
-FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:8d2d83261cbc8854b8c93b1237d7d4aa0069bdb93e2974d980bc7788db56f8f4 AS executor-client-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:5e68f09a652ac6627a83c57655e42e24575efb278b54336039c9308607fc6b21 AS executor-client-builder
 WORKDIR /build
 COPY proxy/executor/ .
 RUN go mod download \

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -8,7 +8,7 @@
 #   instance/  — (optional) extra files, COPYed to /home/botuser/app/instance/
 
 # Build executor thin client (gh/glab shim that forwards via UDS to proxy sidecar)
-FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:8d2d83261cbc8854b8c93b1237d7d4aa0069bdb93e2974d980bc7788db56f8f4 AS executor-client-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:5e68f09a652ac6627a83c57655e42e24575efb278b54336039c9308607fc6b21 AS executor-client-builder
 WORKDIR /build
 COPY dev-bot/proxy/executor/ .
 RUN go mod download \

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Build executor binaries
-FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:8d2d83261cbc8854b8c93b1237d7d4aa0069bdb93e2974d980bc7788db56f8f4 AS executor-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest@sha256:5e68f09a652ac6627a83c57655e42e24575efb278b54336039c9308607fc6b21 AS executor-builder
 WORKDIR /build
 COPY executor/ .
 RUN go mod download \


### PR DESCRIPTION
## Summary

Supersedes [PR #484](https://github.com/OpenShift-Fleet/rehor/pull/484) with a clean successor based on current `master`.

Refreshes the pinned `registry.access.redhat.com/ubi9/go-toolset:latest` digest from `sha256:8d2d83261cbc8854b8c93b1237d7d4aa0069bdb93e2974d980bc7788db56f8f4` to the registry-accepted target `sha256:5e68f09a652ac6627a83c57655e42e24575efb278b54336039c9308607fc6b21`.

Changed files are limited to the three Dockerfiles containing the Go toolset build stages:

- `Dockerfile`
- `Dockerfile.runner`
- `proxy/Dockerfile`

No unrelated source, test, workflow, or documentation changes are included.

## Validation

- `make verify` — passed: 952 passed, 3 skipped, 2 xfailed, 1 xpassed.
- `git diff --check` — passed.
- `make container-verify` — bot, proxy, and memory-server images built successfully; proxy smoke check passed. The final memory-server `/health` probe was blocked by macOS Podman `--network host` behavior: logs showed the service initialized and listened on `0.0.0.0:8080`, but the host-side curl could not reach the Podman VM port. GitHub CI runs this check on Linux Docker.
- Target digest was confirmed available from the Red Hat registry.

Rollback: revert this commit to restore the previous digest.

Assisted by: [Pi](https://pi.dev) — gpt-5.6-luna xhigh

---

### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->

[RHCLOUD-XXXXX](https://issues.redhat.com/browse/RHCLOUD-XXXXX)

---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [ ] No breaking changes to existing consumers (or migration path documented)
- [ ] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by Claude Code -->
