### PR TITLE
fix(proxy): use basic auth for GitHub git

### DIFF
--- a/proxy/executor/gitauth.go
+++ b/proxy/executor/gitauth.go
@@ -46,9 +46,9 @@ func defaultHostRegistry() map[string]*GitHost {
 		"github.com": {
 			Scheme:   "https",
 			Host:     "github.com",
-			AuthType: AuthTypeBearer,
+			AuthType: AuthTypeBasic,
 			Token:    func() string { return os.Getenv("GH_TOKEN") },
-			Username: nil,
+			Username: func() string { return os.Getenv("GH_USERNAME") },
 		},
 		"gitlab.cee.redhat.com": {
 			Scheme:                "https",

--- a/proxy/executor/gitauth_test.go
+++ b/proxy/executor/gitauth_test.go
@@ -26,9 +26,9 @@ func TestGitAuthProxy_GitHub(t *testing.T) {
 		"github.com": {
 			Scheme:   upstreamURL.Scheme,
 			Host:     upstreamURL.Host,
-			AuthType: "bearer",
+			AuthType: "basic",
 			Token:    func() string { return "test-gh-token-123" },
-			Username: nil,
+			Username: func() string { return "github-bot" },
 		},
 	}
 
@@ -41,7 +41,7 @@ func TestGitAuthProxy_GitHub(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", w.Code)
 	}
-	wantAuth := "Bearer test-gh-token-123"
+	wantAuth := "Basic Z2l0aHViLWJvdDp0ZXN0LWdoLXRva2VuLTEyMw=="
 	if gotAuth != wantAuth {
 		t.Errorf("Authorization = %q, want %q", gotAuth, wantAuth)
 	}
@@ -50,6 +50,22 @@ func TestGitAuthProxy_GitHub(t *testing.T) {
 	}
 	if gotQuery != "service=git-upload-pack" {
 		t.Errorf("Query = %q, want service=git-upload-pack", gotQuery)
+	}
+}
+
+func TestDefaultHostRegistry_GitHubUsesBasicAuth(t *testing.T) {
+	t.Setenv("GH_USERNAME", "github-bot")
+	t.Setenv("GH_TOKEN", "token")
+
+	host := defaultHostRegistry()["github.com"]
+	if host.AuthType != AuthTypeBasic {
+		t.Fatalf("AuthType = %q, want %q", host.AuthType, AuthTypeBasic)
+	}
+	if got := host.Username(); got != "github-bot" {
+		t.Errorf("Username() = %q, want github-bot", got)
+	}
+	if got := host.Token(); got != "token" {
+		t.Errorf("Token() = %q, want token", got)
 	}
 }
 
@@ -447,8 +463,9 @@ func TestPerHostTransportManager_TLSConfig(t *testing.T) {
 				"github.com": {
 					Scheme:                "https",
 					Host:                  "github.com",
-					AuthType:              AuthTypeBearer,
+					AuthType:              AuthTypeBasic,
 					Token:                 func() string { return "token" },
+					Username:              func() string { return "github-bot" },
 					TLSInsecureSkipVerify: false,
 				},
 			},
@@ -484,8 +501,9 @@ func TestPerHostTransportManager_CachesTransports(t *testing.T) {
 		"github.com": {
 			Scheme:   "https",
 			Host:     "github.com",
-			AuthType: AuthTypeBearer,
+			AuthType: AuthTypeBasic,
 			Token:    func() string { return "token" },
+			Username: func() string { return "github-bot" },
 		},
 	}
 


### PR DESCRIPTION
### Description
GitHub Smart HTTP rejects the proxy's Bearer authorization header during private repository clone. Use Basic authorization with GH_USERNAME and GH_TOKEN, matching GitHub Git authentication requirements.

[RHCLOUD-50937](https://redhat.atlassian.net/browse/RHCLOUD-50937)

---

### Blast radius
GitHub Git clone/fetch through proxy Git auth listener on port 8447. GitLab authentication remains unchanged. Verified live failure: GitHub Git returned 401 while GitHub API access succeeded.

---

### Rollback plan
Revert commit a545928 and redeploy proxy image.

---

### Checklist
- [x] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images pinned to specific tags, not latest

### AI disclosure
Assisted by: Claude Code