### PR TITLE
ci: add container verification checks

### DIFF
--- a/.github/actions/grype-scan/action.yml
+++ b/.github/actions/grype-scan/action.yml
@@ -1,0 +1,85 @@
+name: grype-scan
+description: >
+  Advisory vulnerability scan of a locally built container image (REHOR-149).
+  Konflux runs clair-scan, which matches by ecosystem and therefore reports
+  nothing for binaries installed outside a package manager — Node lands in the
+  SBOM as pkg:generic and statically linked binaries do not appear at all.
+  grype adds CPE/NVD matching and closes that gap. Advisory only: this action
+  never fails the job. Gating is a follow-up once the baseline is triaged.
+
+inputs:
+  image:
+    description: Locally built image reference to scan, e.g. bot:verify
+    required: true
+  name:
+    description: Short name used in the job summary heading
+    required: true
+  grype-version:
+    description: grype release tag, kept in step with the version installed in Dockerfile
+    required: false
+    default: v0.118.0
+
+runs:
+  using: composite
+  steps:
+    - name: Run grype
+      shell: bash
+      run: |
+        # GitHub invokes Bash with -e; this scan is intentionally advisory.
+        set -uo pipefail
+        set +e
+        report="grype-${{ inputs.name }}.json"
+
+        docker run --rm \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          "anchore/grype:${{ inputs.grype-version }}" \
+          "docker:${{ inputs.image }}" -o json > "$report" 2>grype-err.txt
+        status=$?
+
+        echo "### grype: ${{ inputs.name }} (\`${{ inputs.image }}\`)" >> "$GITHUB_STEP_SUMMARY"
+        echo >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$status" -ne 0 ] || ! jq -e . "$report" >/dev/null 2>&1; then
+          {
+            echo "Scan did not complete (exit ${status}). Advisory step — not failing the job."
+            echo
+            echo '```'
+            tail -20 grype-err.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        total=$(jq '.matches | length' "$report")
+        {
+          echo "Total findings: **${total}**"
+          echo
+          echo "| Severity | Count |"
+          echo "| --- | --- |"
+          jq -r '
+            {Critical:0, High:1, Medium:2, Low:3, Negligible:4, Unknown:5} as $rank
+            | (.matches // [])
+            | group_by(.vulnerability.severity)
+            | map({sev: .[0].vulnerability.severity, n: length})
+            | sort_by($rank[.sev] // 99)[]
+            | "| \(.sev) | \(.n) |"
+          ' "$report"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        {
+          echo
+          echo "<details><summary>Critical and High findings</summary>"
+          echo
+          echo '```'
+          jq -r '
+            (.matches // [])
+            | map(select(.vulnerability.severity == "Critical" or .vulnerability.severity == "High"))
+            | sort_by(.artifact.name)[]
+            | "\(.vulnerability.severity)\t\(.artifact.name)@\(.artifact.version)\t\(.vulnerability.id)\tfixed-in: \(.vulnerability.fix.versions // [] | join(", ") | if . == "" then "none" else . end)"
+          ' "$report" | head -100
+          echo '```'
+          echo
+          echo "</details>"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        exit 0

--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -23,6 +23,7 @@ on:
   pull_request:
     paths:
       # bot image inputs
+      - "Dockerfile"
       - "Dockerfile.runner"
       - "entrypoint.sh"
       - "config.json"
@@ -41,11 +42,13 @@ on:
       # shared
       - "docker-compose.yml"
       - ".github/workflows/container-verify.yml"
+      - ".github/actions/grype-scan/**"
   push:
     branches:
       - master
     paths:
       # bot image inputs
+      - "Dockerfile"
       - "Dockerfile.runner"
       - "entrypoint.sh"
       - "config.json"
@@ -64,6 +67,7 @@ on:
       # shared
       - "docker-compose.yml"
       - ".github/workflows/container-verify.yml"
+      - ".github/actions/grype-scan/**"
 
 permissions:
   contents: read
@@ -129,6 +133,32 @@ jobs:
             node --version
           '
 
+      - name: Verify Node matches the pinned version
+        # REHOR-149: the image installs Node from the pinned tarball in
+        # Dockerfile, and presets/envs/node/install.sh used to overwrite it with
+        # whatever `nvm install 22` resolved to. This asserts the two agree, so
+        # the shadowing cannot come back unnoticed.
+        run: |
+          set -euo pipefail
+          pinned="$(grep -m1 '^ARG NODE_VERSION=' Dockerfile | cut -d'"' -f2 || true)"
+          runner_pinned="$(grep -m1 '^ARG NODE_VERSION=' Dockerfile.runner | cut -d'"' -f2 || true)"
+          actual="$(docker run --rm --entrypoint bash bot:verify -c 'node --version')"
+          echo "Dockerfile pin=v${pinned} Dockerfile.runner pin=v${runner_pinned} image=${actual}"
+          if [ "${pinned}" != "${runner_pinned}" ]; then
+            echo "::error::NODE_VERSION differs between Dockerfile and Dockerfile.runner"
+            exit 1
+          fi
+          if [ "${actual}" != "v${pinned}" ]; then
+            echo "::error::image ships ${actual} but NODE_VERSION pins v${pinned}"
+            exit 1
+          fi
+
+      - name: Scan bot image with grype (advisory)
+        uses: ./.github/actions/grype-scan
+        with:
+          image: bot:verify
+          name: bot
+
   verify-proxy:
     runs-on: ubuntu-latest
     steps:
@@ -139,6 +169,12 @@ jobs:
       - name: Build proxy image
         run: |
           docker build -t proxy:verify ./proxy
+
+      - name: Scan proxy image with grype (advisory)
+        uses: ./.github/actions/grype-scan
+        with:
+          image: proxy:verify
+          name: proxy
 
       - name: Start proxy container
         run: |
@@ -198,6 +234,12 @@ jobs:
       - name: Build memory-server image
         run: |
           docker build -f memory-server/Dockerfile -t memory-server:verify .
+
+      - name: Scan memory-server image with grype (advisory)
+        uses: ./.github/actions/grype-scan
+        with:
+          image: memory-server:verify
+          name: memory-server
 
       - name: Start memory-server container
         run: |

--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -133,6 +133,12 @@ jobs:
             node --version
           '
 
+      - name: Scan bot image with grype (advisory)
+        uses: ./.github/actions/grype-scan
+        with:
+          image: bot:verify
+          name: bot
+
       - name: Verify Node matches the pinned version
         # REHOR-149: the image installs Node from the pinned tarball in
         # Dockerfile, and presets/envs/node/install.sh used to overwrite it with
@@ -152,12 +158,6 @@ jobs:
             echo "::error::image ships ${actual} but NODE_VERSION pins v${pinned}"
             exit 1
           fi
-
-      - name: Scan bot image with grype (advisory)
-        uses: ./.github/actions/grype-scan
-        with:
-          image: bot:verify
-          name: bot
 
   verify-proxy:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,22 @@ RUN dnf install -y --nodocs --allowerasing \
     libXrandr \
     && dnf clean all
 
-# Node.js 22 (official binary tarball)
+# Node.js (official binary tarball, checksum-verified).
+#
+# NODE_VERSION is the single pin for this image: presets/envs/node/install.sh
+# reads the same variable and skips when this version is already present, so
+# the preset can no longer replace this install with a floating one.
+ARG NODE_VERSION="22.23.2"
+ENV NODE_VERSION="${NODE_VERSION}"
 RUN ARCH=$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/') \
-    && curl -fsSL "https://nodejs.org/dist/v22.15.0/node-v22.15.0-linux-${ARCH}.tar.gz" \
-    | tar -xz -C /usr/local --strip-components=1
+    && TARBALL="node-v${NODE_VERSION}-linux-${ARCH}.tar.gz" \
+    && cd /tmp \
+    && curl -fsSL -O "https://nodejs.org/dist/v${NODE_VERSION}/${TARBALL}" \
+    && curl -fsSL -O "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" \
+    && grep " ${TARBALL}\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xzf "${TARBALL}" -C /usr/local --strip-components=1 \
+    && rm -f "${TARBALL}" SHASUMS256.txt \
+    && [ "$(node --version)" = "v${NODE_VERSION}" ]
 
 
 # Headless Chromium via Playwright (avoids EPEL/CentOS RPMs)

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -91,6 +91,10 @@ COPY instance/ /home/botuser/app/instance/
 COPY dev-bot/presets/ presets/
 ARG GOVERSIONS="1.24.13 1.25.13"
 ENV GOVERSIONS="${GOVERSIONS}"
+# Keep in step with the NODE_VERSION pin in Dockerfile — presets/envs/node
+# installs exactly this version rather than floating on latest 22.x.
+ARG NODE_VERSION="22.23.2"
+ENV NODE_VERSION="${NODE_VERSION}"
 RUN bash presets/install-envs.sh
 
 ENV HOME=/home/botuser

--- a/presets/envs/node/install.sh
+++ b/presets/envs/node/install.sh
@@ -1,18 +1,46 @@
 #!/bin/bash
-# Node.js env preset — nvm + Node.js 22 LTS
-set -e
+# Node.js env preset — pinned Node.js, installed through nvm.
+#
+# The version is pinned and shared with the Dockerfiles through NODE_VERSION.
+# This script is idempotent: when the image already carries exactly the pinned
+# Node it leaves it alone. That matters because the dev-bot Dockerfile installs
+# the same pinned version from the official tarball before this preset runs.
+# Without the check, `nvm install` plus the symlinks below would silently
+# replace a pinned install with a different one (see REHOR-149).
+set -euo pipefail
+
+NODE_VERSION="${NODE_VERSION:-22.23.2}"
+NVM_VERSION="${NVM_VERSION:-v0.40.3}"
+# sha256 of https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh
+NVM_INSTALL_SHA256="2d8359a64a3cb07c02389ad88ceecd43f2fa469c06104f92f98df5b6f315275f"
+
+if command -v node >/dev/null 2>&1 && [ "$(node --version)" = "v${NODE_VERSION}" ]; then
+    echo "[node] v${NODE_VERSION} already present — leaving the existing install in place"
+    exit 0
+fi
 
 export NVM_DIR="${NVM_DIR:-/usr/local/nvm}"
-
-# Install nvm
 mkdir -p "$NVM_DIR"
-curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 
-# Source nvm and install default Node version
+# Install nvm from a tag pinned by content hash, not just by ref.
+curl -fsSL -o /tmp/nvm-install.sh \
+    "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh"
+echo "${NVM_INSTALL_SHA256}  /tmp/nvm-install.sh" | sha256sum -c -
+bash /tmp/nvm-install.sh
+rm -f /tmp/nvm-install.sh
+
+# nvm verifies the downloaded Node tarball against the release SHASUMS256.txt,
+# so pinning the exact version here also pins its checksum.
 . "$NVM_DIR/nvm.sh"
-nvm install 22
-nvm alias default 22
+nvm install "$NODE_VERSION"
+nvm alias default "$NODE_VERSION"
 nvm use default
+
+installed=$(node --version)
+if [ "$installed" != "v${NODE_VERSION}" ]; then
+    echo "[node] expected v${NODE_VERSION}, got ${installed}" >&2
+    exit 1
+fi
 
 # Make node/npm available system-wide (symlink for non-interactive shells)
 NODE_PATH=$(nvm which current)
@@ -21,8 +49,14 @@ ln -sf "$NODE_DIR/node" /usr/local/bin/node
 ln -sf "$NODE_DIR/npm" /usr/local/bin/npm
 ln -sf "$NODE_DIR/npx" /usr/local/bin/npx
 
+# Stable path to the active version, so globally installed npm binaries stay
+# reachable without hardcoding the version number.
+ln -sfn "$(dirname "$NODE_DIR")" /usr/local/nvm/current
+
 # Add nvm init to profile so interactive shells get nvm
 cat > /etc/profile.d/nvm.sh << 'PROFILE'
 export NVM_DIR="/usr/local/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 PROFILE
+
+echo "[node] installed v${NODE_VERSION}"


### PR DESCRIPTION
### Summary
- Expand `container-verify.yml` path coverage to include `Dockerfile` and the local Grype action.
- Run advisory Grype scans against bot, proxy, and memory-server images.
- Pin Node.js `22.23.2` consistently across the image and Node environment preset.
- Verify the built image contains exactly the declared Node version.

### CVE remediation
The initial workflow-only commit intentionally demonstrated the Node-version drift. Follow-up commit `af30db0` now fixes it by:

- Pinning Node.js `22.23.2` in both Dockerfiles.
- Verifying the official Node tarball against `SHASUMS256.txt`.
- Pinning the nvm installer by version and SHA-256.
- Preventing the environment preset from replacing the pinned image installation with floating `nvm install 22`.

Grype remains advisory while the image baseline is being triaged; its findings are published in the GitHub Actions job summary.

### Validation
- `make verify` — passed: 952 Python tests, Go vet/tests, dashboard typecheck/build, and 85 dashboard tests.
- YAML and composite-action Bash syntax checks — passed.
- PR Container Verify — passed: bot Grype scan and Node consistency check, proxy verification, and memory-server verification.
- PR Container E2E, Biome, and pre-push Ruff formatting checks — passed.

Assisted by: [Pi](https://pi.dev) — gpt-5.6-luna xhigh

---

### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->

[REHOR-149](https://issues.redhat.com/browse/REHOR-149)

---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

Revert commits `e8f8c1d`, `d295647`, and `af30db0` to remove the workflow checks, advisory scan action, and Node pin remediation.

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [x] No breaking changes to existing consumers (or migration path documented)
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
